### PR TITLE
Add generation of monarch file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,11 +29,11 @@ jobs:
 
       - name: Langium generate
         run: |
-          HASH_BEFORE=$(sha1sum src/language-server/generated/*.ts syntaxes/*.tmLanguage.json | sha1sum)
+          HASH_BEFORE=$(sha1sum src/language-server/generated/*.ts syntaxes/*.json syntaxes/*.ts)
           
           npm run langium:generate
           
-          HASH_AFTER=$(sha1sum src/language-server/generated/*.ts syntaxes/*.tmLanguage.json | sha1sum)
+          HASH_AFTER=$(sha1sum src/language-server/generated/*.ts syntaxes/*.json syntaxes/*.ts)
           
           if [[ $HASH_BEFORE != $HASH_AFTER ]]; then
             echo "The generated code is not up to date."

--- a/langium-config.json
+++ b/langium-config.json
@@ -6,6 +6,9 @@
         "fileExtensions": [".odl"],
         "textMate": {
             "out": "syntaxes/open-data-language.tmLanguage.json"
+        },
+        "monarch": {
+            "out": "./syntaxes/open-data-language.monarch.ts"
         }
     }],
     "out": "src/language-server/generated"

--- a/syntaxes/open-data-language.monarch.ts
+++ b/syntaxes/open-data-language.monarch.ts
@@ -1,0 +1,30 @@
+// Monarch syntax highlighting for the open-data-language language.
+export default {
+    keywords: [
+        'Hello','person'
+    ],
+    operators: [
+        '!'
+    ],
+    symbols:  /!/,
+
+    tokenizer: {
+        initial: [
+            { regex: /[_a-zA-Z][\w_]*/, action: { cases: { '@keywords': {"token":"keyword"}, '@default': {"token":"ID"} }} },
+            { regex: /[0-9]+/, action: {"token":"number"} },
+            { regex: /"[^"]*"|'[^']*'/, action: {"token":"string"} },
+            { include: '@whitespace' },
+            { regex: /@symbols/, action: { cases: { '@operators': {"token":"operator"}, '@default': {"token":""} }} },
+        ],
+        whitespace: [
+            { regex: /\s+/, action: {"token":"white"} },
+            { regex: /\/\*/, action: {"token":"comment","next":"@comment"} },
+            { regex: /\/\/[^\n\r]*/, action: {"token":"comment"} },
+        ],
+        comment: [
+            { regex: /[^\/\*]+/, action: {"token":"comment"} },
+            { regex: /\*\//, action: {"token":"comment","next":"@pop"} },
+            { regex: /[\/\*]/, action: {"token":"comment"} },
+        ],
+    }
+};


### PR DESCRIPTION
- Additionally generates a [monarch](https://microsoft.github.io/monaco-editor/monarch.html) file in the `syntaxes` folder when running `langium:generate`
- Adjusts the CI to consider this new file when checking for outdated generated artifacts