### PR TITLE
Separate block meta information from executors

### DIFF
--- a/src/cli/executors/block-executor.ts
+++ b/src/cli/executors/block-executor.ts
@@ -1,5 +1,5 @@
 import { BlockType } from '../../language-server/generated/ast';
-import { DataType, undefinedType } from '../data-types';
+import { BlockMetaInformation } from '../../language-server/meta-information/block-meta-inf';
 
 import * as R from './execution-result';
 
@@ -7,24 +7,10 @@ export abstract class BlockExecutor<
   B extends BlockType,
   InType = unknown,
   OutType = unknown,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  M extends BlockMetaInformation<B, InType, OutType> = BlockMetaInformation<B>,
 > {
-  protected constructor(
-    readonly block: B,
-    readonly inputDataType: DataType<InType>,
-    readonly outputDataType: DataType<OutType>,
-  ) {}
-
-  canExecuteAfter<T extends BlockType>(blockAfter: BlockExecutor<T>): boolean {
-    return this.outputDataType === blockAfter.inputDataType;
-  }
-
-  hasInput(): boolean {
-    return this.inputDataType !== undefinedType;
-  }
-
-  hasOutput(): boolean {
-    return this.outputDataType !== undefinedType;
-  }
+  constructor(readonly block: B) {}
 
   abstract execute(input: InType): Promise<R.Result<OutType>>;
 }

--- a/src/cli/executors/csv-file-extractor-executor.ts
+++ b/src/cli/executors/csv-file-extractor-executor.ts
@@ -4,7 +4,8 @@ import { parseString as parseStringAsCsv } from '@fast-csv/parse';
 import { ParserOptionsArgs } from '@fast-csv/parse/build/src/ParserOptions';
 
 import { CSVFileExtractor } from '../../language-server/generated/ast';
-import { Sheet, sheetType, undefinedType } from '../data-types';
+import { CSVFileExtractorMetaInformation } from '../../language-server/meta-information/csv-file-extractor-meta-inf';
+import { Sheet } from '../data-types';
 
 import { BlockExecutor } from './block-executor';
 import * as R from './execution-result';
@@ -12,12 +13,9 @@ import * as R from './execution-result';
 export class CSVFileExtractorExecutor extends BlockExecutor<
   CSVFileExtractor,
   void,
-  Sheet
+  Sheet,
+  CSVFileExtractorMetaInformation
 > {
-  constructor(block: CSVFileExtractor) {
-    super(block, undefinedType, sheetType);
-  }
-
   override async execute(): Promise<R.Result<Sheet>> {
     try {
       const raw = await R.dataOrThrowAsync(this.fetchRawData());

--- a/src/cli/executors/layout-validator-executor.ts
+++ b/src/cli/executors/layout-validator-executor.ts
@@ -6,7 +6,8 @@ import {
   isColumnSection,
   isRowSection,
 } from '../../language-server/generated/ast';
-import { Sheet, Table, sheetType, tableType } from '../data-types';
+import { LayoutValidatorMetaInformation } from '../../language-server/meta-information/layout-validator-meta-inf';
+import { Sheet, Table } from '../data-types';
 import { getColumn, getColumnIndexFromSelector } from '../data-util';
 import { getDataType } from '../datatypes';
 import { AbstractDataType } from '../datatypes/AbstractDataType';
@@ -17,12 +18,9 @@ import * as R from './execution-result';
 export class LayoutValidatorExecutor extends BlockExecutor<
   LayoutValidator,
   Sheet,
-  Table
+  Table,
+  LayoutValidatorMetaInformation
 > {
-  constructor(block: LayoutValidator) {
-    super(block, sheetType, tableType);
-  }
-
   override execute(input: Sheet): Promise<R.Result<Table>> {
     const sections = this.block.layout.ref?.sections || [];
     this.ensureValidSections(sections, input.data);

--- a/src/cli/executors/postgres-loader-executor.ts
+++ b/src/cli/executors/postgres-loader-executor.ts
@@ -1,7 +1,8 @@
 import { Client } from 'pg';
 
 import { PostgresLoader } from '../../language-server/generated/ast';
-import { Table, tableType, undefinedType } from '../data-types';
+import { PostgresLoaderMetaInformation } from '../../language-server/meta-information/postgres-loader-meta-inf';
+import { Table } from '../data-types';
 import { AbstractDataType } from '../datatypes/AbstractDataType';
 import { PostgresColumnTypeVisitor } from '../datatypes/visitors/PostgresColumnTypeVisitor';
 import { PostgresValueRepresentationVisitor } from '../datatypes/visitors/PostgresValueRepresentationVisitor';
@@ -12,12 +13,9 @@ import * as R from './execution-result';
 export class PostgresLoaderExecutor extends BlockExecutor<
   PostgresLoader,
   Table,
-  void
+  void,
+  PostgresLoaderMetaInformation
 > {
-  constructor(block: PostgresLoader) {
-    super(block, tableType, undefinedType);
-  }
-
   override async execute(input: Table): Promise<R.Result<void>> {
     const client = new Client({
       connectionString: 'postgresql://postgres:@localhost:5432/jvalue',

--- a/src/language-server/jayvee-module.ts
+++ b/src/language-server/jayvee-module.ts
@@ -13,7 +13,6 @@ import {
   JayveeGeneratedModule,
   JayveeGeneratedSharedModule,
 } from './generated/module';
-// eslint-disable-next-line import/no-cycle
 import { JayveeValidationRegistry, JayveeValidator } from './jayvee-validator';
 
 /**

--- a/src/language-server/jayvee-validator.ts
+++ b/src/language-server/jayvee-validator.ts
@@ -4,8 +4,6 @@ import {
   ValidationRegistry,
 } from 'langium';
 
-// eslint-disable-next-line import/no-cycle
-import { getExecutor } from '../cli/interpreter';
 import { collectIngoingPipes, collectOutgoingPipes } from '../cli/model-util';
 
 import {
@@ -19,6 +17,7 @@ import {
   isRowSection,
 } from './generated/ast';
 import type { JayveeServices } from './jayvee-module';
+import { getMetaInformation } from './meta-information/meta-inf-util';
 
 /**
  * Registry for validation checks.
@@ -108,10 +107,10 @@ export class JayveeValidator {
       return;
     }
 
-    const fromBlockExecutor = getExecutor(fromBlock.type);
-    const toBlockExecutor = getExecutor(toBlock.type);
+    const fromBlockMetaInf = getMetaInformation(fromBlock.type);
+    const toBlockMetaInf = getMetaInformation(toBlock.type);
 
-    if (!fromBlockExecutor.canExecuteAfter(toBlockExecutor)) {
+    if (!fromBlockMetaInf.canBeConnectedTo(toBlockMetaInf)) {
       accept(
         'error',
         `The output of block ${fromBlock.type.$type} is incompatible with the input of block ${toBlock.type.$type}`,
@@ -143,7 +142,7 @@ export class JayveeValidator {
     whatToCheck: 'input' | 'output',
     accept: ValidationAcceptor,
   ): void {
-    const blockExecutor = getExecutor(block.type);
+    const blockMetaInf = getMetaInformation(block.type);
 
     let pipes: Pipe[];
     switch (whatToCheck) {
@@ -158,8 +157,8 @@ export class JayveeValidator {
     }
 
     if (
-      (whatToCheck === 'input' && !blockExecutor.hasInput()) ||
-      (whatToCheck === 'output' && !blockExecutor.hasOutput())
+      (whatToCheck === 'input' && !blockMetaInf.hasInput()) ||
+      (whatToCheck === 'output' && !blockMetaInf.hasOutput())
     ) {
       for (const pipe of pipes) {
         accept(

--- a/src/language-server/meta-information/block-meta-inf.ts
+++ b/src/language-server/meta-information/block-meta-inf.ts
@@ -1,0 +1,28 @@
+import { DataType, undefinedType } from '../../cli/data-types';
+import { BlockType } from '../generated/ast';
+
+export abstract class BlockMetaInformation<
+  B extends BlockType,
+  InType = unknown,
+  OutType = unknown,
+> {
+  protected constructor(
+    readonly block: B,
+    readonly inputDataType: DataType<InType>,
+    readonly outputDataType: DataType<OutType>,
+  ) {}
+
+  canBeConnectedTo<T extends BlockType>(
+    blockAfter: BlockMetaInformation<T>,
+  ): boolean {
+    return this.outputDataType === blockAfter.inputDataType;
+  }
+
+  hasInput(): boolean {
+    return this.inputDataType !== undefinedType;
+  }
+
+  hasOutput(): boolean {
+    return this.outputDataType !== undefinedType;
+  }
+}

--- a/src/language-server/meta-information/csv-file-extractor-meta-inf.ts
+++ b/src/language-server/meta-information/csv-file-extractor-meta-inf.ts
@@ -1,0 +1,14 @@
+import { Sheet, sheetType, undefinedType } from '../../cli/data-types';
+import { CSVFileExtractor } from '../generated/ast';
+
+import { BlockMetaInformation } from './block-meta-inf';
+
+export class CSVFileExtractorMetaInformation extends BlockMetaInformation<
+  CSVFileExtractor,
+  void,
+  Sheet
+> {
+  constructor(block: CSVFileExtractor) {
+    super(block, undefinedType, sheetType);
+  }
+}

--- a/src/language-server/meta-information/layout-validator-meta-inf.ts
+++ b/src/language-server/meta-information/layout-validator-meta-inf.ts
@@ -1,0 +1,14 @@
+import { Sheet, Table, sheetType, tableType } from '../../cli/data-types';
+import { LayoutValidator } from '../generated/ast';
+
+import { BlockMetaInformation } from './block-meta-inf';
+
+export class LayoutValidatorMetaInformation extends BlockMetaInformation<
+  LayoutValidator,
+  Sheet,
+  Table
+> {
+  constructor(block: LayoutValidator) {
+    super(block, sheetType, tableType);
+  }
+}

--- a/src/language-server/meta-information/meta-inf-util.ts
+++ b/src/language-server/meta-information/meta-inf-util.ts
@@ -1,0 +1,26 @@
+import {
+  BlockType,
+  isCSVFileExtractor,
+  isLayoutValidator,
+  isPostgresLoader,
+} from '../generated/ast';
+
+import { BlockMetaInformation } from './block-meta-inf';
+import { CSVFileExtractorMetaInformation } from './csv-file-extractor-meta-inf';
+import { LayoutValidatorMetaInformation } from './layout-validator-meta-inf';
+import { PostgresLoaderMetaInformation } from './postgres-loader-meta-inf';
+
+export function getMetaInformation(
+  blockType: BlockType,
+): BlockMetaInformation<BlockType> {
+  if (isCSVFileExtractor(blockType)) {
+    return new CSVFileExtractorMetaInformation(blockType);
+  }
+  if (isLayoutValidator(blockType)) {
+    return new LayoutValidatorMetaInformation(blockType);
+  }
+  if (isPostgresLoader(blockType)) {
+    return new PostgresLoaderMetaInformation(blockType);
+  }
+  throw new Error('Unknown block type');
+}

--- a/src/language-server/meta-information/postgres-loader-meta-inf.ts
+++ b/src/language-server/meta-information/postgres-loader-meta-inf.ts
@@ -1,0 +1,14 @@
+import { Table, tableType, undefinedType } from '../../cli/data-types';
+import { PostgresLoader } from '../generated/ast';
+
+import { BlockMetaInformation } from './block-meta-inf';
+
+export class PostgresLoaderMetaInformation extends BlockMetaInformation<
+  PostgresLoader,
+  Table,
+  void
+> {
+  constructor(block: PostgresLoader) {
+    super(block, tableType, undefinedType);
+  }
+}


### PR DESCRIPTION
Separates the meta information of a block from its execution logic:

- Subclasses of `BlockMetaInformation` contain all information that is related to a block type
  - Currently input and output types of blocks (i.e. implicit information that is part of M2)
  - Semantic model validations now only rely on `BlockMetaInformation` and not on any `BlockExecutor`
- `BlockExecutor` is only used by the interpreter now
  - Generics ensure that input and output types of executors match the type information from the corresponding `BlockMetaInformation`