### PR TITLE
Simplify interpreter CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 3. In Visual Studio Code, press `F5` to open a new window with the Jayvee extension loaded.
 4. Create a new file with a `.jv` file name suffix or open an existing file in the directory `example`.
 5. Verify that syntax highlighting, validation, completion etc. are working as expected.
-6. Run `node dist/apps/interpreter/main.js` to see options for the CLI of the interpreter; `node dist/apps/interpreter/main.js run <file>` interprets a given `.jv` file.
+6. Run `node dist/apps/interpreter/main.js` to see options for the CLI of the interpreter; `node dist/apps/interpreter/main.js <file>` interprets a given `.jv` file.
 
 ## Development
 

--- a/apps/interpreter/README.md
+++ b/apps/interpreter/README.md
@@ -1,5 +1,65 @@
 # Interpreter
 
+## Run the interpreter locally
+
+Build the interpreter:
+
+```console
+npx nx run interpreter:build
+```
+
+See [Usage](#usage) for how to use the interpreter. Replace `jv` with `node dist/apps/interpreter/main.js` when running the commands.
+
+## Global installation
+
+The interpreter is published as a private npm package with scope `@jvalue` and registry `https://npm.pkg.github.com`.
+In order to install the package, you need to set up your authentication first.
+
+### Authentication
+
+Choose one of the following two ways for setting up the authentication. Both require a personal access token with the permission `read:packages`. Such a token can be generated on the [personal access token page of your GitHub developer settings](https://github.com/settings/tokens). Make sure to replace `PERSONAL-ACCESS-TOKEN` with your token in the following commands.
+
+#### Modify the local npm config
+
+```console
+npm config set //npm.pkg.github.com/:_authToken=PERSONAL-ACCESS-TOKEN
+npm config set @jvalue:registry=https://npm.pkg.github.com
+```
+
+#### Log in to the GitHub package registry
+
+```console
+npm login --scope=@jvalue --registry=https://npm.pkg.github.com
+
+> Username: GITHUB-USERNAME
+> Password: PERSONAL-ACCESS-TOKEN
+> Email: GITHUB-PUBLIC-EMAIL-ADDRESS
+```
+
+See [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-with-a-personal-access-token) for more details.
+
+### Actual installation
+
+```console
+npm i -g @jvalue/interpreter
+```
+
+See [Usage](#usage) for how to use the interpreter.
+
+## Usage
+
+### Run a `.jv` file
+
+```console
+jv <file>
+```
+
+### Show help
+
+```console
+jv -h
+```
+
 ## Important project files
 
 - `package.json` - used for publishing the interpreter as npm package.

--- a/apps/interpreter/src/index.ts
+++ b/apps/interpreter/src/index.ts
@@ -1,18 +1,14 @@
-import { JayveeLanguageMetaData } from '@jayvee/language-server';
 import { Command } from 'commander';
 
 import { runAction } from './interpreter';
 
 const program = new Command();
 
-const fileExtensions = JayveeLanguageMetaData.fileExtensions.join(', ');
 program
-  .command('run')
-  .argument(
-    '<file>',
-    `source file (possible file extensions: ${fileExtensions})`,
-  )
-  .description('run the pipeline model in the source file')
+  .argument('<file>', `path to the .jv source file`)
+  .description('Run a Jayvee file')
   .action(runAction);
+
+program.showHelpAfterError();
 
 program.parse(process.argv);


### PR DESCRIPTION
Part of #38 

Simplifies the interpreter CLI and improves the README. Does not add the `-f` option for specifying the file. Instead it is always passed as an argument (`jv <file>`). Also does not introduce runtime parameters to the language and the CLI.