### PR TITLE
Interpreter run script example

### DIFF
--- a/apps/interpreter/project.json
+++ b/apps/interpreter/project.json
@@ -23,6 +23,13 @@
         "lintFilePatterns": ["apps/interpreter/**/*.ts"]
       }
     },
+    "run": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "commands": ["node dist/apps/interpreter/main.js"]
+      }
+    },
     "test": {
       "executor": "@nrwl/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "nx run-many --target lint --max-warnings 0",
     "test": "nx run-many --target test",
     "generate": "nx run language-server:generate",
-    "example": "node dist/apps/interpreter/main.js example/cars.jv"
+    "example": "nx run interpreter:run example/cars.jv"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Refactors the `npm run example` script to rebuild instead of relying on the last built version.