### PR TITLE
Simplify AST iteration

### DIFF
--- a/apps/interpreter/src/runtime-parameter-util.ts
+++ b/apps/interpreter/src/runtime-parameter-util.ts
@@ -7,6 +7,7 @@ import {
 } from '@jayvee/language-server';
 import * as E from 'fp-ts/lib/Either';
 import { streamAst } from 'langium';
+import { assertUnreachable } from 'langium/lib/utils/errors';
 
 import * as R from './executors/execution-result';
 


### PR DESCRIPTION
Simplifies iterating the AST for extracting runtime parameters by using the [`streamAst`](https://github.com/langium/langium/blob/a18ebca4ce58391d1d7bbb7dc1509b6ec597bb23/packages/langium/src/utils/ast-util.ts#L137-L143) function provided by Langium.