### PR TITLE
Use assertions instead of throwing errors

### DIFF
--- a/apps/interpreter/src/executors/block-executor.ts
+++ b/apps/interpreter/src/executors/block-executor.ts
@@ -1,3 +1,5 @@
+import { strict as assert } from 'assert';
+
 import {
   Block,
   BlockType,
@@ -17,20 +19,20 @@ export abstract class BlockExecutor<InputType = unknown, OutputType = unknown> {
   protected constructor(readonly blockType: BlockType) {}
 
   get block(): Block {
-    if (this._block === undefined) {
-      throw new Error(
-        `No block was set for the executor of block type ${this.blockType}`,
-      );
-    }
+    assert(
+      this._block !== undefined,
+      `No block was set for the executor of block type ${this.blockType}`,
+    );
+
     return this._block;
   }
 
   set block(block: Block) {
-    if (block.type !== this.blockType) {
-      throw new Error(
-        `The provided block does not match the desired type: expected ${this.blockType}, actual ${block.type}`,
-      );
-    }
+    assert(
+      block.type === this.blockType,
+      `The provided block does not match the desired type: expected ${this.blockType}, actual ${block.type}`,
+    );
+
     this._block = block;
   }
 
@@ -41,11 +43,11 @@ export abstract class BlockExecutor<InputType = unknown, OutputType = unknown> {
   }
 
   get runtimeParameters(): Map<string, string | number | boolean> {
-    if (this._runtimeParameters === undefined) {
-      throw new Error(
-        `No runtime parameters were set for the executor of block type ${this.blockType}`,
-      );
-    }
+    assert(
+      this._runtimeParameters !== undefined,
+      `No runtime parameters were set for the executor of block type ${this.blockType}`,
+    );
+
     return this._runtimeParameters;
   }
 
@@ -53,31 +55,31 @@ export abstract class BlockExecutor<InputType = unknown, OutputType = unknown> {
 
   protected getStringAttributeValue(attributeName: string): string {
     const attributeValue = this.getAttributeValue(attributeName);
-    if (typeof attributeValue !== 'string') {
-      throw new Error(
-        `The value of attribute "${attributeName}" in block "${this.block.name}" is unexpectedly not of type string`,
-      );
-    }
+    assert(
+      typeof attributeValue === 'string',
+      `The value of attribute "${attributeName}" in block "${this.block.name}" is unexpectedly not of type string`,
+    );
+
     return attributeValue;
   }
 
   protected getIntAttributeValue(attributeName: string): number {
     const attributeValue = this.getAttributeValue(attributeName);
-    if (typeof attributeValue !== 'number') {
-      throw new Error(
-        `The value of attribute "${attributeName}" in block "${this.block.name}" is unexpectedly not of type string`,
-      );
-    }
+    assert(
+      typeof attributeValue === 'number',
+      `The value of attribute "${attributeName}" in block "${this.block.name}" is unexpectedly not of type string`,
+    );
+
     return attributeValue;
   }
 
   protected getLayoutAttributeValue(attributeName: string): Layout {
     const attributeValue = this.getAttributeValue(attributeName);
-    if (!isLayout(attributeValue)) {
-      throw new Error(
-        `The value of attribute "${attributeName}" in block "${this.block.name}" is unexpectedly not of type layout`,
-      );
-    }
+    assert(
+      isLayout(attributeValue),
+      `The value of attribute "${attributeName}" in block "${this.block.name}" is unexpectedly not of type layout`,
+    );
+
     return attributeValue;
   }
 
@@ -88,17 +90,17 @@ export abstract class BlockExecutor<InputType = unknown, OutputType = unknown> {
     if (attribute === undefined) {
       const metaInf = getMetaInformation(this.blockType);
       const attributeSpec = metaInf.getAttributeSpecification(attributeName);
-      if (attributeSpec === undefined) {
-        throw new Error(
-          `Attribute with name "${attributeName}" is not allowed in a block of type ${this.blockType}`,
-        );
-      }
+      assert(
+        attributeSpec !== undefined,
+        `Attribute with name "${attributeName}" is not allowed in a block of type ${this.blockType}`,
+      );
+
       const defaultValue = attributeSpec.defaultValue;
-      if (defaultValue === undefined) {
-        throw new Error(
-          `The block "${this.block.name}" of type ${this.block.type} is missing a required attribute called "${attributeName}"`,
-        );
-      }
+      assert(
+        defaultValue !== undefined,
+        `The block "${this.block.name}" of type ${this.block.type} is missing a required attribute called "${attributeName}"`,
+      );
+
       return defaultValue;
     }
     const attributeValue = attribute.value;

--- a/apps/interpreter/src/executors/utils/block-executor-registry.ts
+++ b/apps/interpreter/src/executors/utils/block-executor-registry.ts
@@ -1,3 +1,5 @@
+import { strict as assert } from 'assert';
+
 import { Block, BlockType } from '@jayvee/language-server';
 
 import { BlockExecutor } from '../block-executor';
@@ -11,11 +13,11 @@ const registeredBlockExecutors = new Map<BlockType, BlockExecutorType>();
 
 export function registerBlockExecutor(blockExecutor: BlockExecutorType) {
   const blockType = new blockExecutor().blockType;
-  if (registeredBlockExecutors.has(blockType)) {
-    throw new Error(
-      `Multiple executors were registered for block type ${blockType}`,
-    );
-  }
+  assert(
+    !registeredBlockExecutors.has(blockType),
+    `Multiple executors were registered for block type ${blockType}`,
+  );
+
   registeredBlockExecutors.set(blockType, blockExecutor);
 }
 
@@ -24,9 +26,11 @@ export function createBlockExecutor(
   runtimeParameters: Map<string, string | number | boolean>,
 ): BlockExecutor {
   const blockExecutor = registeredBlockExecutors.get(block.type);
-  if (blockExecutor === undefined) {
-    throw new Error(`No executor was registered for block type ${block.type}`);
-  }
+  assert(
+    blockExecutor !== undefined,
+    `No executor was registered for block type ${block.type}`,
+  );
+
   const blockExecutorInstance = new blockExecutor();
   blockExecutorInstance.block = block;
   blockExecutorInstance.runtimeParameters = runtimeParameters;

--- a/apps/interpreter/src/runtime-parameter-util.ts
+++ b/apps/interpreter/src/runtime-parameter-util.ts
@@ -1,3 +1,5 @@
+import { strict as assert } from 'assert';
+
 import {
   AttributeType,
   Model,
@@ -86,11 +88,11 @@ function parseParameterAsMatchingType(
   const attributeName = requiredParameter.$container.name;
 
   const attributeSpec = metaInf.getAttributeSpecification(attributeName);
-  if (attributeSpec === undefined) {
-    throw new Error(
-      `Attribute with name "${attributeName}" is not allowed in a block of type ${block.type}`,
-    );
-  }
+  assert(
+    attributeSpec !== undefined,
+    `Attribute with name "${attributeName}" is not allowed in a block of type ${block.type}`,
+  );
+
   const requiredType = attributeSpec.type;
 
   switch (requiredType) {
@@ -107,11 +109,13 @@ function parseParameterAsMatchingType(
         });
       }
       return R.ok(Number.parseInt(value, 10));
-    case AttributeType.LAYOUT:
-      throw new Error(
+    default:
+      assert(
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        requiredType !== AttributeType.LAYOUT,
         'Runtime parameters are not allowed for attributes of type layout',
       );
-    default:
+
       assertUnreachable(requiredType);
   }
 }


### PR DESCRIPTION
Part of #61 

The refactoring to dynamic attributes lead to uncertainties at runtime. Before this PR, generic errors were thrown when certain assumptions were not fulfilled. This PR replaces them with [assertions](https://nodejs.org/api/assert.html#assertvalue-message) to reduce boilerplate code and clearly distinguish between conditions we assume to always be true (-> AssertionError if false) and conditions that could possibly be false at runtime.