### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jayvee",
-  "version": "0.0.0",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jayvee",
-      "version": "0.0.0",
+      "version": "0.0.5",
       "dependencies": {
         "chalk": "^4.1.2",
         "chevrotain": "^9.1.0",


### PR DESCRIPTION
When running `npm install`, I noticed that `package-lock.json` was not up to date. This PR includes the updated file.

If, in the future, you would like to catch such issues in CI, I recommend to take a look at my npm package: https://www.npmjs.com/package/package-lock-utd