### PR TITLE
Add validation for column IDs

### DIFF
--- a/libs/language-server/src/lib/jayvee-module.ts
+++ b/libs/language-server/src/lib/jayvee-module.ts
@@ -16,6 +16,7 @@ import {
 import { JayveeCompletionProvider } from './completion/jayvee-completion-provider';
 import { BlockValidator } from './validation/block-validator';
 import { CellRangeSelectionValidator } from './validation/cell-range-selection-validator';
+import { ColumnSelectionValidator } from './validation/column-selection-validator';
 import { LayoutValidator } from './validation/layout-validator';
 import { ModelValidator } from './validation/model-validator';
 import { PipeValidator } from './validation/pipe-validator';
@@ -33,6 +34,7 @@ export interface JayveeAddedServices {
     PipeValidator: PipeValidator;
     BlockValidator: BlockValidator;
     CellRangeSelectionValidator: CellRangeSelectionValidator;
+    ColumnSelectionValidator: ColumnSelectionValidator;
   };
 }
 
@@ -59,6 +61,7 @@ export const JayveeModule: Module<
     PipeValidator: () => new PipeValidator(),
     BlockValidator: () => new BlockValidator(),
     CellRangeSelectionValidator: () => new CellRangeSelectionValidator(),
+    ColumnSelectionValidator: () => new ColumnSelectionValidator(),
   },
   lsp: {
     CompletionProvider: (services: LangiumServices) =>

--- a/libs/language-server/src/lib/validation/column-selection-validator.ts
+++ b/libs/language-server/src/lib/validation/column-selection-validator.ts
@@ -1,0 +1,36 @@
+import { ValidationAcceptor, ValidationChecks } from 'langium';
+
+import { ColumnSelection, JayveeAstType } from '../ast/generated/ast';
+
+import { JayveeValidator } from './jayvee-validator';
+
+export class ColumnSelectionValidator implements JayveeValidator {
+  get checks(): ValidationChecks<JayveeAstType> {
+    return {
+      ColumnSelection: [this.checkColumnIdSyntax],
+    };
+  }
+
+  checkColumnIdSyntax(
+    this: void,
+    columnSelection: ColumnSelection,
+    accept: ValidationAcceptor,
+  ): void {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (columnSelection.columnId === undefined) {
+      return;
+    }
+
+    const columnIdRegex = /^([A-Z]+|\*)$/;
+    if (!columnIdRegex.test(columnSelection.columnId)) {
+      accept(
+        'error',
+        'Columns need to be denoted via capital letters or the * character',
+        {
+          node: columnSelection,
+          property: 'columnId',
+        },
+      );
+    }
+  }
+}

--- a/libs/language-server/src/lib/validation/validation-registry.ts
+++ b/libs/language-server/src/lib/validation/validation-registry.ts
@@ -30,5 +30,9 @@ export class JayveeValidationRegistry extends ValidationRegistry {
       cellRangeSelectionValidator.checks,
       cellRangeSelectionValidator,
     );
+
+    const columnSelectionValidator =
+      services.validation.ColumnSelectionValidator;
+    this.register(columnSelectionValidator.checks, columnSelectionValidator);
   }
 }


### PR DESCRIPTION
Adds validation for column IDs because they need to be capital letters or `*` but the language grammar also allows lowercase letters and underscores.