### PR TITLE
Add table interpretation as execution extension

### DIFF
--- a/example/cars.jv
+++ b/example/cars.jv
@@ -5,42 +5,39 @@ pipeline CarsPipeline {
 	
 	pipe {
 		from: CarsExtractor;
-		to: CarColumnNameWriter;
+		to: NameHeaderWriter;
 	}
 
-	block CarColumnNameWriter oftype CellWriter {
+	block NameHeaderWriter oftype CellWriter {
 		at: cell A1;
 		write: "name";
 	}
 
     pipe {
-        from: CarColumnNameWriter;
-        to: CarsValidator;
+        from: NameHeaderWriter;
+        to: CarsTableInterpreter;
     }
 
-	layout CarsLayout {
-		header row 1: text;
-
-		column A: text;
-		column B: decimal;
-		column C: integer;
-		column D: decimal;
-		column E: integer;
-		column F: decimal;
-		column G: decimal;
-		column H: decimal;
-		column I: integer;
-		column J: integer;
-		column K: integer;
-		column L: integer;
-	}
-
-	block CarsValidator oftype LayoutValidator {
-		validationLayout: CarsLayout;
+	block CarsTableInterpreter oftype TableInterpreter {
+		header: true;
+		columns: [
+			"name" typed text,
+			"mpg" typed decimal,
+			"cyl" typed integer,
+			"disp" typed decimal,
+			"hp" typed integer,
+			"drat" typed decimal,
+			"wt" typed decimal,
+			"qsec" typed decimal,
+			"vs" typed integer,
+			"am" typed integer,
+			"gear" typed integer,
+			"carb" typed integer
+		];
 	}
 
 	pipe {
-		from: CarsValidator;
+		from: CarsTableInterpreter;
 		to: CarsLoader;
 	}
 

--- a/example/gas.jv
+++ b/example/gas.jv
@@ -4,19 +4,37 @@ pipeline GasReservePipeline {
 	    delimiter: ";";
 	}
 
-	layout GasReserveLayout {
-		header row 1: text;
-		column A: text;
-		column B: decimal;
-		column C: decimal;
-		column D: decimal;
-		column E: decimal;
-		column F: decimal;
-	}
+	pipe {
+    	from: GasReserveExtractor;
+    	to: DateHeaderWriter;
+    }
 
-	block GasReserveValidator oftype LayoutValidator {
-		validationLayout: GasReserveLayout;
-	}
+	block DateHeaderWriter oftype CellWriter {
+    	at: cell A1;
+    	write: "Datum";
+    }
+
+    pipe {
+       	from: DateHeaderWriter;
+      	to: GasReserveTableInterpreter;
+    }
+
+	block GasReserveTableInterpreter oftype TableInterpreter {
+    	header: true;
+    	columns: [
+    		"Datum" typed text,
+    		"Kritisch" typed decimal,
+    		"Angespannt" typed decimal,
+    		"Stabil" typed decimal,
+    		"Speicherstand IST" typed decimal,
+    		"gesetzliche Ziele" typed decimal
+    	];
+    }
+
+    pipe {
+        from: GasReserveTableInterpreter;
+        to: GasReserveLoader;
+    }
 
 	block GasReserveLoader oftype PostgresLoader {
 		host: requires DB_HOST;
@@ -25,15 +43,5 @@ pipeline GasReservePipeline {
 		password: requires DB_PASSWORD;
 		database: requires DB_DATABASE;
 		table: requires DB_TABLE;
-	}
-
-	pipe {
-		from: GasReserveExtractor;
-		to: GasReserveValidator;
-	}
-
-	pipe {
-		from: GasReserveValidator;
-		to: GasReserveLoader;
 	}
 }

--- a/libs/execution/src/lib/block-executor.ts
+++ b/libs/execution/src/lib/block-executor.ts
@@ -3,10 +3,12 @@ import { strict as assert } from 'assert';
 import {
   Attribute,
   Block,
+  DataTypeAssignment,
   Layout,
   SemanticCellRange,
   getOrFailMetaInformation,
   isCellRange,
+  isDataTypeAssignment,
   isLayout,
   isRuntimeParameter,
 } from '@jayvee/language-server';
@@ -90,6 +92,16 @@ export abstract class BlockExecutor<InputType = unknown, OutputType = unknown> {
     return attributeValue;
   }
 
+  protected getBooleanAttributeValue(attributeName: string): boolean {
+    const attributeValue = this.getAttributeValue(attributeName);
+    assert(
+      typeof attributeValue === 'boolean',
+      `The value of attribute "${attributeName}" in block "${this.block.name}" is unexpectedly not of type boolean`,
+    );
+
+    return attributeValue;
+  }
+
   protected getLayoutAttributeValue(attributeName: string): Layout {
     const attributeValue = this.getAttributeValue(attributeName);
     assert(
@@ -121,6 +133,19 @@ export abstract class BlockExecutor<InputType = unknown, OutputType = unknown> {
       `The value of attribute "${attributeName}" in block "${this.block.name}" is unexpectedly not of type cell range collection`,
     );
     return attributeValue.map((cellRange) => new SemanticCellRange(cellRange));
+  }
+
+  protected getDataTypeAssignmentCollectionAttributeValue(
+    attributeName: string,
+  ): DataTypeAssignment[] {
+    const attributeValue = this.getAttributeValue(attributeName);
+    assert(
+      Array.isArray(attributeValue) &&
+        attributeValue.every(isDataTypeAssignment),
+      `The value of attribute "${attributeName}" in block "${this.block.name}" is unexpectedly not of type data type assignment collection`,
+    );
+
+    return attributeValue;
   }
 
   private getAttributeValue(attributeName: string): unknown {

--- a/libs/extensions/tabular/exec/src/extension.ts
+++ b/libs/extensions/tabular/exec/src/extension.ts
@@ -10,6 +10,7 @@ import { ColumnDeleterExecutor } from './lib/column-deleter-executor';
 import { CSVFileExtractorExecutor } from './lib/csv-file-extractor-executor';
 import { LayoutValidatorExecutor } from './lib/layout-validator-executor';
 import { RowDeleterExecutor } from './lib/row-deleter-executor';
+import { TableInterpreterExecutor } from './lib/table-interpreter-executor';
 
 export class TabularExecExtension implements JayveeExecExtension {
   getBlockExecutors(): Array<
@@ -22,6 +23,7 @@ export class TabularExecExtension implements JayveeExecExtension {
       ColumnDeleterExecutor,
       RowDeleterExecutor,
       CellRangeSelectorExecutor,
+      TableInterpreterExecutor,
     ];
   }
 }

--- a/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
@@ -1,0 +1,198 @@
+import { strict as assert } from 'assert';
+
+import { BlockExecutor } from '@jayvee/execution';
+import * as R from '@jayvee/execution';
+import {
+  AbstractDataType,
+  CellIndex,
+  DataTypeAssignment,
+  Sheet,
+  Table,
+  getDataType,
+  rowIndexToString,
+} from '@jayvee/language-server';
+
+interface ColumnDefinitionEntry {
+  sheetColumnIndex: number;
+  columnName: string;
+  dataType: AbstractDataType;
+  astNode: DataTypeAssignment;
+}
+
+export class TableInterpreterExecutor extends BlockExecutor<Sheet, Table> {
+  constructor() {
+    super('TableInterpreter');
+  }
+
+  override async execute(inputSheet: Sheet): Promise<R.Result<Table>> {
+    const header = this.getBooleanAttributeValue('header');
+    const columnDefinitions =
+      this.getDataTypeAssignmentCollectionAttributeValue('columns');
+
+    let columnEntries: ColumnDefinitionEntry[];
+
+    if (header) {
+      if (inputSheet.height < 1) {
+        return Promise.resolve(
+          R.err({
+            message: 'The input sheet is empty and thus has no header',
+            diagnostic: {
+              node: this.getOrFailAttribute('header'),
+            },
+          }),
+        );
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const headerRow = inputSheet.data[0]!;
+
+      columnEntries = this.deriveColumnDefinitionEntriesFromHeader(
+        columnDefinitions,
+        headerRow,
+      );
+    } else {
+      if (inputSheet.width < columnDefinitions.length) {
+        return Promise.resolve(
+          R.err({
+            message: `There are ${columnDefinitions.length} column definitions but the input sheet only has ${inputSheet.width} columns`,
+            diagnostic: {
+              node: this.getOrFailAttribute('columns'),
+            },
+          }),
+        );
+      }
+
+      columnEntries =
+        this.deriveColumnDefinitionEntriesWithoutHeader(columnDefinitions);
+    }
+
+    const numberOfTableRows = header
+      ? inputSheet.height - 1
+      : inputSheet.height;
+    this.logger.logDebug(
+      `Validating ${numberOfTableRows} row(s) according to the column types`,
+    );
+
+    const tableData = this.constructAndValidateTableData(
+      inputSheet,
+      header,
+      columnEntries,
+    );
+
+    this.logger.logDebug(
+      `Validation completed, the resulting table has ${tableData.length} row(s) and ${columnEntries.length} column(s)`,
+    );
+
+    const tableColumnNames = columnEntries.map(
+      (columnEntry) => columnEntry.columnName,
+    );
+    const tableColumnTypes = columnEntries.map(
+      (columnEntry) => columnEntry.dataType,
+    );
+    const resultingTable: Table = {
+      columnNames: tableColumnNames,
+      columnTypes: tableColumnTypes,
+      data: tableData,
+    };
+
+    return Promise.resolve(R.ok(resultingTable));
+  }
+
+  private constructAndValidateTableData(
+    sheet: Sheet,
+    header: boolean,
+    columnEntries: ColumnDefinitionEntry[],
+  ): string[][] {
+    const tableData: string[][] = [];
+    sheet.data.forEach((sheetRow, sheetRowIndex) => {
+      if (header && sheetRowIndex === 0) {
+        return;
+      }
+
+      const tableRow = this.constructAndValidateTableRow(
+        sheetRow,
+        sheetRowIndex,
+        columnEntries,
+      );
+      if (tableRow === undefined) {
+        this.logger.logDebug(`Omitting row ${rowIndexToString(sheetRowIndex)}`);
+      } else {
+        tableData.push(tableRow);
+      }
+    });
+    return tableData;
+  }
+
+  private constructAndValidateTableRow(
+    sheetRow: string[],
+    sheetRowIndex: number,
+    columnEntries: ColumnDefinitionEntry[],
+  ): string[] | undefined {
+    let invalidRow = false;
+    const tableRow: string[] = [];
+    columnEntries.forEach((columnEntry, tableColumnIndex) => {
+      const sheetColumnIndex = columnEntry.sheetColumnIndex;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const value = sheetRow[sheetColumnIndex]!;
+      if (!columnEntry.dataType.isValid(value)) {
+        const cellIndex = new CellIndex(sheetColumnIndex, sheetRowIndex);
+        this.logger.logDebug(
+          `The value at cell ${cellIndex.toString()} does not match the type ${
+            columnEntry.astNode.type
+          }`,
+        );
+        invalidRow = true;
+        return;
+      }
+      tableRow[tableColumnIndex] = value;
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (invalidRow) {
+      return undefined;
+    }
+
+    assert(tableRow.length === columnEntries.length);
+    return tableRow;
+  }
+
+  private deriveColumnDefinitionEntriesWithoutHeader(
+    columnDefinitions: DataTypeAssignment[],
+  ): ColumnDefinitionEntry[] {
+    return columnDefinitions.map<ColumnDefinitionEntry>(
+      (columnDefinition, columnDefinitionIndex) => ({
+        sheetColumnIndex: columnDefinitionIndex,
+        columnName: columnDefinition.name,
+        dataType: getDataType(columnDefinition.type),
+        astNode: columnDefinition,
+      }),
+    );
+  }
+
+  private deriveColumnDefinitionEntriesFromHeader(
+    columnDefinitions: DataTypeAssignment[],
+    headerRow: string[],
+  ): ColumnDefinitionEntry[] {
+    this.logger.logDebug(`Matching header with provided column names`);
+
+    const columnEntries: ColumnDefinitionEntry[] = [];
+    for (const columnDefinition of columnDefinitions) {
+      const indexOfMatchingHeader = headerRow.findIndex(
+        (headerColumnName) => headerColumnName === columnDefinition.name,
+      );
+      if (indexOfMatchingHeader === -1) {
+        this.logger.logDebug(
+          `Omitting column "${columnDefinition.name}" as the name was not found in the header`,
+        );
+        continue;
+      }
+      columnEntries.push({
+        sheetColumnIndex: indexOfMatchingHeader,
+        columnName: columnDefinition.name,
+        dataType: getDataType(columnDefinition.type),
+        astNode: columnDefinition,
+      });
+    }
+
+    return columnEntries;
+  }
+}


### PR DESCRIPTION
Part of #140

Also updates the examples, so they use the new `TableInterpreter` block type.