### PR TITLE
Fix LSP Auto-Completion

### DIFF
--- a/libs/language-server/src/lib/completion/jayvee-completion-provider.ts
+++ b/libs/language-server/src/lib/completion/jayvee-completion-provider.ts
@@ -32,18 +32,17 @@ export class JayveeCompletionProvider extends DefaultCompletionProvider {
       isRuleCall(next.feature) &&
       next.feature.rule.ref !== undefined
     ) {
-      if (isBlock(astNode)) {
-        if (next.type === Attribute) {
-          return this.completionForAttributeName(astNode, acceptor);
-        }
-        if (next.type === BlockType) {
-          return this.completionForBlockType(acceptor);
-        }
+      const isBlockTypeCompletion = isBlock(astNode) && next.type === BlockType;
+      if (isBlockTypeCompletion) {
+        return this.completionForBlockType(acceptor);
       }
-      if (isAttribute(astNode)) {
-        if (next.type === Attribute) {
-          return this.completionForAttributeName(astNode, acceptor);
-        }
+
+      const isFirstAttributeCompletion =
+        isBlock(astNode) && next.type === Attribute;
+      const isOtherAttributeCompletion =
+        isAttribute(astNode) && next.type === Attribute;
+      if (isFirstAttributeCompletion || isOtherAttributeCompletion) {
+        return this.completionForAttributeName(astNode, acceptor);
       }
     }
     return super.completionFor(context, next, acceptor);


### PR DESCRIPTION
Closes #151.

- Adapted to the changes of elevating `BlockType` to an `AstElement`. Better diff [here].(https://github.com/jvalue/jayvee/compare/main...55eafbb)
- Refactored the code with explanatory variables for better readbility (can undo if it you like the previous version better)

I also noticed that auto-completion on a `BlockType` does not work once you started typing the word. If no letter is written it works. I traced it down to not even the `completionFor` method - which seems a little weird to me. For `Attributes` it works just fine. Should probably an issue for its own.