### PR TITLE
Refactor mobility.jv to tableInterpreter

### DIFF
--- a/rfc/0002-mobility.jv
+++ b/rfc/0002-mobility.jv
@@ -136,35 +136,41 @@ pipeline GtfsPipeline {
 
 
 	block AgencyLoader oftype SQLiteTablesLoader {
+		table: "Agency";
 		file: "./gtfs.db";
 	}
 
 	block StopsLoader oftype SQLiteTablesLoader {
+		table: "Stops";
 		file: "./gtfs.db";
 	}
 
 
 	block RoutesLoader oftype SQLiteTablesLoader {
+		table: "Routes";
 		file: "./gtfs.db";
-		recreateDatabase: false;
 	}
 
 
-	lock TripsLoader oftype SQLiteTablesLoader {
+	block TripsLoader oftype SQLiteTablesLoader {
+		table: "Trips";
 		file: "./gtfs.db";
 	}
 
 
 	block StopTimesLoader oftype SQLiteTablesLoader {
+		table: "StopTimes"
 		file: "./gtfs.db";
 	}
 
 	block CalendarDatesLoader oftype SQLiteTablesLoader {
+		table: "CalendarDates";
 		file: "./gtfs.db";
 	}
 
 
 	block FeedInfoLoader oftype SQLiteTablesLoader {
+		table: "FeedInfo";
 		file: "./gtfs.db";
 	}
 


### PR DESCRIPTION
This PR holds the changes of mobility.jv which are caused by the replacement of concept layoutValidator with tableInterpreter.

- Discussed in #164
- Overall changes managed in #123 