### PR TITLE
Fix cars-example

### DIFF
--- a/example/cars.jv
+++ b/example/cars.jv
@@ -6,7 +6,7 @@ pipeline CarsPipeline {
 	  -> CarsTableInterpreter
 	  -> CarsLoader;
 
-	block CarsExtractor oftype CSVFileExtractor {
+	block CarsExtractor oftype HttpExtractor {
 		url: "https://gist.githubusercontent.com/noamross/e5d3e859aa0c794be10b/raw/b999fb4425b54c63cab088c0ce2c0d6ce961a563/cars.csv";
 	}
 


### PR DESCRIPTION
Recognized, that a merge from main to dev changed the cars.jv example to use the old CSVFileExtractor. Changed this to the new HttpExtractor.