### PR TITLE
Add pack and install target to the interpreter

### DIFF
--- a/apps/interpreter/project.json
+++ b/apps/interpreter/project.json
@@ -38,14 +38,39 @@
         "passWithNoTests": true
       }
     },
-    "publish": {
+    "pre-publish": {
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
       "options": {
         "commands": [
-          // Prepend shebang to the binary file
-          "sed -i '1i#!/usr/bin/env node' dist/apps/interpreter/main.js",
+          "node tools/scripts/interpreter/prepend-shebang.mjs interpreter main.js"
+        ]
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["pre-publish"],
+      "options": {
+        "commands": [
           "node tools/scripts/publish.mjs interpreter"
+        ]
+      }
+    },
+    "pack": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["pre-publish"],
+      "options": {
+        "commands": [
+          "node tools/scripts/pack.mjs interpreter"
+        ]
+      }
+    },
+    "install": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["pack"],
+      "options": {
+        "commands": [
+          "npm i -g dist/apps/interpreter/jvalue-interpreter-*.tgz"
         ]
       }
     }

--- a/libs/monaco-editor/project.json
+++ b/libs/monaco-editor/project.json
@@ -58,13 +58,13 @@
       }
     },
     "pack": {
-        "executor": "nx:run-commands",
-        "dependsOn": ["pre-publish"],
-        "options": {
-          "commands": [
-            "node tools/scripts/pack.mjs @jayvee/monaco-editor"
-          ]
-        }
+      "executor": "nx:run-commands",
+      "dependsOn": ["pre-publish"],
+      "options": {
+        "commands": [
+          "node tools/scripts/pack.mjs @jayvee/monaco-editor"
+        ]
+      }
     }
   }
 }

--- a/tools/scripts/interpreter/prepend-shebang.mjs
+++ b/tools/scripts/interpreter/prepend-shebang.mjs
@@ -1,0 +1,11 @@
+import {getOutputPath} from "../shared-util.mjs";
+import fs from "fs";
+
+// Executing this script: node path/to/prepend-shebang.mjs {projectName} {file}
+const [, , projectName, file] = process.argv;
+const shebang = '#!/usr/bin/env node';
+
+process.chdir(getOutputPath(projectName));
+
+const previousFileContent = fs.readFileSync(file)
+fs.writeFileSync(file, `${shebang}\n${previousFileContent}`);


### PR DESCRIPTION
Opens an easy way to globally install a locally built interpreter.