### PR TITLE
Add install target to VS Code extension

### DIFF
--- a/apps/vs-code-extension/project.json
+++ b/apps/vs-code-extension/project.json
@@ -52,6 +52,15 @@
           "cd dist/apps/vs-code-extension && npx vsce package --out jayvee.vsix"
         ]
       }
+    },
+    "install": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["pack"],
+      "options": {
+        "commands": [
+          "code --install-extension dist/apps/vs-code-extension/jayvee.vsix"
+        ]
+      }
     }
   },
   "tags": []


### PR DESCRIPTION
Similar to #188 but this time for the VS Code extension.