### PR TITLE
Publish language-server as commonjs

### DIFF
--- a/libs/language-server/tsconfig.lib.json
+++ b/libs/language-server/tsconfig.lib.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "types": ["node"]
+    "types": ["node"],
+    "module": "CommonJS"
   },
   "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"]


### PR DESCRIPTION
language-server was published as ECMAScript Modules. Now it's CommonJS for better interoperability with NodeJS