### PR TITLE
Unit test to ensure constraint executors are registered 

### DIFF
--- a/libs/execution/src/lib/constraints/constraint-executor-registry.ts
+++ b/libs/execution/src/lib/constraints/constraint-executor-registry.ts
@@ -26,6 +26,10 @@ export function registerConstraintExecutor(
   constraintExecutorRegistry.register(executorClass.type, executorClass);
 }
 
+export function getRegisteredConstraintExecutors(): ConstraintExecutorClass[] {
+  return constraintExecutorRegistry.getAll();
+}
+
 export function createConstraintExecutor(
   constraint: Constraint,
 ): ConstraintExecutor {

--- a/libs/execution/src/lib/constraints/default-constraint-executors.spec.ts
+++ b/libs/execution/src/lib/constraints/default-constraint-executors.spec.ts
@@ -1,0 +1,23 @@
+import {
+  getRegisteredConstraintMetaInformation,
+  registerConstraints,
+} from '@jvalue/language-server';
+
+import {
+  getRegisteredConstraintExecutors,
+  registerDefaultConstraintExecutors,
+} from './constraint-executor-registry';
+
+describe('default constraint executors', () => {
+  registerConstraints();
+  registerDefaultConstraintExecutors();
+
+  getRegisteredConstraintMetaInformation().forEach((metaInf) => {
+    it(`should include an executor for ${metaInf.type}`, () => {
+      const matchingConstraintExecutorClass =
+        getRegisteredConstraintExecutors().find((c) => c.type === metaInf.type);
+
+      expect(matchingConstraintExecutorClass).toBeDefined();
+    });
+  });
+});

--- a/libs/language-server/src/lib/constraint/index.ts
+++ b/libs/language-server/src/lib/constraint/index.ts
@@ -1,0 +1,6 @@
+export * from './blacklist-constraint-meta-inf';
+export * from './constraint-registry';
+export * from './length-constraint-meta-inf';
+export * from './range-constraint-meta-inf';
+export * from './regex-constraint-meta-inf';
+export * from './whitelist-constraint-meta-inf';

--- a/libs/language-server/src/lib/index.ts
+++ b/libs/language-server/src/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './ast';
+export * from './constraint';
 export * from './docs';
 export * from './meta-information';
 export * from './util';


### PR DESCRIPTION
Adds a test to ensure that each registered `ConstraintMetaInf` has a corresponding `ConstraintExecutor`.