### PR TITLE
Add PrimitiveValuetype interface

### DIFF
--- a/libs/execution/src/lib/types/valuetypes/atomic-valuetype.ts
+++ b/libs/execution/src/lib/types/valuetypes/atomic-valuetype.ts
@@ -8,25 +8,22 @@ import {
 import { createConstraintExecutor } from '../../constraints/constraint-executor-registry';
 import { ExecutionContext } from '../../execution-context';
 
+import { PrimitiveType, PrimitiveValuetype } from './primitive-valuetype';
 import { Valuetype } from './valuetype';
 import { ValuetypeVisitor } from './visitors/valuetype-visitor';
 
-export class AtomicValuetype<T> implements Valuetype<T> {
+export class AtomicValuetype<T extends PrimitiveType> implements Valuetype<T> {
   constructor(
-    private readonly baseValuetype: Valuetype<T>,
+    private readonly primitiveValuetype: PrimitiveValuetype<T>,
     private readonly astNode: ValuetypeDefinition,
   ) {}
 
-  get primitiveValuetype() {
-    return this.baseValuetype.primitiveValuetype;
-  }
-
   acceptVisitor<R>(visitor: ValuetypeVisitor<R>): R {
-    return this.baseValuetype.acceptVisitor(visitor);
+    return this.primitiveValuetype.acceptVisitor(visitor);
   }
 
   isValid(value: unknown, context: ExecutionContext): boolean {
-    if (!this.baseValuetype.isValid(value, context)) {
+    if (!this.primitiveValuetype.isValid(value, context)) {
       return false;
     }
 
@@ -50,7 +47,7 @@ export class AtomicValuetype<T> implements Valuetype<T> {
   }
 
   getStandardRepresentation(value: unknown): T {
-    return this.baseValuetype.getStandardRepresentation(value);
+    return this.primitiveValuetype.getStandardRepresentation(value);
   }
 
   private getConstraints(): ConstraintDefinition[] {

--- a/libs/execution/src/lib/types/valuetypes/boolean-valuetype.ts
+++ b/libs/execution/src/lib/types/valuetypes/boolean-valuetype.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/no-cycle
-import { Valuetype } from './valuetype';
+import { PrimitiveValuetype } from './primitive-valuetype';
 // eslint-disable-next-line import/no-cycle
 import { ValuetypeVisitor } from './visitors/valuetype-visitor';
 
-export class BooleanValuetype implements Valuetype {
-  public readonly primitiveValuetype = 'boolean';
+export class BooleanValuetype implements PrimitiveValuetype<boolean> {
+  public readonly primitiveValuetypeKeyword = 'boolean';
 
   private readonly BOOLEAN_STRING_REPRESENTATIONS = [
     'true',
@@ -43,7 +43,7 @@ export class BooleanValuetype implements Valuetype {
 
     throw new Error(
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `Invalid value: ${value} for type ${this.primitiveValuetype}`,
+      `Invalid value: ${value} for type ${this.primitiveValuetypeKeyword}`,
     );
   }
 }

--- a/libs/execution/src/lib/types/valuetypes/decimal-valuetype.ts
+++ b/libs/execution/src/lib/types/valuetypes/decimal-valuetype.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/no-cycle
-import { Valuetype } from './valuetype';
+import { PrimitiveValuetype } from './primitive-valuetype';
 // eslint-disable-next-line import/no-cycle
 import { ValuetypeVisitor } from './visitors/valuetype-visitor';
 
-export class DecimalValuetype implements Valuetype {
-  public readonly primitiveValuetype = 'decimal';
+export class DecimalValuetype implements PrimitiveValuetype<number> {
+  public readonly primitiveValuetypeKeyword = 'decimal';
 
   private readonly DOT_SEPARATOR_REGEX = /^[+-]?([0-9]*[.])?[0-9]+$/;
   private readonly COMMA_SEPARATOR_REGEX = /^[+-]?([0-9]*[,])?[0-9]+$/;
@@ -38,7 +38,7 @@ export class DecimalValuetype implements Valuetype {
 
     throw new Error(
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `Invalid value: ${value} for type ${this.primitiveValuetype}`,
+      `Invalid value: ${value} for type ${this.primitiveValuetypeKeyword}`,
     );
   }
 }

--- a/libs/execution/src/lib/types/valuetypes/integer-valuetype.ts
+++ b/libs/execution/src/lib/types/valuetypes/integer-valuetype.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/no-cycle
-import { Valuetype } from './valuetype';
+import { PrimitiveValuetype } from './primitive-valuetype';
 // eslint-disable-next-line import/no-cycle
 import { ValuetypeVisitor } from './visitors/valuetype-visitor';
 
-export class IntegerValuetype implements Valuetype {
-  public readonly primitiveValuetype = 'integer';
+export class IntegerValuetype implements PrimitiveValuetype<number> {
+  public readonly primitiveValuetypeKeyword = 'integer';
 
   isValid(value: unknown): boolean {
     if (typeof value === 'string') {
@@ -28,7 +28,7 @@ export class IntegerValuetype implements Valuetype {
 
     throw new Error(
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `Invalid value: ${value} for type ${this.primitiveValuetype}`,
+      `Invalid value: ${value} for type ${this.primitiveValuetypeKeyword}`,
     );
   }
 }

--- a/libs/execution/src/lib/types/valuetypes/primitive-valuetype.ts
+++ b/libs/execution/src/lib/types/valuetypes/primitive-valuetype.ts
@@ -1,0 +1,11 @@
+import { PrimitiveValuetypeKeyword } from '@jvalue/language-server';
+
+// eslint-disable-next-line import/no-cycle
+import { Valuetype } from './valuetype';
+
+export type PrimitiveType = string | number | boolean;
+
+export interface PrimitiveValuetype<T extends PrimitiveType = PrimitiveType>
+  extends Valuetype<T> {
+  readonly primitiveValuetypeKeyword: PrimitiveValuetypeKeyword;
+}

--- a/libs/execution/src/lib/types/valuetypes/text-valuetype.ts
+++ b/libs/execution/src/lib/types/valuetypes/text-valuetype.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line import/no-cycle
-import { Valuetype } from './valuetype';
+import { PrimitiveValuetype } from './primitive-valuetype';
 // eslint-disable-next-line import/no-cycle
 import { ValuetypeVisitor } from './visitors/valuetype-visitor';
 
-export class TextValuetype implements Valuetype<string> {
-  public readonly primitiveValuetype = 'text';
+export class TextValuetype implements PrimitiveValuetype<string> {
+  public readonly primitiveValuetypeKeyword = 'text';
 
   isValid(value: unknown): boolean {
     return typeof value === 'string';
@@ -24,7 +24,7 @@ export class TextValuetype implements Valuetype<string> {
 
     throw new Error(
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      `Invalid value: ${value} for type ${this.primitiveValuetype}`,
+      `Invalid value: ${value} for type ${this.primitiveValuetypeKeyword}`,
     );
   }
 }

--- a/libs/execution/src/lib/types/valuetypes/valuetype-util.ts
+++ b/libs/execution/src/lib/types/valuetypes/valuetype-util.ts
@@ -9,6 +9,7 @@ import { AtomicValuetype } from './atomic-valuetype';
 import { BooleanValuetype } from './boolean-valuetype';
 import { DecimalValuetype } from './decimal-valuetype';
 import { IntegerValuetype } from './integer-valuetype';
+import { PrimitiveValuetype } from './primitive-valuetype';
 import { TextValuetype } from './text-valuetype';
 import { Valuetype } from './valuetype';
 
@@ -28,9 +29,9 @@ export function getValuetype(
 }
 
 function getPrimitiveValuetype(
-  primitiveValuetype: PrimitiveValuetypeKeyword,
-): Valuetype {
-  switch (primitiveValuetype) {
+  keyword: PrimitiveValuetypeKeyword,
+): PrimitiveValuetype {
+  switch (keyword) {
     case 'text':
       return new TextValuetype();
     case 'decimal':
@@ -40,6 +41,6 @@ function getPrimitiveValuetype(
     case 'boolean':
       return new BooleanValuetype();
     default:
-      assertUnreachable(primitiveValuetype);
+      assertUnreachable(keyword);
   }
 }

--- a/libs/execution/src/lib/types/valuetypes/valuetype.ts
+++ b/libs/execution/src/lib/types/valuetypes/valuetype.ts
@@ -1,5 +1,3 @@
-import { PrimitiveValuetypeKeyword } from '@jvalue/language-server';
-
 import { ExecutionContext } from '../../execution-context';
 
 // eslint-disable-next-line import/no-cycle
@@ -8,8 +6,6 @@ import { ValuetypeVisitor } from './visitors/valuetype-visitor';
 import { VisitableValuetype } from './visitors/visitable-valuetype';
 
 export interface Valuetype<T = unknown> extends VisitableValuetype {
-  readonly primitiveValuetype: PrimitiveValuetypeKeyword;
-
   acceptVisitor<R>(visitor: ValuetypeVisitor<R>): R;
 
   isValid(value: unknown, context: ExecutionContext): boolean;


### PR DESCRIPTION
Refactors primitive valuetypes so they follow this structure:

```mermaid
classDiagram

Valuetype <|-- AtomicValuetype
Valuetype <|-- PrimitiveValuetype
PrimitiveValuetype <|-- BooleanValuetype
PrimitiveValuetype <|-- DecimalValuetype
PrimitiveValuetype <|-- IntegerValuetype
PrimitiveValuetype <|-- TextValuetype

PrimitiveValuetype <-- AtomicValuetype : primitiveValuetype
```