### PR TITLE
Add validation for bounds of ranges

### DIFF
--- a/libs/extensions/std/lang/src/text-range-selector-meta-inf.ts
+++ b/libs/extensions/std/lang/src/text-range-selector-meta-inf.ts
@@ -34,6 +34,35 @@ export class TextRangeSelectorMetaInformation extends BlockMetaInformation {
 
       // Output type:
       IOType.TEXT_FILE,
+
+      (propertyBody, accept) => {
+        const lineFromProperty = propertyBody.properties.find(
+          (p) => p.name === 'lineFrom',
+        );
+        const lineToProperty = propertyBody.properties.find(
+          (p) => p.name === 'lineTo',
+        );
+
+        if (lineFromProperty === undefined || lineToProperty === undefined) {
+          return;
+        }
+
+        assert(isNumericLiteral(lineFromProperty.value));
+        assert(isNumericLiteral(lineToProperty.value));
+
+        const lineFrom = lineFromProperty.value.value;
+        const lineTo = lineToProperty.value.value;
+
+        if (lineFrom > lineTo) {
+          [lineFromProperty, lineToProperty].forEach((property) => {
+            accept(
+              'error',
+              'The lower line number needs to be smaller or equal to the upper line number',
+              { node: property.value },
+            );
+          });
+        }
+      },
     );
     this.docs.description = 'Selects a range of lines from a `TextFile`.';
   }

--- a/libs/language-server/src/lib/meta-information/block-meta-inf.ts
+++ b/libs/language-server/src/lib/meta-information/block-meta-inf.ts
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { ValidationAcceptor } from 'langium';
+
+import { PropertyBody } from '../ast/generated/ast';
 // eslint-disable-next-line import/no-cycle
 import { IOType } from '../ast/model-util';
 
@@ -21,8 +24,9 @@ export abstract class BlockMetaInformation extends MetaInformation {
     properties: Record<string, PropertySpecification>,
     public readonly inputType: IOType,
     public readonly outputType: IOType,
+    validation?: (property: PropertyBody, accept: ValidationAcceptor) => void,
   ) {
-    super(blockType, properties);
+    super(blockType, properties, validation);
   }
 
   canBeConnectedTo(blockAfter: BlockMetaInformation): boolean {

--- a/libs/language-server/src/lib/meta-information/constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/meta-information/constraint-meta-inf.ts
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { PrimitiveValuetypeKeyword } from '../ast/generated/ast';
+import { ValidationAcceptor } from 'langium';
+
+import { PrimitiveValuetypeKeyword, PropertyBody } from '../ast/generated/ast';
 
 // eslint-disable-next-line import/no-cycle
 import { MetaInformation, PropertySpecification } from './meta-inf';
@@ -12,7 +14,8 @@ export abstract class ConstraintMetaInformation extends MetaInformation {
     constraintType: string,
     properties: Record<string, PropertySpecification>,
     public readonly compatiblePrimitiveValuetypes: PrimitiveValuetypeKeyword[],
+    validation?: (property: PropertyBody, accept: ValidationAcceptor) => void,
   ) {
-    super(constraintType, properties);
+    super(constraintType, properties, validation);
   }
 }

--- a/libs/language-server/src/lib/meta-information/meta-inf.ts
+++ b/libs/language-server/src/lib/meta-information/meta-inf.ts
@@ -4,7 +4,7 @@
 
 import { ValidationAcceptor } from 'langium';
 
-import { PropertyAssignment } from '../ast/generated/ast';
+import { PropertyAssignment, PropertyBody } from '../ast/generated/ast';
 // eslint-disable-next-line import/no-cycle
 import { PropertyValuetype } from '../ast/model-util';
 
@@ -33,10 +33,14 @@ export abstract class MetaInformation {
   protected constructor(
     public readonly type: string,
     private readonly properties: Record<string, PropertySpecification>,
+    private readonly validation?: (
+      property: PropertyBody,
+      accept: ValidationAcceptor,
+    ) => void,
   ) {}
 
-  validate(properties: PropertyAssignment[], accept: ValidationAcceptor): void {
-    for (const property of properties) {
+  validate(propertyBody: PropertyBody, accept: ValidationAcceptor): void {
+    for (const property of propertyBody.properties) {
       const propertySpecification = this.getPropertySpecification(
         property.name,
       );
@@ -45,6 +49,10 @@ export abstract class MetaInformation {
         continue;
       }
       propertyValidationFn(property, accept);
+    }
+
+    if (this.validation !== undefined) {
+      this.validation(propertyBody, accept);
     }
   }
 

--- a/libs/language-server/src/lib/validation/validators/property-body-validator.ts
+++ b/libs/language-server/src/lib/validation/validators/property-body-validator.ts
@@ -154,7 +154,7 @@ export class PropertyBodyValidator implements JayveeValidator {
     if (metaInf === undefined) {
       return;
     }
-    metaInf.validate(propertyBody.properties, accept);
+    metaInf.validate(propertyBody, accept);
   }
 }
 


### PR DESCRIPTION
Adds a mechanism to add validation to an entire block type. I noticed that such validations consist of a lot of boilerplate code for accessing property values. I think this is fine for now as there are not so many applications, but we should consider to refactor it in the future.