### PR TITLE
Execution time logging

### DIFF
--- a/apps/interpreter/src/interpreter.ts
+++ b/apps/interpreter/src/interpreter.ts
@@ -155,6 +155,7 @@ async function executeBlocks(
           }`,
           { node: blockData.block, property: 'name' },
         );
+        executionContext.exitNode(block);
         return ExitCode.FAILURE;
       }
 
@@ -163,6 +164,7 @@ async function executeBlocks(
           result.left.message,
           result.left.diagnostic,
         );
+        executionContext.exitNode(block);
         return ExitCode.FAILURE;
       }
 

--- a/apps/interpreter/src/interpreter.ts
+++ b/apps/interpreter/src/interpreter.ts
@@ -149,8 +149,16 @@ async function executeBlocks(
 
     // Check, if parent emitted a value
     if (inputValue != null) {
+      const startTime = new Date();
       try {
         result = await blockExecutor.execute(inputValue, executionContext);
+        const endTime = new Date();
+        const executionDurationMs = Math.round(
+          endTime.getTime() - startTime.getTime(),
+        );
+        executionContext.logger.logDebug(
+          `Execution duration: ${executionDurationMs} ms.`,
+        );
       } catch (unexpectedError) {
         executionContext.logger.logErrDiagnostic(
           `An unknown error occurred: ${

--- a/apps/interpreter/src/interpreter.ts
+++ b/apps/interpreter/src/interpreter.ts
@@ -114,14 +114,7 @@ async function runPipeline(
   );
   const exitCode = await executeBlocks(executionContext, executionOrder);
 
-  const endTime = new Date();
-  const executionDurationMs = Math.round(
-    endTime.getTime() - startTime.getTime(),
-  );
-  executionContext.logger.logDebug(
-    `Execution duration: ${executionDurationMs} ms.`,
-  );
-
+  logExecutionDuration(startTime, executionContext.logger);
   return exitCode;
 }
 
@@ -152,13 +145,7 @@ async function executeBlocks(
       const startTime = new Date();
       try {
         result = await blockExecutor.execute(inputValue, executionContext);
-        const endTime = new Date();
-        const executionDurationMs = Math.round(
-          endTime.getTime() - startTime.getTime(),
-        );
-        executionContext.logger.logDebug(
-          `Execution duration: ${executionDurationMs} ms.`,
-        );
+        logExecutionDuration(startTime, executionContext.logger);
       } catch (unexpectedError) {
         executionContext.logger.logErrDiagnostic(
           `An unknown error occurred: ${
@@ -194,6 +181,14 @@ async function executeBlocks(
     executionContext.exitNode(block);
   }
   return ExitCode.SUCCESS;
+}
+
+export function logExecutionDuration(startTime: Date, logger: Logger): void {
+  const endTime = new Date();
+  const executionDurationMs = Math.round(
+    endTime.getTime() - startTime.getTime(),
+  );
+  logger.logDebug(`Execution duration: ${executionDurationMs} ms.`);
 }
 
 export function logPipelineOverview(


### PR DESCRIPTION
Closes #251. Adds tracking and logging the execution duration of a pipeline and its blocks.

## Cars Example

```
> nx run interpreter:run -d example/cars.jv

[CarsPipeline] Overview:
        Blocks (6 blocks with 5 pipes):
         -> CarsExtractor (HttpExtractor)
                 -> CarsTextFileInterpreter (TextFileInterpreter)
                         -> CarsCSVInterpreter (CSVInterpreter)
                                 -> NameHeaderWriter (CellWriter)
                                         -> CarsTableInterpreter (TableInterpreter)
                                                 -> CarsLoader (SQLiteLoader)
[CarsExtractor] Fetching raw data from https://gist.githubusercontent.com/noamross/e5d3e859aa0c794be10b/raw/b999fb4425b54c63cab088c0ce2c0d6ce961a563/cars.csv
[CarsExtractor] Successfully fetched raw data
[CarsExtractor] Execution duration: 394 ms.
[CarsTextFileInterpreter] Decoding file content using encoding "utf-8"
[CarsTextFileInterpreter] Splitting lines using line break /\r?\n/
[CarsTextFileInterpreter] Lines were split successfully, the resulting text file has 33 lines
[CarsTextFileInterpreter] Execution duration: 1 ms.
[CarsCSVInterpreter] Parsing raw data as CSV using delimiter ","
[CarsCSVInterpreter] Parsing raw data as CSV-sheet successful
[CarsCSVInterpreter] Execution duration: 22 ms.
[NameHeaderWriter] Writing "name" at cell A1
[NameHeaderWriter] Execution duration: 1 ms.
[CarsTableInterpreter] Matching header with provided column names
[CarsTableInterpreter] Validating 32 row(s) according to the column types
[CarsTableInterpreter] Validation completed, the resulting table has 32 row(s) and 12 column(s)
[CarsTableInterpreter] Execution duration: 2 ms.
[CarsLoader] Opening database file ./cars.sqlite
[CarsLoader] Dropping previous table "Cars" if it exists
[CarsLoader] Creating table "Cars"
[CarsLoader] Inserting 32 row(s) into table "Cars"
[CarsLoader] The data was successfully loaded into the database
[CarsLoader] Execution duration: 40 ms.
[CarsPipeline] Execution duration: 464 ms.
```

## Gas Example
Fails since I didn't start postgres. Serves as demonstration for the case of a failing pipeline.

```
> nx run interpreter:run -d -e DB_HOST=localhost -e DB_PORT=5432 -e DB_USERNAME=postgres -e DB_PASSWORD=postgres -e DB_DATABASE=postgres -e DB_TABLE=GasReserve example/gas.jv

[GasReservePipeline] Overview:
        Runtime Parameters (6):
                DB_HOST: localhost
                DB_PORT: 5432
                DB_USERNAME: postgres
                DB_PASSWORD: postgres
                DB_DATABASE: postgres
                DB_TABLE: GasReserve
        Blocks (6 blocks with 1 pipes):
         -> GasReserveHttpExtractor (HttpExtractor)
                 -> GasReserveTextFileInterpreter (TextFileInterpreter)
                         -> GasReserveCSVInterpreter (CSVInterpreter)
                                 -> DateHeaderWriter (CellWriter)
                                         -> GasReserveTableInterpreter (TableInterpreter)
                                                 -> GasReserveLoader (PostgresLoader)
[GasReserveHttpExtractor] Fetching raw data from https://www.bundesnetzagentur.de/_tools/SVG/js2/_functions/csv_export.html?view=renderCSV&id=1089590
[GasReserveHttpExtractor] Successfully fetched raw data
[GasReserveHttpExtractor] Execution duration: 270 ms.
[GasReserveTextFileInterpreter] Decoding file content using encoding "utf-8"
[GasReserveTextFileInterpreter] Splitting lines using line break /\r?\n/
[GasReserveTextFileInterpreter] Lines were split successfully, the resulting text file has 0 lines
[GasReserveTextFileInterpreter] Execution duration: 1 ms.
[GasReserveCSVInterpreter] Parsing raw data as CSV using delimiter ";"
[GasReserveCSVInterpreter] Parsing raw data as CSV-sheet successful
[GasReserveCSVInterpreter] Execution duration: 1 ms.
[DateHeaderWriter] Execution duration: 1 ms.
error: The specified cell does not exist in the sheet
In /home/georgschwarz/dev/jvalue/jayvee/example/gas.jv:27:7
27 |         at: cell A1;
   |             ^^^^^^^
[GasReservePipeline] Execution duration: 277 ms.
Warning: run-commands command "node dist/apps/interpreter/main.js -d -e DB_HOST=localhost -e DB_PORT=5432 -e DB_USERNAME=postgres -e DB_PASSWORD=postgres -e DB_DATABASE=postgres -e DB_TABLE=GasReserve example/gas.jv" exited with non-zero status code

 ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Ran target run for project interpreter and 10 task(s) it depends on (8s)
 
         With additional flags:
           example/gas.jv
           --d=true
           --e=[DB_HOST=localhost,DB_PORT=5432,DB_USERNAME=postgres,DB_PASSWORD=postgres,DB_DATABASE=postgres,DB_TABLE=GasReserve]
 
    ✖    1/11 failed
    ✔    10/11 succeeded [8 read from cache]
```