### PR TITLE
Introduce boolean expressions

### DIFF
--- a/libs/execution/src/lib/execution-context.ts
+++ b/libs/execution/src/lib/execution-context.ts
@@ -13,7 +13,9 @@ import {
   PropertyAssignment,
   TextLiteral,
   ValuetypeAssignment,
+  evaluateExpression,
   getOrFailMetaInformation,
+  isBooleanExpression,
   isCellRangeLiteral,
   isCollectionLiteral,
   isNumericLiteral,
@@ -171,6 +173,9 @@ export class ExecutionContext {
     }
     if (isCellRangeLiteral(propertyValue)) {
       return propertyValue;
+    }
+    if (isBooleanExpression(propertyValue)) {
+      return evaluateExpression(propertyValue);
     }
     const value = propertyValue.value;
     if (isReference(value)) {

--- a/libs/execution/src/lib/types/valuetypes/atomic-valuetype.ts
+++ b/libs/execution/src/lib/types/valuetypes/atomic-valuetype.ts
@@ -2,8 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { strict as assert } from 'assert';
+
 import {
   ConstraintDefinition,
+  PropertyValuetype,
   ValuetypeDefinition,
   isConstraintReferenceLiteral,
   validateTypedCollection,
@@ -63,8 +66,10 @@ export class AtomicValuetype<T extends PrimitiveType>
     const constraintCollection = this.astNode.constraints;
     const constraintReferences = validateTypedCollection(
       constraintCollection,
-      isConstraintReferenceLiteral,
+      PropertyValuetype.CONSTRAINT,
     ).validItems;
+
+    assert(constraintReferences.every(isConstraintReferenceLiteral));
 
     const constraints = constraintReferences.map(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/libs/extensions/std/lang/src/text-line-deleter-meta-inf.ts
+++ b/libs/extensions/std/lang/src/text-line-deleter-meta-inf.ts
@@ -26,23 +26,18 @@ export class TextLineDeleterMetaInformation extends BlockMetaInformation {
 
             const { validItems, invalidItems } = validateTypedCollection(
               propertyValue,
-              isNumericLiteral,
+              PropertyValuetype.INTEGER,
             );
 
-            const invalidTypeErrorMessage =
-              'Only integers are allowed in this collection';
             invalidItems.forEach((invalidValue) =>
-              accept('error', invalidTypeErrorMessage, {
+              accept('error', 'Only integers are allowed in this collection', {
                 node: invalidValue,
               }),
             );
 
+            assert(validItems.every(isNumericLiteral));
+
             for (const numericLiteral of validItems) {
-              if (!Number.isInteger(numericLiteral.value)) {
-                accept('error', invalidTypeErrorMessage, {
-                  node: numericLiteral,
-                });
-              }
               if (numericLiteral.value <= 0) {
                 accept('error', `Line numbers need to be greater than zero`, {
                   node: numericLiteral,

--- a/libs/extensions/tabular/lang/src/lib/column-deleter-meta-inf.ts
+++ b/libs/extensions/tabular/lang/src/lib/column-deleter-meta-inf.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { strict as assert } from 'assert';
+
 import {
   BlockMetaInformation,
   CellRangeWrapper,
@@ -28,7 +30,7 @@ export class ColumnDeleterMetaInformation extends BlockMetaInformation {
 
             const { validItems, invalidItems } = validateTypedCollection(
               propertyValue,
-              isCellRangeLiteral,
+              PropertyValuetype.CELL_RANGE,
             );
 
             invalidItems.forEach((invalidValue) =>
@@ -40,6 +42,8 @@ export class ColumnDeleterMetaInformation extends BlockMetaInformation {
                 },
               ),
             );
+
+            assert(validItems.every(isCellRangeLiteral));
 
             for (const collectionValue of validItems) {
               if (!CellRangeWrapper.canBeWrapped(collectionValue)) {

--- a/libs/extensions/tabular/lang/src/lib/row-deleter-meta-inf.ts
+++ b/libs/extensions/tabular/lang/src/lib/row-deleter-meta-inf.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { strict as assert } from 'assert';
+
 import {
   BlockMetaInformation,
   CellRangeWrapper,
@@ -28,7 +30,7 @@ export class RowDeleterMetaInformation extends BlockMetaInformation {
 
             const { validItems, invalidItems } = validateTypedCollection(
               propertyValue,
-              isCellRangeLiteral,
+              PropertyValuetype.CELL_RANGE,
             );
 
             invalidItems.forEach((invalidValue) =>
@@ -40,6 +42,8 @@ export class RowDeleterMetaInformation extends BlockMetaInformation {
                 },
               ),
             );
+
+            assert(validItems.every(isCellRangeLiteral));
 
             for (const collectionValue of validItems) {
               if (!CellRangeWrapper.canBeWrapped(collectionValue)) {

--- a/libs/extensions/tabular/lang/src/lib/table-interpreter-meta-inf.ts
+++ b/libs/extensions/tabular/lang/src/lib/table-interpreter-meta-inf.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { strict as assert } from 'assert';
+
 import {
   BlockMetaInformation,
   IOType,
@@ -46,7 +48,7 @@ export class TableInterpreterMetaInformation extends BlockMetaInformation {
 
             const { validItems, invalidItems } = validateTypedCollection(
               propertyValue,
-              isValuetypeAssignmentLiteral,
+              PropertyValuetype.VALUETYPE_ASSIGNMENT,
             );
 
             invalidItems.forEach((invalidValue) =>
@@ -58,6 +60,8 @@ export class TableInterpreterMetaInformation extends BlockMetaInformation {
                 },
               ),
             );
+
+            assert(validItems.every(isValuetypeAssignmentLiteral));
 
             const valuetypeAssignments = validItems.map(
               (assignment) => assignment.value,

--- a/libs/language-server/src/grammar/expression.langium
+++ b/libs/language-server/src/grammar/expression.langium
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import 'terminal'
+
+BooleanExpression:
+  OrExpression;
+
+// The nesting of the following rules implies the precedence of the operators:
+
+OrExpression infers BooleanExpression:
+  AndExpression ({infer BinaryExpression.left=current} operator='or' right=AndExpression)*;
+
+AndExpression infers BooleanExpression:
+  XorExpression ({infer BinaryExpression.left=current} operator='and' right=XorExpression)*;
+
+XorExpression infers BooleanExpression:
+  EqualityExpression ({infer BinaryExpression.left=current} operator='xor' right=EqualityExpression)*;
+
+EqualityExpression infers BooleanExpression:
+  PrimaryExpression ({infer BinaryExpression.left=current} operator=('==' | '!=') right=PrimaryExpression)*;
+
+PrimaryExpression infers BooleanExpression:
+  '(' BooleanExpression ')'
+  | UnaryExpression
+  | BooleanLiteral;
+
+UnaryExpression:
+  operator='!' expression=PrimaryExpression;
+
+BooleanLiteral:
+  value?='true' | 'false';

--- a/libs/language-server/src/grammar/expression.langium
+++ b/libs/language-server/src/grammar/expression.langium
@@ -27,7 +27,7 @@ PrimaryExpression infers BooleanExpression:
   | BooleanLiteral;
 
 UnaryExpression:
-  operator='!' expression=PrimaryExpression;
+  operator='not' expression=PrimaryExpression;
 
 BooleanLiteral:
   value?='true' | 'false';

--- a/libs/language-server/src/grammar/property.langium
+++ b/libs/language-server/src/grammar/property.langium
@@ -6,6 +6,7 @@ import 'terminal';
 import 'valuetype';
 import 'cellrange';
 import 'constraint';
+import 'expression';
 
 PropertyBody:
   '{' (properties+=PropertyAssignment)* '}';
@@ -22,14 +23,11 @@ PropertyValueLiteral:
 AtomicLiteral:
   TextLiteral
   | NumericLiteral
-  | BooleanLiteral
-  | CellRangeLiteral
+  | BooleanExpression
   | RegexLiteral
+  | CellRangeLiteral
   | ValuetypeAssignmentLiteral
   | ConstraintReferenceLiteral;
-
-CollectionLiteral:
-  '[' (values+=(AtomicLiteral) (',' values+=(AtomicLiteral))*)? ','? ']';
 
 TextLiteral:
   value=STRING;
@@ -37,8 +35,8 @@ TextLiteral:
 NumericLiteral:
   value=(INTEGER | NUMBER);
 
-BooleanLiteral:
-  value=(TRUE | FALSE);
+CollectionLiteral:
+  '[' (values+=(AtomicLiteral) (',' values+=(AtomicLiteral))*)? ','? ']';
 
 RegexLiteral:
   value=REGEX;

--- a/libs/language-server/src/grammar/terminal.langium
+++ b/libs/language-server/src/grammar/terminal.langium
@@ -5,8 +5,6 @@
 // The order of the terminals matters here, it implicitly defines the prioritization for the lexer.
 // For more details, see https://langium.org/docs/grammar-language/#terminal-rules
 
-terminal TRUE returns boolean: /true/;
-terminal FALSE returns boolean: /false/;
 terminal CELL_REFERENCE: /([A-Z]+|\*)([0-9]+|\*)/;
 terminal ID: /[_a-zA-Z][\w_]*/;
 

--- a/libs/language-server/src/lib/ast/model-util.ts
+++ b/libs/language-server/src/lib/ast/model-util.ts
@@ -229,7 +229,7 @@ export function evaluateExpression(expression: BooleanExpression): boolean {
   }
   if (isUnaryExpression(expression)) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    assert(expression.operator === '!');
+    assert(expression.operator === 'not');
     return !evaluateExpression(expression.expression);
   }
   if (isBinaryExpression(expression)) {

--- a/libs/language-server/src/lib/ast/model-util.ts
+++ b/libs/language-server/src/lib/ast/model-util.ts
@@ -228,13 +228,18 @@ export function evaluateExpression(expression: BooleanExpression): boolean {
     return expression.value;
   }
   if (isUnaryExpression(expression)) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    assert(expression.operator === 'not');
-    return !evaluateExpression(expression.expression);
+    const unaryOperator = expression.operator;
+    switch (unaryOperator) {
+      case 'not': {
+        return !evaluateExpression(expression.expression);
+      }
+      default:
+        assertUnreachable(unaryOperator);
+    }
   }
   if (isBinaryExpression(expression)) {
-    const operator = expression.operator;
-    switch (operator) {
+    const binaryOperator = expression.operator;
+    switch (binaryOperator) {
       case '==': {
         const leftValue = evaluateExpression(expression.left);
         const rightValue = evaluateExpression(expression.right);
@@ -267,9 +272,8 @@ export function evaluateExpression(expression: BooleanExpression): boolean {
         return rightValue;
       }
       default:
-        assertUnreachable(operator);
+        assertUnreachable(binaryOperator);
     }
-    return false;
   }
   assertUnreachable(expression);
 }

--- a/libs/language-server/src/lib/constraint/allowlist-constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/constraint/allowlist-constraint-meta-inf.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { validateTypedCollection } from '../ast/collection-util';
-import { isCollectionLiteral, isTextLiteral } from '../ast/generated/ast';
+import { isCollectionLiteral } from '../ast/generated/ast';
 import { PropertyValuetype } from '../ast/model-util';
 import { ConstraintMetaInformation } from '../meta-information/constraint-meta-inf';
 
@@ -22,7 +22,7 @@ export class AllowlistConstraintMetaInformation extends ConstraintMetaInformatio
 
             const { invalidItems } = validateTypedCollection(
               propertyValue,
-              isTextLiteral,
+              PropertyValuetype.TEXT,
             );
 
             invalidItems.forEach((invalidValue) =>

--- a/libs/language-server/src/lib/constraint/denylist-constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/constraint/denylist-constraint-meta-inf.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { validateTypedCollection } from '../ast/collection-util';
-import { isCollectionLiteral, isTextLiteral } from '../ast/generated/ast';
+import { isCollectionLiteral } from '../ast/generated/ast';
 import { PropertyValuetype } from '../ast/model-util';
 import { ConstraintMetaInformation } from '../meta-information/constraint-meta-inf';
 
@@ -22,7 +22,7 @@ export class DenylistConstraintMetaInformation extends ConstraintMetaInformation
 
             const { invalidItems } = validateTypedCollection(
               propertyValue,
-              isTextLiteral,
+              PropertyValuetype.TEXT,
             );
 
             invalidItems.forEach((invalidValue) =>

--- a/libs/language-server/src/lib/constraint/range-constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/constraint/range-constraint-meta-inf.ts
@@ -4,7 +4,11 @@
 
 import { strict as assert } from 'assert';
 
-import { isBooleanLiteral, isNumericLiteral } from '../ast';
+import {
+  evaluateExpression,
+  isBooleanExpression,
+  isNumericLiteral,
+} from '../ast';
 import { PropertyValuetype } from '../ast/model-util';
 import { ConstraintMetaInformation } from '../meta-information/constraint-meta-inf';
 
@@ -66,8 +70,10 @@ export class RangeConstraintMetaInformation extends ConstraintMetaInformation {
           );
           let lowerBoundInclusive = true;
           if (lowerBoundInclusiveProperty !== undefined) {
-            assert(isBooleanLiteral(lowerBoundInclusiveProperty.value));
-            lowerBoundInclusive = lowerBoundInclusiveProperty.value.value;
+            assert(isBooleanExpression(lowerBoundInclusiveProperty.value));
+            lowerBoundInclusive = evaluateExpression(
+              lowerBoundInclusiveProperty.value,
+            );
           }
 
           const upperBoundInclusiveProperty = propertyBody.properties.find(
@@ -75,8 +81,10 @@ export class RangeConstraintMetaInformation extends ConstraintMetaInformation {
           );
           let upperBoundInclusive = true;
           if (upperBoundInclusiveProperty !== undefined) {
-            assert(isBooleanLiteral(upperBoundInclusiveProperty.value));
-            upperBoundInclusive = upperBoundInclusiveProperty.value.value;
+            assert(isBooleanExpression(upperBoundInclusiveProperty.value));
+            upperBoundInclusive = evaluateExpression(
+              upperBoundInclusiveProperty.value,
+            );
           }
 
           const errorMessage =

--- a/libs/language-server/src/lib/jayvee-module.ts
+++ b/libs/language-server/src/lib/jayvee-module.ts
@@ -26,6 +26,7 @@ import { BlockValidator } from './validation/validators/block-validator';
 import { CellRangeSelectionValidator } from './validation/validators/cell-range-selection-validator';
 import { ColumnExpressionValidator } from './validation/validators/column-expression-validator';
 import { ConstraintValidator } from './validation/validators/constraint-validator';
+import { ExpressionValidator } from './validation/validators/expression-validator';
 import { JayveeModelValidator } from './validation/validators/model-validator';
 import { PipeValidator } from './validation/validators/pipe-validator';
 import { PipelineDefinitionValidator } from './validation/validators/pipeline-validator';
@@ -48,6 +49,7 @@ export interface JayveeAddedServices {
     ConstraintValidator: ConstraintValidator;
     RegexValueValidator: RegexValueValidator;
     ValuetypeValidator: ValuetypeValidator;
+    ExpressionValidator: ExpressionValidator;
   };
 }
 
@@ -81,6 +83,7 @@ export const JayveeModule: Module<
     ConstraintValidator: () => new ConstraintValidator(),
     RegexValueValidator: () => new RegexValueValidator(),
     ValuetypeValidator: () => new ValuetypeValidator(),
+    ExpressionValidator: () => new ExpressionValidator(),
   },
   lsp: {
     CompletionProvider: (services: LangiumServices) =>

--- a/libs/language-server/src/lib/validation/validation-registry.ts
+++ b/libs/language-server/src/lib/validation/validation-registry.ts
@@ -47,5 +47,8 @@ export class JayveeValidationRegistry extends ValidationRegistry {
 
     const valuetypeValidator = services.validation.ValuetypeValidator;
     this.register(valuetypeValidator.checks, valuetypeValidator);
+
+    const expressionValidator = services.validation.ExpressionValidator;
+    this.register(expressionValidator.checks, expressionValidator);
   }
 }

--- a/libs/language-server/src/lib/validation/validators/expression-validator.ts
+++ b/libs/language-server/src/lib/validation/validators/expression-validator.ts
@@ -35,6 +35,7 @@ export class ExpressionValidator implements JayveeValidator {
     const evaluatedExpression = evaluateExpression(expression);
     accept(
       'info',
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       `The expression can be simplified to ${evaluatedExpression}`,
       { node: expression },
     );

--- a/libs/language-server/src/lib/validation/validators/expression-validator.ts
+++ b/libs/language-server/src/lib/validation/validators/expression-validator.ts
@@ -1,0 +1,38 @@
+import { ValidationAcceptor, ValidationChecks } from 'langium';
+
+import {
+  BooleanExpression,
+  JayveeAstType,
+  isBooleanExpression,
+  isBooleanLiteral,
+} from '../../ast/generated/ast';
+import { evaluateExpression } from '../../ast/model-util';
+import { JayveeValidator } from '../jayvee-validator';
+
+export class ExpressionValidator implements JayveeValidator {
+  get checks(): ValidationChecks<JayveeAstType> {
+    return {
+      BooleanExpression: [this.checkSimplification],
+    };
+  }
+
+  checkSimplification(
+    this: void,
+    expression: BooleanExpression,
+    accept: ValidationAcceptor,
+  ): void {
+    if (isBooleanLiteral(expression)) {
+      return;
+    }
+    if (isBooleanExpression(expression.$container)) {
+      return;
+    }
+
+    const evaluatedExpression = evaluateExpression(expression);
+    accept(
+      'info',
+      `The expression can be simplified to ${evaluatedExpression}`,
+      { node: expression },
+    );
+  }
+}

--- a/libs/language-server/src/lib/validation/validators/expression-validator.ts
+++ b/libs/language-server/src/lib/validation/validators/expression-validator.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { ValidationAcceptor, ValidationChecks } from 'langium';
 
 import {


### PR DESCRIPTION
Preparation for #213

Allows users to use boolean expressions wherever a boolean value is expected. Introduces the following operators (ordered descending by [precedence](https://en.wikipedia.org/wiki/Order_of_operations)):

- `not`: unary operator to negate a boolean value
- `==` / `!=`: binary operator to check (in)equality
- `xor`: binary operator to compute exclusive OR
- `and`: binary operator to compute AND
- `or`: binary operator to compute OR

Example for a boolean expression: `(not true or false) xor true and true` which evaluates to `true`.

Also adds a diagnostic to propose a simplification for expressions that can be evaluated at compile-time:
![image](https://user-images.githubusercontent.com/51856713/232048899-c7a4dfa3-61ed-46ca-984f-0e3fcba76180.png)
