### PR TITLE
Introduce validation context

### DIFF
--- a/libs/extensions/std/lang/src/gtfs-rt-interpreter-meta-inf.ts
+++ b/libs/extensions/std/lang/src/gtfs-rt-interpreter-meta-inf.ts
@@ -8,9 +8,9 @@ import {
   IOType,
   PropertyAssignment,
   PropertyValuetype,
+  ValidationContext,
   isTextLiteral,
 } from '@jvalue/jayvee-language-server';
-import { ValidationAcceptor } from 'langium';
 
 export class GtfsRTInterpreterMetaInformation extends BlockMetaInformation {
   constructor() {
@@ -100,14 +100,18 @@ const blockExampleUsage = `block GtfsRTTripUpdateInterpreter oftype GtfsRTInterp
 
 function isGtfsRTEntity(
   property: PropertyAssignment,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ) {
   const propertyValue = property.value;
   assert(isTextLiteral(propertyValue));
 
   if (!['trip_update', 'alert', 'vehicle'].includes(propertyValue.value)) {
-    accept('error', `Entity must be "trip_update", "alert" or "vehicle"`, {
-      node: propertyValue,
-    });
+    context.accept(
+      'error',
+      `Entity must be "trip_update", "alert" or "vehicle"`,
+      {
+        node: propertyValue,
+      },
+    );
   }
 }

--- a/libs/extensions/std/lang/src/text-file-interpreter-meta-inf.ts
+++ b/libs/extensions/std/lang/src/text-file-interpreter-meta-inf.ts
@@ -23,16 +23,20 @@ export class TextFileInterpreterMetaInformation extends BlockMetaInformation {
           docs: {
             description: 'The encoding used for decoding the file contents.',
           },
-          validation: (property, accept) => {
+          validation: (property, context) => {
             const propertyValue = property.value;
             assert(isTextLiteral(propertyValue));
 
             try {
               new TextDecoder(propertyValue.value);
             } catch (error) {
-              accept('error', `Unknown encoding "${propertyValue.value}"`, {
-                node: propertyValue,
-              });
+              context.accept(
+                'error',
+                `Unknown encoding "${propertyValue.value}"`,
+                {
+                  node: propertyValue,
+                },
+              );
             }
           },
         },

--- a/libs/extensions/std/lang/src/text-line-deleter-meta-inf.ts
+++ b/libs/extensions/std/lang/src/text-line-deleter-meta-inf.ts
@@ -20,7 +20,7 @@ export class TextLineDeleterMetaInformation extends BlockMetaInformation {
       {
         lines: {
           type: PropertyValuetype.COLLECTION,
-          validation: (property, accept) => {
+          validation: (property, context) => {
             const propertyValue = property.value;
             assert(isCollectionLiteral(propertyValue));
 
@@ -30,18 +30,26 @@ export class TextLineDeleterMetaInformation extends BlockMetaInformation {
             );
 
             invalidItems.forEach((invalidValue) =>
-              accept('error', 'Only integers are allowed in this collection', {
-                node: invalidValue,
-              }),
+              context.accept(
+                'error',
+                'Only integers are allowed in this collection',
+                {
+                  node: invalidValue,
+                },
+              ),
             );
 
             assert(validItems.every(isNumericLiteral));
 
             for (const numericLiteral of validItems) {
               if (numericLiteral.value <= 0) {
-                accept('error', `Line numbers need to be greater than zero`, {
-                  node: numericLiteral,
-                });
+                context.accept(
+                  'error',
+                  `Line numbers need to be greater than zero`,
+                  {
+                    node: numericLiteral,
+                  },
+                );
               }
             }
           },

--- a/libs/extensions/std/lang/src/text-range-selector-meta-inf.ts
+++ b/libs/extensions/std/lang/src/text-range-selector-meta-inf.ts
@@ -9,9 +9,9 @@ import {
   IOType,
   PropertyAssignment,
   PropertyValuetype,
+  ValidationContext,
   isNumericLiteral,
 } from '@jvalue/jayvee-language-server';
-import { ValidationAcceptor } from 'langium';
 
 export class TextRangeSelectorMetaInformation extends BlockMetaInformation {
   constructor() {
@@ -35,7 +35,7 @@ export class TextRangeSelectorMetaInformation extends BlockMetaInformation {
       // Output type:
       IOType.TEXT_FILE,
 
-      (propertyBody, accept) => {
+      (propertyBody, context) => {
         const lineFromProperty = propertyBody.properties.find(
           (p) => p.name === 'lineFrom',
         );
@@ -55,7 +55,7 @@ export class TextRangeSelectorMetaInformation extends BlockMetaInformation {
 
         if (lineFrom > lineTo) {
           [lineFromProperty, lineToProperty].forEach((property) => {
-            accept(
+            context.accept(
               'error',
               'The lower line number needs to be smaller or equal to the upper line number',
               { node: property.value },
@@ -70,13 +70,13 @@ export class TextRangeSelectorMetaInformation extends BlockMetaInformation {
 
 function greaterThanZeroValidation(
   property: PropertyAssignment,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ) {
   const propertyValue = property.value;
   assert(isNumericLiteral(propertyValue));
 
   if (propertyValue.value <= 0) {
-    accept('error', `Line numbers need to be greater than zero`, {
+    context.accept('error', `Line numbers need to be greater than zero`, {
       node: propertyValue,
     });
   }

--- a/libs/extensions/tabular/lang/src/lib/column-deleter-meta-inf.ts
+++ b/libs/extensions/tabular/lang/src/lib/column-deleter-meta-inf.ts
@@ -22,7 +22,7 @@ export class ColumnDeleterMetaInformation extends BlockMetaInformation {
       {
         delete: {
           type: PropertyValuetype.COLLECTION,
-          validation: (property, accept) => {
+          validation: (property, context) => {
             const propertyValue = property.value;
             if (!isCollectionLiteral(propertyValue)) {
               return;
@@ -34,7 +34,7 @@ export class ColumnDeleterMetaInformation extends BlockMetaInformation {
             );
 
             invalidItems.forEach((invalidValue) =>
-              accept(
+              context.accept(
                 'error',
                 'Only cell ranges are allowed in this collection',
                 {
@@ -51,9 +51,13 @@ export class ColumnDeleterMetaInformation extends BlockMetaInformation {
               }
               const semanticCellRange = new CellRangeWrapper(collectionValue);
               if (!isColumnWrapper(semanticCellRange)) {
-                accept('error', 'An entire column needs to be selected', {
-                  node: semanticCellRange.astNode,
-                });
+                context.accept(
+                  'error',
+                  'An entire column needs to be selected',
+                  {
+                    node: semanticCellRange.astNode,
+                  },
+                );
               }
             }
           },

--- a/libs/extensions/tabular/lang/src/lib/row-deleter-meta-inf.ts
+++ b/libs/extensions/tabular/lang/src/lib/row-deleter-meta-inf.ts
@@ -22,7 +22,7 @@ export class RowDeleterMetaInformation extends BlockMetaInformation {
       {
         delete: {
           type: PropertyValuetype.COLLECTION,
-          validation: (property, accept) => {
+          validation: (property, context) => {
             const propertyValue = property.value;
             if (!isCollectionLiteral(propertyValue)) {
               return;
@@ -34,7 +34,7 @@ export class RowDeleterMetaInformation extends BlockMetaInformation {
             );
 
             invalidItems.forEach((invalidValue) =>
-              accept(
+              context.accept(
                 'error',
                 'Only cell ranges are allowed in this collection',
                 {
@@ -51,7 +51,7 @@ export class RowDeleterMetaInformation extends BlockMetaInformation {
               }
               const semanticCellRange = new CellRangeWrapper(collectionValue);
               if (!isRowWrapper(semanticCellRange)) {
-                accept('error', 'An entire row needs to be selected', {
+                context.accept('error', 'An entire row needs to be selected', {
                   node: semanticCellRange.astNode,
                 });
               }

--- a/libs/extensions/tabular/lang/src/lib/table-interpreter-meta-inf.ts
+++ b/libs/extensions/tabular/lang/src/lib/table-interpreter-meta-inf.ts
@@ -40,7 +40,7 @@ export class TableInterpreterMetaInformation extends BlockMetaInformation {
         },
         columns: {
           type: PropertyValuetype.COLLECTION,
-          validation: (property, accept) => {
+          validation: (property, context) => {
             const propertyValue = property.value;
             if (!isCollectionLiteral(propertyValue)) {
               return;
@@ -52,7 +52,7 @@ export class TableInterpreterMetaInformation extends BlockMetaInformation {
             );
 
             invalidItems.forEach((invalidValue) =>
-              accept(
+              context.accept(
                 'error',
                 'Only type assignments are allowed in this collection',
                 {
@@ -68,7 +68,7 @@ export class TableInterpreterMetaInformation extends BlockMetaInformation {
             );
             getNodesWithNonUniqueNames(valuetypeAssignments).forEach(
               (valuetypeAssignment) => {
-                accept(
+                context.accept(
                   'error',
                   `The column name "${valuetypeAssignment.name}" needs to be unique.`,
                   {

--- a/libs/language-server/src/lib/constraint/allowlist-constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/constraint/allowlist-constraint-meta-inf.ts
@@ -14,7 +14,7 @@ export class AllowlistConstraintMetaInformation extends ConstraintMetaInformatio
       {
         allowlist: {
           type: PropertyValuetype.COLLECTION,
-          validation: (property, accept) => {
+          validation: (property, context) => {
             const propertyValue = property.value;
             if (!isCollectionLiteral(propertyValue)) {
               return;
@@ -26,7 +26,7 @@ export class AllowlistConstraintMetaInformation extends ConstraintMetaInformatio
             );
 
             invalidItems.forEach((invalidValue) =>
-              accept(
+              context.accept(
                 'error',
                 'Only text values are allowed in this collection',
                 {

--- a/libs/language-server/src/lib/constraint/denylist-constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/constraint/denylist-constraint-meta-inf.ts
@@ -14,7 +14,7 @@ export class DenylistConstraintMetaInformation extends ConstraintMetaInformation
       {
         denylist: {
           type: PropertyValuetype.COLLECTION,
-          validation: (property, accept) => {
+          validation: (property, context) => {
             const propertyValue = property.value;
             if (!isCollectionLiteral(propertyValue)) {
               return;
@@ -26,7 +26,7 @@ export class DenylistConstraintMetaInformation extends ConstraintMetaInformation
             );
 
             invalidItems.forEach((invalidValue) =>
-              accept(
+              context.accept(
                 'error',
                 'Only text values are allowed in this collection',
                 {

--- a/libs/language-server/src/lib/constraint/length-constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/constraint/length-constraint-meta-inf.ts
@@ -4,11 +4,10 @@
 
 import { strict as assert } from 'assert';
 
-import { ValidationAcceptor } from 'langium';
-
 import { PropertyAssignment, isNumericLiteral } from '../ast';
 import { PropertyValuetype } from '../ast/model-util';
 import { ConstraintMetaInformation } from '../meta-information/constraint-meta-inf';
+import { ValidationContext } from '../validation/validation-context';
 
 export class LengthConstraintMetaInformation extends ConstraintMetaInformation {
   constructor() {
@@ -27,7 +26,7 @@ export class LengthConstraintMetaInformation extends ConstraintMetaInformation {
         },
       },
       ['text'],
-      (propertyBody, accept) => {
+      (propertyBody, context) => {
         const minLengthProperty = propertyBody.properties.find(
           (p) => p.name === 'minLength',
         );
@@ -50,7 +49,7 @@ export class LengthConstraintMetaInformation extends ConstraintMetaInformation {
 
         if (minLength > maxLength) {
           [minLengthProperty, maxLengthProperty].forEach((property) => {
-            accept(
+            context.accept(
               'error',
               'The minimum length needs to be smaller or equal to the maximum length',
               { node: property.value },
@@ -77,14 +76,18 @@ export class LengthConstraintMetaInformation extends ConstraintMetaInformation {
 
 function nonNegativeValidation(
   property: PropertyAssignment,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ) {
   const propertyValue = property.value;
   assert(isNumericLiteral(propertyValue));
 
   if (propertyValue.value < 0) {
-    accept('error', `Bounds for length need to be equal or greater than zero`, {
-      node: propertyValue,
-    });
+    context.accept(
+      'error',
+      `Bounds for length need to be equal or greater than zero`,
+      {
+        node: propertyValue,
+      },
+    );
   }
 }

--- a/libs/language-server/src/lib/constraint/range-constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/constraint/range-constraint-meta-inf.ts
@@ -35,7 +35,7 @@ export class RangeConstraintMetaInformation extends ConstraintMetaInformation {
         },
       },
       ['integer', 'decimal'],
-      (propertyBody, accept) => {
+      (propertyBody, context) => {
         const lowerBoundProperty = propertyBody.properties.find(
           (p) => p.name === 'lowerBound',
         );
@@ -58,7 +58,7 @@ export class RangeConstraintMetaInformation extends ConstraintMetaInformation {
 
         if (lowerBound > upperBound) {
           [lowerBoundProperty, upperBoundProperty].forEach((property) => {
-            accept(
+            context.accept(
               'error',
               'The lower bound needs to be smaller or equal to the upper bound',
               { node: property.value },
@@ -90,13 +90,13 @@ export class RangeConstraintMetaInformation extends ConstraintMetaInformation {
           const errorMessage =
             'Lower and upper bounds need to be inclusive if they are identical';
           if (!lowerBoundInclusive) {
-            accept('error', errorMessage, {
+            context.accept('error', errorMessage, {
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               node: lowerBoundInclusiveProperty!.value,
             });
           }
           if (!upperBoundInclusive) {
-            accept('error', errorMessage, {
+            context.accept('error', errorMessage, {
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               node: upperBoundInclusiveProperty!.value,
             });

--- a/libs/language-server/src/lib/meta-information/block-meta-inf.ts
+++ b/libs/language-server/src/lib/meta-information/block-meta-inf.ts
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { ValidationAcceptor } from 'langium';
-
 import { PropertyBody } from '../ast/generated/ast';
 // eslint-disable-next-line import/no-cycle
 import { IOType } from '../ast/model-util';
+import { ValidationContext } from '../validation/validation-context';
 
 import { ExampleDoc, MetaInformation, PropertySpecification } from './meta-inf';
 
@@ -23,7 +22,7 @@ export abstract class BlockMetaInformation extends MetaInformation {
     properties: Record<string, PropertySpecification>,
     public readonly inputType: IOType,
     public readonly outputType: IOType,
-    validation?: (property: PropertyBody, accept: ValidationAcceptor) => void,
+    validation?: (property: PropertyBody, context: ValidationContext) => void,
   ) {
     super(blockType, properties, validation);
   }

--- a/libs/language-server/src/lib/meta-information/constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/meta-information/constraint-meta-inf.ts
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { ValidationAcceptor } from 'langium';
-
 import { PrimitiveValuetypeKeyword, PropertyBody } from '../ast/generated/ast';
+import { ValidationContext } from '../validation/validation-context';
 
 // eslint-disable-next-line import/no-cycle
 import { ExampleDoc, MetaInformation, PropertySpecification } from './meta-inf';
@@ -20,7 +19,7 @@ export abstract class ConstraintMetaInformation extends MetaInformation {
     constraintType: string,
     properties: Record<string, PropertySpecification>,
     public readonly compatiblePrimitiveValuetypes: PrimitiveValuetypeKeyword[],
-    validation?: (property: PropertyBody, accept: ValidationAcceptor) => void,
+    validation?: (property: PropertyBody, context: ValidationContext) => void,
   ) {
     super(constraintType, properties, validation);
   }

--- a/libs/language-server/src/lib/meta-information/meta-inf.ts
+++ b/libs/language-server/src/lib/meta-information/meta-inf.ts
@@ -2,18 +2,17 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { ValidationAcceptor } from 'langium';
-
 import { PropertyAssignment, PropertyBody } from '../ast/generated/ast';
 // eslint-disable-next-line import/no-cycle
 import { PropertyValuetype } from '../ast/model-util';
+import { ValidationContext } from '../validation/validation-context';
 
 export interface PropertySpecification {
   type: PropertyValuetype;
   defaultValue?: unknown;
   validation?: (
     property: PropertyAssignment,
-    accept: ValidationAcceptor,
+    context: ValidationContext,
   ) => void;
   docs?: PropertyDocs;
 }
@@ -35,11 +34,11 @@ export abstract class MetaInformation {
     private readonly properties: Record<string, PropertySpecification>,
     private readonly validation?: (
       property: PropertyBody,
-      accept: ValidationAcceptor,
+      context: ValidationContext,
     ) => void,
   ) {}
 
-  validate(propertyBody: PropertyBody, accept: ValidationAcceptor): void {
+  validate(propertyBody: PropertyBody, context: ValidationContext): void {
     for (const property of propertyBody.properties) {
       const propertySpecification = this.getPropertySpecification(
         property.name,
@@ -48,11 +47,11 @@ export abstract class MetaInformation {
       if (propertyValidationFn === undefined) {
         continue;
       }
-      propertyValidationFn(property, accept);
+      propertyValidationFn(property, context);
     }
 
     if (this.validation !== undefined) {
-      this.validation(propertyBody, accept);
+      this.validation(propertyBody, context);
     }
   }
 

--- a/libs/language-server/src/lib/validation/checks/column-literal.ts
+++ b/libs/language-server/src/lib/validation/checks/column-literal.ts
@@ -6,20 +6,19 @@
  * See the FAQ section of README.md for an explanation why the following eslint rule is disabled for this file.
  */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { ValidationAcceptor } from 'langium';
-
 import { ColumnLiteral } from '../../ast/generated/ast';
+import { ValidationContext } from '../validation-context';
 
 export function validateColumnLiteral(
   column: ColumnLiteral,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
-  checkColumnIdSyntax(column, accept);
+  checkColumnIdSyntax(column, context);
 }
 
 function checkColumnIdSyntax(
   column: ColumnLiteral,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
   if (column.columnId === undefined) {
     return;
@@ -27,7 +26,7 @@ function checkColumnIdSyntax(
 
   const columnIdRegex = /^([A-Z]+|\*)$/;
   if (!columnIdRegex.test(column.columnId)) {
-    accept(
+    context.accept(
       'error',
       'Columns need to be denoted via capital letters or the * character',
       {

--- a/libs/language-server/src/lib/validation/checks/constraint-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/constraint-definition.ts
@@ -6,27 +6,31 @@
  * See the FAQ section of README.md for an explanation why the following ESLint rule is disabled for this file.
  */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { ValidationAcceptor } from 'langium';
 
 import { ConstraintDefinition } from '../../ast';
 import { getMetaInformation } from '../../meta-information/meta-inf-registry';
+import { ValidationContext } from '../validation-context';
 
 export function validateConstraintDefinition(
   constraint: ConstraintDefinition,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
-  checkConstraintType(constraint, accept);
+  checkConstraintType(constraint, context);
 }
 
 function checkConstraintType(
   constraint: ConstraintDefinition,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
   const metaInf = getMetaInformation(constraint.type);
   if (metaInf === undefined) {
-    accept('error', `Unknown constraint type '${constraint.type.name ?? ''}'`, {
-      node: constraint,
-      property: 'type',
-    });
+    context.accept(
+      'error',
+      `Unknown constraint type '${constraint.type.name ?? ''}'`,
+      {
+        node: constraint,
+        property: 'type',
+      },
+    );
   }
 }

--- a/libs/language-server/src/lib/validation/checks/expression.ts
+++ b/libs/language-server/src/lib/validation/checks/expression.ts
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { ValidationAcceptor } from 'langium';
-
 import {
   BooleanExpression,
   isBooleanExpression,
@@ -14,17 +12,18 @@ import {
   evaluateExpression,
   inferTypesFromValue,
 } from '../../ast/model-util';
+import { ValidationContext } from '../validation-context';
 
 export function validateExpression(
   expression: BooleanExpression,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
-  checkSimplification(expression, accept);
+  checkSimplification(expression, context);
 }
 
 function checkSimplification(
   expression: BooleanExpression,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
   if (isBooleanLiteral(expression)) {
     return;
@@ -37,7 +36,7 @@ function checkSimplification(
   }
 
   const evaluatedExpression = evaluateExpression(expression);
-  accept(
+  context.accept(
     'info',
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     `The expression can be simplified to ${evaluatedExpression}`,

--- a/libs/language-server/src/lib/validation/checks/jayvee-model.ts
+++ b/libs/language-server/src/lib/validation/checks/jayvee-model.ts
@@ -2,14 +2,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { ValidationAcceptor } from 'langium';
-
 import { JayveeModel } from '../../ast/generated/ast';
+import { ValidationContext } from '../validation-context';
 import { checkUniqueNames } from '../validation-util';
 
 export function validateJayveeModel(
   model: JayveeModel,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
-  checkUniqueNames(model.pipelines, accept);
+  checkUniqueNames(model.pipelines, context);
 }

--- a/libs/language-server/src/lib/validation/checks/pipe-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/pipe-definition.ts
@@ -2,22 +2,21 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { ValidationAcceptor } from 'langium';
-
 import { PipeDefinition } from '../../ast/generated/ast';
 import { createSemanticPipes } from '../../ast/wrappers/pipe-wrapper';
 import { getMetaInformation } from '../../meta-information/meta-inf-registry';
+import { ValidationContext } from '../validation-context';
 
 export function validatePipeDefinition(
   pipe: PipeDefinition,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
-  checkBlockCompatibility(pipe, accept);
+  checkBlockCompatibility(pipe, context);
 }
 
 function checkBlockCompatibility(
   pipe: PipeDefinition,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
   const semanticPipes = createSemanticPipes(pipe);
   for (const semanticPipe of semanticPipes) {
@@ -33,8 +32,8 @@ function checkBlockCompatibility(
     if (fromBlockMetaInf.hasOutput() && toBlockMetaInf.hasInput()) {
       if (!fromBlockMetaInf.canBeConnectedTo(toBlockMetaInf)) {
         const errorMessage = `The output type "${fromBlockMetaInf.outputType}" of ${fromBlockMetaInf.type} is incompatible with the input type "${toBlockMetaInf.inputType}" of ${toBlockMetaInf.type}`;
-        accept('error', errorMessage, semanticPipe.getFromDiagnostic());
-        accept('error', errorMessage, semanticPipe.getToDiagnostic());
+        context.accept('error', errorMessage, semanticPipe.getFromDiagnostic());
+        context.accept('error', errorMessage, semanticPipe.getToDiagnostic());
       }
     }
   }

--- a/libs/language-server/src/lib/validation/checks/pipeline-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/pipeline-definition.ts
@@ -2,29 +2,32 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { ValidationAcceptor } from 'langium';
-
 import { PipelineDefinition } from '../../ast/generated/ast';
 import { collectStartingBlocks } from '../../ast/model-util';
+import { ValidationContext } from '../validation-context';
 import { checkUniqueNames } from '../validation-util';
 
 export function validatePipelineDefinition(
   pipeline: PipelineDefinition,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
-  checkStartingBlocks(pipeline, accept);
-  checkUniqueNames(pipeline.blocks, accept);
+  checkStartingBlocks(pipeline, context);
+  checkUniqueNames(pipeline.blocks, context);
 }
 
 function checkStartingBlocks(
   pipeline: PipelineDefinition,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
   const startingBlocks = collectStartingBlocks(pipeline);
   if (startingBlocks.length === 0) {
-    accept('error', `An extractor block is required for this pipeline`, {
-      node: pipeline,
-      property: 'name',
-    });
+    context.accept(
+      'error',
+      `An extractor block is required for this pipeline`,
+      {
+        node: pipeline,
+        property: 'name',
+      },
+    );
   }
 }

--- a/libs/language-server/src/lib/validation/checks/range-literal.ts
+++ b/libs/language-server/src/lib/validation/checks/range-literal.ts
@@ -6,21 +6,21 @@
  * See the FAQ section of README.md for an explanation why the following eslint rule is disabled for this file.
  */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { ValidationAcceptor } from 'langium';
 
 import { RangeLiteral } from '../../ast/generated/ast';
 import { CellRangeWrapper } from '../../ast/wrappers/cell-range-wrapper';
+import { ValidationContext } from '../validation-context';
 
 export function validateRangeLiteral(
   range: RangeLiteral,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
-  checkRangeLimits(range, accept);
+  checkRangeLimits(range, context);
 }
 
 function checkRangeLimits(
   range: RangeLiteral,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
   if (range.cellFrom === undefined || range.cellTo === undefined) {
     return;
@@ -30,7 +30,7 @@ function checkRangeLimits(
     semanticCellRange.from.columnIndex > semanticCellRange.to.columnIndex ||
     semanticCellRange.from.rowIndex > semanticCellRange.to.rowIndex
   ) {
-    accept(
+    context.accept(
       'error',
       `Cell ranges need to be spanned from top-left to bottom-right`,
       {

--- a/libs/language-server/src/lib/validation/checks/regex-literal.ts
+++ b/libs/language-server/src/lib/validation/checks/regex-literal.ts
@@ -2,30 +2,29 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { ValidationAcceptor } from 'langium';
-
 import { RegexLiteral } from '../../ast';
+import { ValidationContext } from '../validation-context';
 
 export function validateRegexLiteral(
   regex: RegexLiteral,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
-  checkRegexParsability(regex, accept);
+  checkRegexParsability(regex, context);
 }
 
 function checkRegexParsability(
   regex: RegexLiteral,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
   try {
     new RegExp(regex.value);
   } catch (error) {
     if (error instanceof SyntaxError) {
-      accept('error', `A parsing error occurred: ${error.message}`, {
+      context.accept('error', `A parsing error occurred: ${error.message}`, {
         node: regex,
       });
     } else {
-      accept(
+      context.accept(
         'error',
         `An unknown parsing error occurred: ${JSON.stringify(error)}.`,
         {

--- a/libs/language-server/src/lib/validation/checks/valuetype-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/valuetype-definition.ts
@@ -6,7 +6,6 @@
  * See the FAQ section of README.md for an explanation why the following ESLint rule is disabled for this file.
  */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { ValidationAcceptor } from 'langium';
 
 import {
   PropertyValuetype,
@@ -15,33 +14,38 @@ import {
   isConstraintReferenceLiteral,
 } from '../../ast';
 import { getMetaInformation } from '../../meta-information/meta-inf-registry';
+import { ValidationContext } from '../validation-context';
 
 export function validateValuetypeDefinition(
   valuetype: ValuetypeDefinition,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
-  checkConstraintsCollectionValues(valuetype, accept);
-  checkConstraintsMatchPrimitiveValuetype(valuetype, accept);
+  checkConstraintsCollectionValues(valuetype, context);
+  checkConstraintsMatchPrimitiveValuetype(valuetype, context);
 }
 
 function checkConstraintsCollectionValues(
   valuetype: ValuetypeDefinition,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
   const constraints = valuetype.constraints;
   constraints.values.forEach((collectionValue) => {
     const types = inferTypesFromValue(collectionValue);
     if (!types.includes(PropertyValuetype.CONSTRAINT)) {
-      accept('error', 'Only constraints are allowed in this collection', {
-        node: collectionValue,
-      });
+      context.accept(
+        'error',
+        'Only constraints are allowed in this collection',
+        {
+          node: collectionValue,
+        },
+      );
     }
   });
 }
 
 function checkConstraintsMatchPrimitiveValuetype(
   valuetype: ValuetypeDefinition,
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
   if (valuetype.type === undefined) {
     return;
@@ -66,7 +70,7 @@ function checkConstraintsMatchPrimitiveValuetype(
     if (
       !metaInf.compatiblePrimitiveValuetypes.includes(valuetype.type.keyword)
     ) {
-      accept(
+      context.accept(
         'error',
         `Only constraints for type "${valuetype.type.keyword}" are allowed in this collection`,
         {

--- a/libs/language-server/src/lib/validation/index.ts
+++ b/libs/language-server/src/lib/validation/index.ts
@@ -2,5 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+export * from './validation-context';
 export * from './validation-registry';
 export * from './validation-util';

--- a/libs/language-server/src/lib/validation/validation-context.ts
+++ b/libs/language-server/src/lib/validation/validation-context.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { AstNode, DiagnosticInfo, ValidationAcceptor } from 'langium';
+
+export class ValidationContext {
+  private errorOccurred = false;
+
+  constructor(private readonly validationAcceptor: ValidationAcceptor) {}
+
+  accept: ValidationAcceptor = <N extends AstNode>(
+    severity: 'error' | 'warning' | 'info' | 'hint',
+    message: string,
+    info: DiagnosticInfo<N>,
+  ): void => {
+    if (severity === 'error') {
+      this.errorOccurred = true;
+    }
+    this.validationAcceptor(severity, message, info);
+  };
+
+  hasErrorOccurred(): boolean {
+    return this.errorOccurred;
+  }
+}

--- a/libs/language-server/src/lib/validation/validation-util.ts
+++ b/libs/language-server/src/lib/validation/validation-util.ts
@@ -2,16 +2,18 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { AstNode, ValidationAcceptor } from 'langium';
+import { AstNode } from 'langium';
+
+import { ValidationContext } from './validation-context';
 
 export type NamedAstNode = AstNode & { name: string };
 
 export function checkUniqueNames(
   nodes: NamedAstNode[],
-  accept: ValidationAcceptor,
+  context: ValidationContext,
 ): void {
   getNodesWithNonUniqueNames(nodes).forEach((node) => {
-    accept(
+    context.accept(
       'error',
       `The ${node.$type.toLowerCase()} name "${node.name}" needs to be unique.`,
       {


### PR DESCRIPTION
Introduces a `ValidationContext` class that is provided instead of `ValidationAcceptor` to report diagnostics during validation. More precisely it is a wrapper around the usual `ValidationAcceptor`. The purpose is to allow checking whether errors occurred during validation and use this information to abort the validation early.

The PR also includes a few improvements for existing validation checks.