### PR TITLE
Fix parsing of decimal numbers

### DIFF
--- a/libs/language-server/src/grammar/property.langium
+++ b/libs/language-server/src/grammar/property.langium
@@ -33,7 +33,7 @@ TextLiteral:
   value=STRING;
 
 NumericLiteral:
-  value=(INTEGER | NUMBER);
+  value=(INTEGER | SIGNED_INTEGER | DECIMAL | SIGNED_DECIMAL);
 
 CollectionLiteral:
   '[' (values+=(AtomicLiteral) (',' values+=(AtomicLiteral))*)? ','? ']';

--- a/libs/language-server/src/grammar/terminal.langium
+++ b/libs/language-server/src/grammar/terminal.langium
@@ -8,9 +8,10 @@
 terminal CELL_REFERENCE: /([A-Z]+|\*)([0-9]+|\*)/;
 terminal ID: /[_a-zA-Z][\w_]*/;
 
-// INTEGER is required for row IDs and overlaps with NUMBER below
+terminal SIGNED_DECIMAL returns number: ('+' | '-') DECIMAL;
+terminal DECIMAL returns number: INTEGER '.' INTEGER;
+terminal SIGNED_INTEGER returns number: ('+' | '-') INTEGER;
 terminal INTEGER returns number: /[0-9]+/;
-terminal NUMBER returns number: /[+-]?[0-9]+(\.[0-9]+)?/;
 
 terminal STRING: /"[^"]*"|'[^']*'/;
 


### PR DESCRIPTION
I noticed that decimal numbers are not parsed correctly:

![image](https://user-images.githubusercontent.com/51856713/233082529-964a443d-bac1-4420-a08f-e45ef8cdd90f.png)

This PR provides a fix by changing the grammar, so the terminals get recognized correctly.