### PR TITLE
Show constraint docs when hovering

### DIFF
--- a/libs/language-server/src/lib/docs/lsp-doc-generator.ts
+++ b/libs/language-server/src/lib/docs/lsp-doc-generator.ts
@@ -2,19 +2,31 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { BlockMetaInformation } from '../meta-information';
+import {
+  BlockMetaInformation,
+  ConstraintMetaInformation,
+} from '../meta-information';
 import { MetaInformation } from '../meta-information/meta-inf';
 
 import {
   JayveeBlockTypeDocGenerator,
+  JayveeConstraintTypeDocGenerator,
   JayveePropertyDocGenerator,
 } from './jayvee-doc-generator';
 import { MarkdownBuilder } from './markdown-builder';
 
 export class LspDocGenerator
-  implements JayveeBlockTypeDocGenerator, JayveePropertyDocGenerator
+  implements
+    JayveeBlockTypeDocGenerator,
+    JayveeConstraintTypeDocGenerator,
+    JayveePropertyDocGenerator
 {
   generateBlockTypeDoc(metaInf: BlockMetaInformation): string {
+    const markdownBuilder = new MarkdownBuilder();
+    return markdownBuilder.line(metaInf.docs.description).build();
+  }
+
+  generateConstraintTypeDoc(metaInf: ConstraintMetaInformation): string {
     const markdownBuilder = new MarkdownBuilder();
     return markdownBuilder.line(metaInf.docs.description).build();
   }

--- a/libs/language-server/src/lib/hover/jayvee-hover-provider.ts
+++ b/libs/language-server/src/lib/hover/jayvee-hover-provider.ts
@@ -7,8 +7,10 @@ import { Hover } from 'vscode-languageserver-protocol';
 
 import {
   BlockTypeLiteral,
+  ConstraintTypeLiteral,
   PropertyAssignment,
   isBlockTypeLiteral,
+  isConstraintTypeLiteral,
   isPropertyAssignment,
 } from '../ast';
 import { LspDocGenerator } from '../docs/lsp-doc-generator';
@@ -21,6 +23,9 @@ export class JayveeHoverProvider extends AstNodeHoverProvider {
     let doc = undefined;
     if (isBlockTypeLiteral(astNode)) {
       doc = this.getBlockTypeMarkdownDoc(astNode);
+    }
+    if (isConstraintTypeLiteral(astNode)) {
+      doc = this.getConstraintTypeMarkdownDoc(astNode);
     }
     if (isPropertyAssignment(astNode)) {
       doc = this.getPropertyMarkdownDoc(astNode);
@@ -48,6 +53,18 @@ export class JayveeHoverProvider extends AstNodeHoverProvider {
 
     const lspDocBuilder = new LspDocGenerator();
     return lspDocBuilder.generateBlockTypeDoc(blockMetaInf);
+  }
+
+  private getConstraintTypeMarkdownDoc(
+    constraintType: ConstraintTypeLiteral,
+  ): string | undefined {
+    const constraintMetaInf = getMetaInformation(constraintType);
+    if (constraintMetaInf === undefined) {
+      return;
+    }
+
+    const lspDocBuilder = new LspDocGenerator();
+    return lspDocBuilder.generateConstraintTypeDoc(constraintMetaInf);
   }
 
   private getPropertyMarkdownDoc(


### PR DESCRIPTION
Now shows a description when hovering over a constraint type:

![image](https://user-images.githubusercontent.com/51856713/233085624-7c7c2d43-ee50-48b1-96ea-1c50d75134ae.png)
