### PR TITLE
Add an empty standard library

### DIFF
--- a/apps/vs-code-extension/src/extension.ts
+++ b/apps/vs-code-extension/src/extension.ts
@@ -12,10 +12,13 @@ import {
   TransportKind,
 } from 'vscode-languageclient/node';
 
+import { StandardLibraryFileSystemProvider } from './standard-library-file-system-provider';
+
 let client: LanguageClient;
 
 // This function is called when the extension is activated.
 export function activate(context: vscode.ExtensionContext): void {
+  StandardLibraryFileSystemProvider.register(context);
   client = startLanguageClient(context);
 }
 

--- a/apps/vs-code-extension/src/standard-library-file-system-provider.ts
+++ b/apps/vs-code-extension/src/standard-library-file-system-provider.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { STANDARD_LIBRARY_SOURCECODE } from '@jvalue/jayvee-language-server';
+import {
+  EventEmitter,
+  ExtensionContext,
+  FileChangeEvent,
+  FileStat,
+  FileSystemError,
+  FileSystemProvider,
+  FileType,
+  Uri,
+  workspace,
+} from 'vscode';
+
+export class StandardLibraryFileSystemProvider implements FileSystemProvider {
+  // The following class members only serve to satisfy the interface:
+  private readonly didChangeFile = new EventEmitter<FileChangeEvent[]>();
+  onDidChangeFile = this.didChangeFile.event;
+
+  static register(context: ExtensionContext) {
+    context.subscriptions.push(
+      workspace.registerFileSystemProvider(
+        'builtin',
+        new StandardLibraryFileSystemProvider(),
+        {
+          isReadonly: true,
+          isCaseSensitive: false,
+        },
+      ),
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  stat(uri: Uri): FileStat {
+    const date = Date.now();
+    return {
+      ctime: date,
+      mtime: date,
+      size: STANDARD_LIBRARY_SOURCECODE.length,
+      type: FileType.File,
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  readFile(uri: Uri): Uint8Array {
+    // We could return different libraries based on the URI
+    // We have only one, so we always return the same
+    return new Uint8Array(Buffer.from(STANDARD_LIBRARY_SOURCECODE));
+  }
+
+  watch() {
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      dispose: () => {},
+    };
+  }
+
+  readDirectory(): [] {
+    throw FileSystemError.NoPermissions();
+  }
+
+  createDirectory() {
+    throw FileSystemError.NoPermissions();
+  }
+
+  writeFile() {
+    throw FileSystemError.NoPermissions();
+  }
+
+  delete() {
+    throw FileSystemError.NoPermissions();
+  }
+
+  rename() {
+    throw FileSystemError.NoPermissions();
+  }
+}

--- a/apps/vs-code-extension/src/standard-library-file-system-provider.ts
+++ b/apps/vs-code-extension/src/standard-library-file-system-provider.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { TextEncoder } from 'util';
+
 import { STANDARD_LIBRARY_SOURCECODE } from '@jvalue/jayvee-language-server';
 import {
   EventEmitter,
@@ -39,7 +41,7 @@ export class StandardLibraryFileSystemProvider implements FileSystemProvider {
     return {
       ctime: date,
       mtime: date,
-      size: STANDARD_LIBRARY_SOURCECODE.length,
+      size: new TextEncoder().encode(STANDARD_LIBRARY_SOURCECODE).length,
       type: FileType.File,
     };
   }

--- a/libs/language-server/src/lib/builtin-library/index.ts
+++ b/libs/language-server/src/lib/builtin-library/index.ts
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+export * from './jayvee-standard-library';
+export * from './jayvee-workspace-manager';

--- a/libs/language-server/src/lib/builtin-library/jayvee-standard-library.ts
+++ b/libs/language-server/src/lib/builtin-library/jayvee-standard-library.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+export const STANDARD_LIBRARY_FILENAME = 'standard.jv';
+
+export const STANDARD_LIBRARY_SOURCECODE = `
+// TBD
+`.trimLeft();

--- a/libs/language-server/src/lib/builtin-library/jayvee-workspace-manager.ts
+++ b/libs/language-server/src/lib/builtin-library/jayvee-workspace-manager.ts
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import {
+  DefaultWorkspaceManager,
+  LangiumDocument,
+  LangiumDocumentFactory,
+  LangiumSharedServices,
+} from 'langium';
+import { WorkspaceFolder } from 'vscode-languageserver';
+import { URI } from 'vscode-uri';
+
+import {
+  STANDARD_LIBRARY_FILENAME,
+  STANDARD_LIBRARY_SOURCECODE,
+} from './jayvee-standard-library';
+
+export class JayveeWorkspaceManager extends DefaultWorkspaceManager {
+  private documentFactory: LangiumDocumentFactory;
+
+  constructor(services: LangiumSharedServices) {
+    super(services);
+    this.documentFactory = services.workspace.LangiumDocumentFactory;
+  }
+
+  override async loadAdditionalDocuments(
+    folders: WorkspaceFolder[],
+    collector: (document: LangiumDocument) => void,
+  ): Promise<void> {
+    collector(
+      this.documentFactory.fromString(
+        STANDARD_LIBRARY_SOURCECODE,
+        URI.parse(`builtin:///${STANDARD_LIBRARY_FILENAME}`),
+      ),
+    );
+    return Promise.resolve();
+  }
+}

--- a/libs/language-server/src/lib/builtin-library/jayvee-workspace-manager.ts
+++ b/libs/language-server/src/lib/builtin-library/jayvee-workspace-manager.ts
@@ -28,12 +28,12 @@ export class JayveeWorkspaceManager extends DefaultWorkspaceManager {
     folders: WorkspaceFolder[],
     collector: (document: LangiumDocument) => void,
   ): Promise<void> {
+    await super.loadAdditionalDocuments(folders, collector);
     collector(
       this.documentFactory.fromString(
         STANDARD_LIBRARY_SOURCECODE,
         URI.parse(`builtin:///${STANDARD_LIBRARY_FILENAME}`),
       ),
     );
-    return Promise.resolve();
   }
 }

--- a/libs/language-server/src/lib/index.ts
+++ b/libs/language-server/src/lib/index.ts
@@ -3,11 +3,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 export * from './ast';
+export * from './builtin-library';
 export * from './constraint';
 export * from './docs';
 export * from './meta-information';
 export * from './util';
-export * from './validation';
 
+export * from './validation';
 export * from './jayvee-module';
 export * from './extension';

--- a/libs/language-server/src/lib/jayvee-module.ts
+++ b/libs/language-server/src/lib/jayvee-module.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
+  DeepPartial,
   DefaultSharedModuleContext,
   LangiumServices,
   LangiumSharedServices,
@@ -17,6 +18,7 @@ import {
   JayveeGeneratedModule,
   JayveeGeneratedSharedModule,
 } from './ast/generated/module';
+import { JayveeWorkspaceManager } from './builtin-library/jayvee-workspace-manager';
 import { JayveeCompletionProvider } from './completion/jayvee-completion-provider';
 import { registerConstraints } from './constraint/constraint-registry';
 import { JayveeHoverProvider } from './hover/jayvee-hover-provider';
@@ -34,6 +36,8 @@ export interface JayveeAddedServices {}
  * of custom service classes.
  */
 export type JayveeServices = LangiumServices & JayveeAddedServices;
+
+export type JayveeSharedServices = LangiumSharedServices;
 
 /**
  * Dependency injection module that overrides Langium default services and contributes the
@@ -55,6 +59,15 @@ export const JayveeModule: Module<
       new JayveeCompletionProvider(services),
     HoverProvider: (services: LangiumServices) =>
       new JayveeHoverProvider(services),
+  },
+};
+
+export const JayveeSharedModule: Module<
+  JayveeSharedServices,
+  DeepPartial<LangiumSharedServices>
+> = {
+  workspace: {
+    WorkspaceManager: (services) => new JayveeWorkspaceManager(services),
   },
 };
 
@@ -80,6 +93,7 @@ export function createJayveeServices(context: DefaultSharedModuleContext): {
   const shared = inject(
     createDefaultSharedModule(context),
     JayveeGeneratedSharedModule,
+    JayveeSharedModule,
   );
   const Jayvee = inject(
     createDefaultModule({ shared }),


### PR DESCRIPTION
Preparation for #217 

Adds a builtin Jayvee file `standard.jv` that can serve as a standard library in the future. For now, the file is empty (it only contains a comment, so it has no semantics yet).

In VS Code, when navigating to that file, it is marked as read-only and thus cannot be edited by users.

To accomplish this, I followed this guide from the Langium documentation: https://langium.org/guides/builtin-library/