### PR TITLE
Fix line comment parsing error

### DIFF
--- a/libs/language-server/src/grammar/terminal.langium
+++ b/libs/language-server/src/grammar/terminal.langium
@@ -13,7 +13,8 @@ terminal INTEGER returns number: /[0-9]+/;
 
 terminal STRING: /"[^"]*"|'[^']*'/;
 
+hidden terminal SINGLE_LINE_COMMENT: /\/\/[^\n\r]*/;
+
 terminal REGEX: /\/.+\//;
 
 hidden terminal WHITESPACE: /\s+/;
-hidden terminal SINGLE_LINE_COMMENT: /\/\/[^\n\r]*/;


### PR DESCRIPTION
Closes #297 

The fix was simple but not so easy to find: the terminal order caused the `REGEX` terminal to be picked over `SINGLE_LINE_COMMENT`. So comments with `/` characters were (I guess partly) tokenized as regexes instead of comments which caused the error. Changing the order fixes the problem:

![image](https://user-images.githubusercontent.com/51856713/235192361-06b23221-ea5a-4237-84ce-b9b54538db4c.png)
