### PR TITLE
Add dummy version to VS Code extension

### DIFF
--- a/apps/vs-code-extension/package.json
+++ b/apps/vs-code-extension/package.json
@@ -41,5 +41,6 @@
     "type": "git",
     "url": "https://github.com/jvalue/jayvee.git"
   },
-  "homepage": "https://github.com/jvalue/jayvee"
+  "homepage": "https://github.com/jvalue/jayvee",
+  "version": "0.0.0"
 }


### PR DESCRIPTION
Follow-up for #296

I noticed that due to the missing `version` field in the `package.json` file, the VS Code extension does not load properly during development (i.e. when pressing F5 to run the extension locally).

To fix this problem, I added a version field with a dummy value. Seems like the version value needs to match the semantic versioning schema.