### PR TITLE
Fix operator parsing bug

### DIFF
--- a/libs/language-server/src/grammar/cellrange.langium
+++ b/libs/language-server/src/grammar/cellrange.langium
@@ -11,13 +11,22 @@ CellRangeLiteral:
   | CellLiteral;
 
 RangeLiteral:
-  'range' cellFrom=CELL_REFERENCE ':' cellTo=CELL_REFERENCE;
+  'range' cellFrom=(CELL_REFERENCE | CellReference) ':' cellTo=(CELL_REFERENCE | CellReference);
 
 ColumnLiteral:
-  'column' columnId=(ID | '*');
+  'column' columnId=ColumnId;
 
 RowLiteral:
-  'row' rowId=(INTEGER | '*');
+  'row' rowId=RowId;
 
 CellLiteral:
-  'cell' cellId=CELL_REFERENCE;
+  'cell' cellId=(CELL_REFERENCE | CellReference);
+
+CellReference:
+  columnId=ColumnId rowId=RowId;
+
+ColumnId:
+  value=(ID | '*');
+
+RowId:
+  value=(INTEGER | '*');

--- a/libs/language-server/src/grammar/terminal.langium
+++ b/libs/language-server/src/grammar/terminal.langium
@@ -5,7 +5,7 @@
 // The order of the terminals matters here, it implicitly defines the prioritization for the lexer.
 // For more details, see https://langium.org/docs/grammar-language/#terminal-rules
 
-terminal CELL_REFERENCE: /([A-Z]+|\*)([0-9]+|\*)/;
+terminal CELL_REFERENCE: /[A-Z]+/ INTEGER;
 terminal ID: /[_a-zA-Z][\w_]*/;
 
 terminal DECIMAL returns number: INTEGER '.' INTEGER;

--- a/libs/language-server/src/lib/validation/checks/column-id.ts
+++ b/libs/language-server/src/lib/validation/checks/column-id.ts
@@ -6,32 +6,32 @@
  * See the FAQ section of README.md for an explanation why the following eslint rule is disabled for this file.
  */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { ColumnLiteral } from '../../ast/generated/ast';
+import { ColumnId } from '../../ast/generated/ast';
 import { ValidationContext } from '../validation-context';
 
-export function validateColumnLiteral(
-  column: ColumnLiteral,
+export function validateColumnId(
+  columnId: ColumnId,
   context: ValidationContext,
 ): void {
-  checkColumnIdSyntax(column, context);
+  checkColumnIdSyntax(columnId, context);
 }
 
 function checkColumnIdSyntax(
-  column: ColumnLiteral,
+  columnId: ColumnId,
   context: ValidationContext,
 ): void {
-  if (column.columnId === undefined) {
+  if (columnId.value === undefined || columnId.value === '*') {
     return;
   }
 
-  const columnIdRegex = /^([A-Z]+|\*)$/;
-  if (!columnIdRegex.test(column.columnId)) {
+  const columnIdRegex = /^[A-Z]+$/;
+  if (!columnIdRegex.test(columnId.value)) {
     context.accept(
       'error',
       'Columns need to be denoted via capital letters or the * character',
       {
-        node: column,
-        property: 'columnId',
+        node: columnId,
+        property: 'value',
       },
     );
   }

--- a/libs/language-server/src/lib/validation/validation-registry.ts
+++ b/libs/language-server/src/lib/validation/validation-registry.ts
@@ -15,7 +15,7 @@ import type { JayveeServices } from '../jayvee-module';
 
 // eslint-disable-next-line import/no-cycle
 import { validateBlockDefinition } from './checks/block-definition';
-import { validateColumnLiteral } from './checks/column-literal';
+import { validateColumnId } from './checks/column-id';
 import { validateConstraintDefinition } from './checks/constraint-definition';
 import { validateJayveeModel } from './checks/jayvee-model';
 import { validatePipeDefinition } from './checks/pipe-definition';
@@ -35,7 +35,7 @@ export class JayveeValidationRegistry extends ValidationRegistry {
 
     this.register<JayveeAstType>({
       BlockDefinition: wrapCheck(validateBlockDefinition),
-      ColumnLiteral: wrapCheck(validateColumnLiteral),
+      ColumnId: wrapCheck(validateColumnId),
       ConstraintDefinition: wrapCheck(validateConstraintDefinition),
       JayveeModel: wrapCheck(validateJayveeModel),
       PipeDefinition: wrapCheck(validatePipeDefinition),


### PR DESCRIPTION
Fixes the issue addressed in #290 

The reason was, that the `*` character used for multiplication was also part of the `CELL_RANGE` terminal which lead to conflicts. This refactoring changes the terminal for cell ranges, so it does not consume any `*` characters. The consequence is that internally `B1` is considered a single token (which needs to be split manually) and on the other hand `B*` consists of two separate tokens `B` and `*`. This slightly complicates things but I can't think of a more elegant alternative.