### PR TITLE
Fix exports of valuetype types

### DIFF
--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts
@@ -6,24 +6,24 @@
 export * from './primitive-valuetype';
 export * from './primitive-valuetypes';
 
-export { BooleanValuetype, isBooleanValuetype } from './boolean-valuetype';
+export { type BooleanValuetype, isBooleanValuetype } from './boolean-valuetype';
 export {
-  CellRangeValuetype,
+  type CellRangeValuetype,
   isCellRangeValuetype,
 } from './cell-range-valuetype';
 export {
-  CollectionValuetype,
+  type CollectionValuetype,
   isCollectionValuetype,
 } from './collection-valuetype';
 export {
-  ConstraintValuetype,
+  type ConstraintValuetype,
   isConstraintValuetype,
 } from './constraint-valuetype';
-export { DecimalValuetype, isDecimalValuetype } from './decimal-valuetype';
-export { IntegerValuetype, isIntegerValuetype } from './integer-valuetype';
-export { RegexValuetype, isRegexValuetype } from './regex-valuetype';
-export { TextValuetype, isTextValuetype } from './text-valuetype';
+export { type DecimalValuetype, isDecimalValuetype } from './decimal-valuetype';
+export { type IntegerValuetype, isIntegerValuetype } from './integer-valuetype';
+export { type RegexValuetype, isRegexValuetype } from './regex-valuetype';
+export { type TextValuetype, isTextValuetype } from './text-valuetype';
 export {
-  ValuetypeAssignmentValuetype,
+  type ValuetypeAssignmentValuetype,
   isValuetypeAssignmentValuetype,
 } from './valuetype-assignment-valuetype';


### PR DESCRIPTION
While working on the documentation, I noticed that the following warnings were logged during `nx run docs:build-generator`:

```
WARNING in ./libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts 7:0-75
export 'BooleanValuetype' (reexported as 'BooleanValuetype') was not found in './boolean-valuetype' (possible exports: Boolean, isBooleanValuetype)

WARNING in ./libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts 8:0-83
export 'CellRangeValuetype' (reexported as 'CellRangeValuetype') was not found in './cell-range-valuetype' (possible exports: CellRange, isCellRangeValuetype)

WARNING in ./libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts 9:0-85
export 'CollectionValuetype' (reexported as 'CollectionValuetype') was not found in './collection-valuetype' (possible exports: Collection, isCollectionValuetype)

WARNING in ./libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts 10:0-85
export 'ConstraintValuetype' (reexported as 'ConstraintValuetype') was not found in './constraint-valuetype' (possible exports: Constraint, isConstraintValuetype)

WARNING in ./libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts 11:0-75
export 'DecimalValuetype' (reexported as 'DecimalValuetype') was not found in './decimal-valuetype' (possible exports: Decimal, isDecimalValuetype)

WARNING in ./libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts 12:0-75
export 'IntegerValuetype' (reexported as 'IntegerValuetype') was not found in './integer-valuetype' (possible exports: Integer, isIntegerValuetype)

WARNING in ./libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts 13:0-69
export 'RegexValuetype' (reexported as 'RegexValuetype') was not found in './regex-valuetype' (possible exports: Regex, isRegexValuetype)

WARNING in ./libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts 14:0-66
export 'TextValuetype' (reexported as 'TextValuetype') was not found in './text-valuetype' (possible exports: Text, isTextValuetype)

WARNING in ./libs/language-server/src/lib/ast/wrappers/value-type/primitive/index.ts 15:0-113
export 'ValuetypeAssignmentValuetype' (reexported as 'ValuetypeAssignmentValuetype') was not found in './valuetype-assignment-valuetype' (possible exports: ValuetypeAssignment, isValuetypeAssignmentValuetype)
```

This PR fixes the issue by adding the `type` keyword to the respective export statements.