### PR TITLE
Improve debugging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         run: npm run generate
 
       - name: Build
-        run: npx nx affected --target=build --parallel=3
+        run: npx nx affected --target=build --configuration=prod --parallel=3
 
       - name: Lint Nx specific workspace files
         run: npx nx workspace-lint

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,23 +24,23 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - name: Publish language server
-        run: npx nx run language-server:publish
+        run: npx nx run language-server:publish:prod
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish interpreter
-        run: npx nx run interpreter:publish
+        run: npx nx run interpreter:publish:prod
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish language server web worker
-        run: npx nx run language-server-web-worker:publish
+        run: npx nx run language-server-web-worker:publish:prod
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish monaco editor
-        run: npx nx run monaco-editor:publish
+        run: npx nx run monaco-editor:publish:prod
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Pack VS Code extension
-        run: npx nx run vs-code-extension:pack
+        run: npx nx run vs-code-extension:pack:prod
       - id: get_release
         uses: bruceadams/get-release@v1.3.2
         env:

--- a/apps/interpreter/project.json
+++ b/apps/interpreter/project.json
@@ -14,7 +14,13 @@
         "main": "apps/interpreter/src/index.ts",
         "tsConfig": "apps/interpreter/tsconfig.app.json",
         "generatePackageJson": true
-      }
+      },
+      "configurations": {
+        // https://nx.dev/recipes/executors/use-executor-configurations
+        "dev": {},
+        "prod": {}
+      },
+      "defaultConfiguration": "dev"
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/apps/interpreter/project.json
+++ b/apps/interpreter/project.json
@@ -27,7 +27,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
       "options": {
-        "commands": ["node dist/apps/interpreter/main.js"]
+        "commands": ["node --enable-source-maps dist/apps/interpreter/main.js"]
       }
     },
     "test": {

--- a/apps/interpreter/src/interpreter.ts
+++ b/apps/interpreter/src/interpreter.ts
@@ -188,7 +188,7 @@ async function executeBlock(
     return R.err({
       message: `An unknown error occurred: ${
         unexpectedError instanceof Error
-          ? unexpectedError.message
+          ? unexpectedError.stack ?? unexpectedError.message
           : JSON.stringify(unexpectedError)
       }`,
       diagnostic: { node: block, property: 'name' },

--- a/apps/language-server-web-worker/project.json
+++ b/apps/language-server-web-worker/project.json
@@ -16,7 +16,13 @@
         "vendorChunk": false,
         "externalDependencies": "none",
         "generatePackageJson": true
-      }
+      },
+      "configurations": {
+        // https://nx.dev/recipes/executors/use-executor-configurations
+        "dev": {},
+        "prod": {}
+      },
+      "defaultConfiguration": "dev"
     },
     "serve": {
       "executor": "@nrwl/js:node",

--- a/apps/vs-code-extension/project.json
+++ b/apps/vs-code-extension/project.json
@@ -23,6 +23,7 @@
       "configurations": {
         "dev": {
           "esbuildOptions": {
+            // Required, so VS Code's debugger is able to attach when running the extension
             "sourcemap": "linked"
           },
           "minify": false

--- a/apps/vs-code-extension/project.json
+++ b/apps/vs-code-extension/project.json
@@ -16,7 +16,6 @@
         "external": ["vscode"],
         "platform": "node",
         "format": ["cjs"],
-        "minify": true,
         "esbuildOptions": {
           "sourcemap": "linked"
         },

--- a/apps/vs-code-extension/project.json
+++ b/apps/vs-code-extension/project.json
@@ -16,13 +16,23 @@
         "external": ["vscode"],
         "platform": "node",
         "format": ["cjs"],
-        "esbuildOptions": {
-          "sourcemap": "linked"
-        },
         "assets": [
           { "input": "apps/vs-code-extension/assets", "glob": "*", "output": "/" }
         ]
-      }
+      },
+      "configurations": {
+        "dev": {
+          "esbuildOptions": {
+            "sourcemap": "linked"
+          },
+          "minify": false
+        },
+        "prod": {
+          "sourcemap": false,
+          "minify": true
+        }
+      },
+      "defaultConfiguration": "dev"
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/apps/vs-code-extension/project.json
+++ b/apps/vs-code-extension/project.json
@@ -28,7 +28,9 @@
           "minify": false
         },
         "prod": {
-          "sourcemap": false,
+          "esbuildOptions": {
+            "sourcemap": false
+          },
           "minify": true
         }
       },

--- a/libs/language-server/project.json
+++ b/libs/language-server/project.json
@@ -23,7 +23,13 @@
         "outputPath": "dist/libs/language-server",
         "main": "libs/language-server/src/index.ts",
         "tsConfig": "libs/language-server/tsconfig.lib.json"
-      }
+      },
+      "configurations": {
+        // https://nx.dev/recipes/executors/use-executor-configurations
+        "dev": {},
+        "prod": {}
+      },
+      "defaultConfiguration": "dev"
     },
     "lint": {
       "executor": "@nrwl/linter:eslint",

--- a/libs/monaco-editor/project.json
+++ b/libs/monaco-editor/project.json
@@ -29,7 +29,13 @@
             "output": "."
           }
         ]
-      }
+      },
+      "configurations": {
+        // https://nx.dev/recipes/executors/use-executor-configurations
+        "dev": {},
+        "prod": {}
+      },
+      "defaultConfiguration": "dev"
     },
     "test": {
       "executor": "@nrwl/jest:jest",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "nx": "nx",
     "format": "nx format:write",
     "build": "nx run-many --target build",
+    "build:prod": "nx run-many --target build --configuration=prod",
     "lint": "nx run-many --target lint --max-warnings 0",
     "test": "nx run-many --target test",
     "generate": "nx run language-server:generate",


### PR DESCRIPTION
Closes #330

The interpreter now logs stack traces when unexpected errors occur. They use source maps when the interpreter is run with `node --enable-source-maps`.

Unfortunately, I could not find out how to make language server logs use source maps in the VS Code extension. I found out that even in the Langium project itself, the logged stack traces don't have a source map:

```
Error:  TypeError: Cannot read properties of undefined (reading 'localeCompare')
    at /home/felix-oq/jvalue/langium/packages/langium-vscode/out/language-server/main.js:12302:54
    at Array.sort (<anonymous>)
    at sortInterfacesTopologically (/home/felix-oq/jvalue/langium/packages/langium-vscode/out/language-server/main.js:12302:32)
    at createAstTypes (/home/felix-oq/jvalue/langium/packages/langium-vscode/out/language-server/main.js:14775:66)
    at collectValidationAst (/home/felix-oq/jvalue/langium/packages/langium-vscode/out/language-server/main.js:14767:19)
    at LangiumGrammarValidationResourcesCollector.collectValidationResources (/home/felix-oq/jvalue/langium/packages/langium-vscode/out/language-server/main.js:24270:72)
    at /home/felix-oq/jvalue/langium/packages/langium-vscode/out/language-server/main.js:24689:56
    at async DefaultDocumentBuilder.notifyBuildPhase (/home/felix-oq/jvalue/langium/packages/langium-vscode/out/language-server/main.js:39812:11)
    at async DefaultDocumentBuilder.runCancelable (/home/felix-oq/jvalue/langium/packages/langium-vscode/out/language-server/main.js:39797:9)
    at async DefaultDocumentBuilder.buildDocuments (/home/felix-oq/jvalue/langium/packages/langium-vscode/out/language-server/main.js:39787:9)
```

To improve the debugging experience nevertheless, I decided to disable minification during development in the VS Code extension. This makes such stack traces a bit more meaningful, because the function names remain the same which eases locating them in the TypeScript codebase.

Note that the source maps still work with debugger of VS Code (i.e. debugging the VS Code extension using breakpoints works).

Some of the resources I stumbled across:
- Someone who apparently had a similar problem: https://github.com/microsoft/vscode/issues/138330
  - The solution that apparently worked in their case (sadly I couldn't get it to work) https://github.com/VSCodeVim/Vim/commit/666ea2fa346f0ff31d7a5e7a234de9b02ddd675d
- Different source map settings in esbuild: https://esbuild.github.io/api/#sourcemap
- Docs for the configuration of esbuild in Nx: https://nx.dev/packages/esbuild/executors/esbuild
- Langium's guide on bundling the VS Code extension: https://langium.org/guides/code-bundling/
- Microsoft's guide on bundling VS Code extensions: https://code.visualstudio.com/api/working-with-extensions/bundling-extension