### PR TITLE
Fix type export of empty collection

### DIFF
--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/index.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/index.ts
@@ -9,6 +9,6 @@ export {
 } from './collection-valuetype';
 
 export {
-  EmptyCollectionValuetype,
+  type EmptyCollectionValuetype,
   isEmptyCollectionValuetype,
 } from './empty-collection-valuetype';


### PR DESCRIPTION
Fixes the type export in order to avoid warnings during building the documentation app.