### PR TITLE
User facing docs for transforms and expressions

### DIFF
--- a/apps/docs/docs/user/core-concepts.md
+++ b/apps/docs/docs/user/core-concepts.md
@@ -116,3 +116,6 @@ valuetype GasFillLevel oftype integer {
     constraints: [ GasFillLevelRange ];
 }
 ```
+
+### Transforms
+`Transforms` are used to transform data from one `ValueType` to a different one. For more details, see [Transforms](./transforms.md)

--- a/apps/docs/docs/user/expressions.md
+++ b/apps/docs/docs/user/expressions.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 5
+---
+
+# Expressions
+
+Expressions in Jayvee are arbitrarily nested statements. They consist of:
+- literals (e.g., numbers `5` or strings `"Example"`)
+- variables (e.g., assigned by `from` properties in [Transforms](./transforms.md))
+- operators (e.g., `*` or `sqrt`)
+
+Expressions get evaluated at runtime by the interpreter to a [Built-in ValueType](./core-concepts.md#valuetypes).
+
+### Example
+
+The following expression is evaluated to the `integer` `10`: `(2 + 3) * 2`
+
+The following expression is evaluated to the `integer` `3`: `floor (3.14)`
+
+The following expression is evaluated to the `boolean` `true`: `"Example" == "Example"`
+
+### Further reading
+For a deeper documentation of how expressions and operators work internally, refer to the [developer docs](../dev/09-expressions-and-operators.md).

--- a/apps/docs/docs/user/expressions.md
+++ b/apps/docs/docs/user/expressions.md
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 Expressions in Jayvee are arbitrarily nested statements. They consist of:
 - literals (e.g., numbers `5` or strings `"Example"`)
-- variables (e.g., assigned by `from` properties in [Transforms](./transforms.md))
+- variables (e.g., declared by `from` properties in [Transforms](./transforms.md))
 - operators (e.g., `*` or `sqrt`)
 
 Expressions get evaluated at runtime by the interpreter to a [Built-in ValueType](./core-concepts.md#valuetypes).

--- a/apps/docs/docs/user/expressions.md.license
+++ b/apps/docs/docs/user/expressions.md.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/docs/docs/user/intro.md
+++ b/apps/docs/docs/user/intro.md
@@ -28,6 +28,12 @@ jv -h
 jv <file>
 ```
 
+Run with **additional debug output**:
+
+```console
+jv <file> -d
+```
+
 With runtime parameters:
 
 ```console

--- a/apps/docs/docs/user/transforms.md
+++ b/apps/docs/docs/user/transforms.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 # Transforms
 
 Transforms are a concept in Jayvee to define the transformation of individual values.
-They are similar to functions in programming languages, i.e. they perform computations on some input values and produce output values.
+They are similar to functions in programming languages, i.e. they perform computations on some input values and produce output values. Transform work by mapping input values to outputs using [expressions](./expressions.md).
 
 :::info Important
 
@@ -37,7 +37,7 @@ Next, they are given a name and, after the `oftype` keyword, typed with a valuet
 Below, there needs to be an output assignment for each output port.
 The output assignment defines how a particular output value is computed.
 They consist of the name of an output port, followed by a `:`.
-Next, an expression specifies how the output value shall be computed.
+Next, an [expression](./expressions.md) specifies how the output value shall be computed.
 Names of input ports can be used in such an expression to refer to input values.
 
 ### Example
@@ -50,6 +50,17 @@ transform CelsiusToKelvin {
   to tempKelvin oftype decimal;
 
   tempKelvin: tempCelsius + 273.15;
+}
+```
+
+The following transform converts a text based status into a boolean value, `true` if the text is `Active`, `false` for any other value:
+
+```jayvee
+transform StatusToBoolean {
+  from statusText oftype text;
+  to statusBoolean oftype boolean;
+
+  statusBoolean: statusText == "Active";
 }
 ```
 


### PR DESCRIPTION
Minor docs updates I noticed when working on sample solutions for AMSE/SAKI. If we ask students to use transforms (and with transforms also expressions), I'd like to have them documented more explicitly in the user docs.