### PR TITLE
Constraint example validation test

### DIFF
--- a/libs/language-server/src/lib/constraint/constraint-registry.ts
+++ b/libs/language-server/src/lib/constraint/constraint-registry.ts
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { ConstraintMetaInformation } from '../meta-information';
 import { registerMetaInformation } from '../meta-information/meta-inf-registry';
+import { ConstructorClass } from '../util';
 
 import { AllowlistConstraintMetaInformation } from './allowlist-constraint-meta-inf';
 import { DenylistConstraintMetaInformation } from './denylist-constraint-meta-inf';
@@ -10,10 +12,18 @@ import { LengthConstraintMetaInformation } from './length-constraint-meta-inf';
 import { RangeConstraintMetaInformation } from './range-constraint-meta-inf';
 import { RegexConstraintMetaInformation } from './regex-constraint-meta-inf';
 
+export function getConstraintMetaInf(): ConstructorClass<ConstraintMetaInformation>[] {
+  return [
+    AllowlistConstraintMetaInformation,
+    DenylistConstraintMetaInformation,
+    RegexConstraintMetaInformation,
+    LengthConstraintMetaInformation,
+    RangeConstraintMetaInformation,
+  ];
+}
+
 export function registerConstraints() {
-  registerMetaInformation(AllowlistConstraintMetaInformation);
-  registerMetaInformation(DenylistConstraintMetaInformation);
-  registerMetaInformation(RegexConstraintMetaInformation);
-  registerMetaInformation(LengthConstraintMetaInformation);
-  registerMetaInformation(RangeConstraintMetaInformation);
+  for (const metaInf of getConstraintMetaInf()) {
+    registerMetaInformation(metaInf);
+  }
 }

--- a/libs/language-server/src/lib/constraint/meta-inf-example-validation.spec.ts
+++ b/libs/language-server/src/lib/constraint/meta-inf-example-validation.spec.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { AstNode } from 'langium';
+import { NodeFileSystem } from 'langium/node';
+
+import { TestLangExtension } from '../../test/extension';
+import { ValidationResult, validationHelper } from '../../test/langium-utils';
+import { useExtension } from '../extension';
+import { JayveeServices, createJayveeServices } from '../jayvee-module';
+
+import { getConstraintMetaInf } from './constraint-registry';
+
+describe('Validation of builtin examples of ConstraintMetaInformation', () => {
+  let services: JayveeServices;
+  let validate: (input: string) => Promise<ValidationResult<AstNode>>;
+
+  beforeAll(() => {
+    // Register test extension
+    useExtension(new TestLangExtension());
+    // Create language services
+    services = createJayveeServices(NodeFileSystem).Jayvee;
+    // Create validation helper for language services
+    validate = validationHelper(services);
+  });
+
+  it.each(
+    getConstraintMetaInf().map((metaInfClass) => {
+      const metaInf = new metaInfClass();
+      return [metaInf.type, metaInf];
+    }),
+  )(
+    'should have no error on %s example validation',
+    async (type, constraintMetaInf) => {
+      for (const example of constraintMetaInf.docs.examples ?? []) {
+        const validationResult = await validate(example.code);
+        const diagnostics = validationResult.diagnostics;
+
+        expect(diagnostics).toHaveLength(0);
+      }
+    },
+  );
+});


### PR DESCRIPTION
This PR adds a test that validates the examples of all `ConstraintMetaInformation` that are part of the language-server.

Note: I had to add `getConstraintMetaInf()` inside `constraint-registry.ts` because the existing methods (like `getRegisteredConstraintMetaInformation`) did not work. The reason for that is that `it.each` gets resolved before `beforeAll`, but the population of the meta-inf-registry happens inside `beforeAll`.