### PR TITLE
Init standard library

### DIFF
--- a/libs/interpreter-lib/src/parsing-util.ts
+++ b/libs/interpreter-lib/src/parsing-util.ts
@@ -7,7 +7,10 @@ import * as path from 'path';
 
 import { Logger } from '@jvalue/jayvee-execution';
 import { AstNode, LangiumDocument, LangiumServices } from 'langium';
-import { DiagnosticSeverity } from 'vscode-languageserver-protocol';
+import {
+  DiagnosticSeverity,
+  WorkspaceFolder,
+} from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 
 export enum ExitCode {
@@ -39,6 +42,9 @@ export async function extractDocumentFromFile(
     services.shared.workspace.LangiumDocuments.getOrCreateDocument(
       URI.file(path.resolve(fileName)),
     );
+
+  await initializeWorkspace(services);
+
   return await validateDocument(document, services, logger);
 }
 
@@ -51,7 +57,21 @@ export async function extractDocumentFromString(
     modelString,
     URI.parse('memory://jayvee.document'),
   );
+
+  await initializeWorkspace(services);
+
   return await validateDocument(document, services, logger);
+}
+
+/**
+ * Initializes the workspace with all workspace folders.
+ * Also loads additional required files, e.g., the standard library
+ */
+async function initializeWorkspace(services: LangiumServices): Promise<void> {
+  const workspaceFolders: WorkspaceFolder[] = [];
+  await services.shared.workspace.WorkspaceManager.initializeWorkspace(
+    workspaceFolders,
+  );
 }
 
 export async function validateDocument(

--- a/libs/language-server/src/lib/builtin-library/jayvee-standard-library.ts
+++ b/libs/language-server/src/lib/builtin-library/jayvee-standard-library.ts
@@ -5,5 +5,8 @@
 export const STANDARD_LIBRARY_FILENAME = 'standard.jv';
 
 export const STANDARD_LIBRARY_SOURCECODE = `
-// TBD
-`.trimLeft();
+valuetype Percent oftype decimal {
+    constraints: [ZeroToHundredDecimal];
+}
+constraint ZeroToHundredDecimal on decimal: value >= 0 and value <= 100;
+`.trimStart();


### PR DESCRIPTION
Partially addresses #397 

## Execution

Executing with a  reference to `Percent` of the standard library works

## Navigation in VSCode

Clicking on a reference to `Percent` allows jumping to a read-only version of the `standard.jv`

![image](https://github.com/jvalue/jayvee/assets/28054628/53ff8b08-4c5a-4c82-8630-4a2c267f28a8)

## Further work (out of scope of this PR)

- auto-complete
- organize standard.jv in multiple jv files
