### PR TITLE
Builtin Valuetypes

### DIFF
--- a/apps/docs/docs/user/.gitignore
+++ b/apps/docs/docs/user/.gitignore
@@ -1,0 +1,1 @@
+builtin-valuetypes.md

--- a/apps/docs/docs/user/.gitignore
+++ b/apps/docs/docs/user/.gitignore
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 builtin-valuetypes.md

--- a/apps/docs/docs/user/constraint-types/_category_.json
+++ b/apps/docs/docs/user/constraint-types/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Constraint Types",
-  "position": 4,
+  "position": 5,
   "link": {
     "type": "generated-index",
     "description": "These constraints are shipped with Jayvee and are available right out of the box."

--- a/apps/docs/docs/user/core-concepts.md
+++ b/apps/docs/docs/user/core-concepts.md
@@ -81,55 +81,29 @@ In the example above, the `url` property of type `text` is defined by the corres
 A `ValueType` is the definition of a data type of the processed data.
 Some `Blocks` use `ValueTypes` to define logic (like filtering or assessing the data type in a data sink).
 We differentiate the following types of `ValueTypes`:
-- `Built-in ValueTypes` come with the basic version of Jayvee. See [Built-in Valuetypes](./builtin-valuetypes).
+- `Built-in ValueTypes` come with the basic version of Jayvee. See [Built-in Valuetypes](./valuetypes/builtin-valuetypes).
 - `Primitive ValueTypes` can be defined by the user to model domain-specific data types and represent a single value.
-  `Constraints` can be added to a `Primitive ValueType` (see [below](#constraints)).
+  `Constraints` can be added to a `Primitive ValueType`.
+See [Primitive Valuetypes](./valuetypes/primitive-valuetypes).
 - `Compound ValueTypes`: UPCOMING.
-
-### Constraints
-
-`Constraints` for `ValueTypes` declare the validity criteria that each concrete value is checked against.
-
-#### Syntax 1: Expression syntax
-
-The syntax of expression-based `Constraints` uses an expression that evaluates to `true` or `false` for the given `value`. The type of the values the expression is working in is indicated ofter the keyword `on`:
-
-```jayvee
-constraint GasFillLevelRange on decimal:
-    value >= 0 and value <= 100;
-```
-
-Refer to the [Expression documentation](./expressions.md) for further reading on expressions.
-
-
-#### Syntax 2: Block-like syntax
-
-The syntax of `Constraints` is similar to the syntax of `Blocks`.
-The availability of property keys and their respective `ValueTypes` is determined by the type of the `Constraint` - indicated by the identifier after the keyword `oftype`:
-
-```jayvee
-constraint GasFillLevelRange oftype RangeConstraint {
-    lowerBound: 0;
-    lowerBoundInclusive: true;
-    upperBound: 100;
-    upperBoundInclusive: true;
-}
-```
-
-Note that the type of `Constraint` also determines its applicability to `ValueTypes`.
-For instance, a `RangeConstraint` can only be applied to the numerical types `integer` and `decimal`.
-
-### Primitive ValueTypes
-
-`Primitive ValueTypes` are based on `Built-in ValueTypes` and use a collection of constraints to restrict the range of valid values.
-Such constraints are implicitly connected via a logical `AND` relation.
-Note that the `Constraints` need to be applicable to the base-type of the `ValueType` - indicated by the identifier after the keyword `oftype`:
 
 ```jayvee
 valuetype GasFillLevel oftype integer {
     constraints: [ GasFillLevelRange ];
 }
+
+constraint GasFillLevelRange on decimal:
+    value >= 0 and value <= 100;
 ```
 
-### Transforms
-`Transforms` are used to transform data from one `ValueType` to a different one. For more details, see [Transforms](./transforms.md)
+## Transforms
+`Transforms` are used to transform data from one `ValueType` to a different one. For more details, see [Transforms](./transforms.md).
+
+```jayvee
+transform CelsiusToKelvin {
+  from tempCelsius oftype decimal;
+  to tempKelvin oftype decimal;
+
+  tempKelvin: tempCelsius + 273.15;
+}
+```

--- a/apps/docs/docs/user/core-concepts.md
+++ b/apps/docs/docs/user/core-concepts.md
@@ -81,8 +81,7 @@ In the example above, the `url` property of type `text` is defined by the corres
 A `ValueType` is the definition of a data type of the processed data.
 Some `Blocks` use `ValueTypes` to define logic (like filtering or assessing the data type in a data sink).
 We differentiate the following types of `ValueTypes`:
-- `Built-in ValueTypes` come with the basic version of Jayvee.
-  Currently `text`, `decimal`, `integer`, and `boolean` are supported.
+- `Built-in ValueTypes` come with the basic version of Jayvee. See [Built-in Valuetypes](./builtin-valuetypes).
 - `Primitive ValueTypes` can be defined by the user to model domain-specific data types and represent a single value.
   `Constraints` can be added to a `Primitive ValueType` (see [below](#constraints)).
 - `Compound ValueTypes`: UPCOMING.

--- a/apps/docs/docs/user/expressions.md
+++ b/apps/docs/docs/user/expressions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Expressions
@@ -9,7 +9,7 @@ Expressions in Jayvee are arbitrarily nested statements. They consist of:
 - variables (e.g., declared by `from` properties in [Transforms](./transforms.md))
 - operators (e.g., `*` or `sqrt`)
 
-Expressions get evaluated at runtime by the interpreter to a [Built-in ValueType](./builtin-valuetypes).
+Expressions get evaluated at runtime by the interpreter to a [Built-in ValueType](./valuetypes/builtin-valuetypes).
 
 ### Example
 

--- a/apps/docs/docs/user/expressions.md
+++ b/apps/docs/docs/user/expressions.md
@@ -9,7 +9,7 @@ Expressions in Jayvee are arbitrarily nested statements. They consist of:
 - variables (e.g., declared by `from` properties in [Transforms](./transforms.md))
 - operators (e.g., `*` or `sqrt`)
 
-Expressions get evaluated at runtime by the interpreter to a [Built-in ValueType](./core-concepts.md#valuetypes).
+Expressions get evaluated at runtime by the interpreter to a [Built-in ValueType](./builtin-valuetypes).
 
 ### Example
 

--- a/apps/docs/docs/user/runtime-parameters.md
+++ b/apps/docs/docs/user/runtime-parameters.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 8
 ---
 
 # Runtime Parameters

--- a/apps/docs/docs/user/transforms.md
+++ b/apps/docs/docs/user/transforms.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 7
 ---
 
 # Transforms

--- a/apps/docs/docs/user/valuetypes/.gitignore
+++ b/apps/docs/docs/user/valuetypes/.gitignore
@@ -1,3 +1,5 @@
 # SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
 #
 # SPDX-License-Identifier: AGPL-3.0-only
+
+builtin-valuetypes.md

--- a/apps/docs/docs/user/valuetypes/_category_.json
+++ b/apps/docs/docs/user/valuetypes/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Valuetypes",
+  "position": 4,
+  "link": {
+    "type": "generated-index",
+    "description": "Jayvee supports these different kinds of valuetypes."
+  }
+}

--- a/apps/docs/docs/user/valuetypes/_category_.json.license
+++ b/apps/docs/docs/user/valuetypes/_category_.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/docs/docs/user/valuetypes/primitive-valuetypes.md
+++ b/apps/docs/docs/user/valuetypes/primitive-valuetypes.md
@@ -1,0 +1,48 @@
+---
+sidebar_position: 2
+---
+# Primitive ValueTypes
+
+`Primitive ValueTypes` are based on `Built-in ValueTypes` and use a collection of constraints to restrict the range of valid values.
+Such constraints are implicitly connected via a logical `AND` relation.
+Note that the `Constraints` need to be applicable to the base-type of the `ValueType` - indicated by the identifier after the keyword `oftype`:
+
+```jayvee
+valuetype GasFillLevel oftype integer {
+    constraints: [ GasFillLevelRange ];
+}
+```
+
+
+## Constraints
+
+`Constraints` for `ValueTypes` declare the validity criteria that each concrete value is checked against.
+
+### Syntax 1: Expression syntax
+
+The syntax of expression-based `Constraints` uses an expression that evaluates to `true` or `false` for the given `value`. The type of the values the expression is working in is indicated ofter the keyword `on`:
+
+```jayvee
+constraint GasFillLevelRange on decimal:
+    value >= 0 and value <= 100;
+```
+
+Refer to the [Expression documentation](../expressions.md) for further reading on expressions.
+
+
+### Syntax 2: Block-like syntax
+
+The syntax of `Constraints` is similar to the syntax of `Blocks`.
+The availability of property keys and their respective `ValueTypes` is determined by the type of the `Constraint` - indicated by the identifier after the keyword `oftype`:
+
+```jayvee
+constraint GasFillLevelRange oftype RangeConstraint {
+    lowerBound: 0;
+    lowerBoundInclusive: true;
+    upperBound: 100;
+    upperBoundInclusive: true;
+}
+```
+
+Note that the type of `Constraint` also determines its applicability to `ValueTypes`.
+For instance, a `RangeConstraint` can only be applied to the numerical types `integer` and `decimal`.

--- a/apps/docs/docs/user/valuetypes/primitive-valuetypes.md.license
+++ b/apps/docs/docs/user/valuetypes/primitive-valuetypes.md.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/docs/generator/src/main.ts
+++ b/apps/docs/generator/src/main.ts
@@ -7,6 +7,7 @@ import { join } from 'path';
 
 import { StdLangExtension } from '@jvalue/jayvee-extensions/std/lang';
 import {
+  PrimitiveValuetypes,
   getRegisteredBlockMetaInformation,
   getRegisteredConstraintMetaInformation,
   registerConstraints,
@@ -21,6 +22,7 @@ function main(): void {
   const rootPath = join(__dirname, '..', '..', '..', '..');
   generateBlockTypeDocs(rootPath);
   generateConstraintTypeDocs(rootPath);
+  generateValueTypeDocs(rootPath);
 }
 
 function generateBlockTypeDocs(rootPath: string): void {
@@ -67,6 +69,19 @@ function generateConstraintTypeDocs(rootPath: string): void {
     });
     console.info(`Generated file ${fileName}`);
   }
+}
+
+function generateValueTypeDocs(rootPath: string): void {
+  const docsPath = join(rootPath, 'apps', 'docs', 'docs', 'user');
+  const userDocBuilder = new UserDocGenerator();
+  const valueTypeDoc =
+    userDocBuilder.generateValueTypesDoc(PrimitiveValuetypes);
+
+  const fileName = `builtin-valuetypes.md`;
+  writeFileSync(join(docsPath, fileName), valueTypeDoc, {
+    flag: 'w',
+  });
+  console.info(`Generated file ${fileName}`);
 }
 
 main();

--- a/apps/docs/generator/src/main.ts
+++ b/apps/docs/generator/src/main.ts
@@ -72,7 +72,7 @@ function generateConstraintTypeDocs(rootPath: string): void {
 }
 
 function generateValueTypeDocs(rootPath: string): void {
-  const docsPath = join(rootPath, 'apps', 'docs', 'docs', 'user');
+  const docsPath = join(rootPath, 'apps', 'docs', 'docs', 'user', 'valuetypes');
   const userDocBuilder = new UserDocGenerator();
   const valueTypeDoc =
     userDocBuilder.generateValueTypesDoc(PrimitiveValuetypes);

--- a/apps/docs/generator/src/user-doc-generator.ts
+++ b/apps/docs/generator/src/user-doc-generator.ts
@@ -31,10 +31,10 @@ export class UserDocGenerator
       .generationComment()
       .description(
         `
-For an intro to valuetypes, see the [Core Concepts](./core-concepts).
+For an introduction to valuetypes, see the [Core Concepts](./core-concepts).
 Built-in valuetypes come with the basic version of Jayvee.
 They are the basis for more restricted \`Primitive Valuetypes\`
-that fullfil [Constrains](./core-concepts#constraints).`.trim(),
+that fullfil [Constraints](./core-concepts#constraints).`.trim(),
         1,
       )
       .heading('Available built-in valuetypes', 1);

--- a/apps/docs/generator/src/user-doc-generator.ts
+++ b/apps/docs/generator/src/user-doc-generator.ts
@@ -31,10 +31,10 @@ export class UserDocGenerator
       .generationComment()
       .description(
         `
-For an introduction to valuetypes, see the [Core Concepts](./core-concepts).
+For an introduction to valuetypes, see the [Core Concepts](../core-concepts).
 Built-in valuetypes come with the basic version of Jayvee.
-They are the basis for more restricted \`Primitive Valuetypes\`
-that fullfil [Constraints](./core-concepts#constraints).`.trim(),
+They are the basis for more restricted [Primitive Valuetypes](./primitive-valuetypes)
+that fullfil [Constraints](./primitive-valuetypes#constraints).`.trim(),
         1,
       )
       .heading('Available built-in valuetypes', 1);
@@ -71,6 +71,7 @@ block ExampleTableInterpreter oftype TableInterpreter {
 
     return builder.build();
   }
+
   generateBlockTypeDoc(metaInf: BlockMetaInformation): string {
     const builder = new UserDocMarkdownBuilder()
       .docTitle(metaInf.type)

--- a/apps/docs/generator/src/user-doc-generator.ts
+++ b/apps/docs/generator/src/user-doc-generator.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { strict as assert } from 'assert';
+
 import {
   BlockMetaInformation,
   ConstraintMetaInformation,
@@ -14,7 +16,6 @@ import {
   PrimitiveValuetype,
   PropertySpecification,
 } from '@jvalue/jayvee-language-server';
-import { strict as assert } from 'assert';
 
 export class UserDocGenerator
   implements
@@ -39,6 +40,7 @@ that fullfil [Constrains](./core-concepts#constraints).`.trim(),
       .heading('Available built-in valuetypes', 1);
 
     Object.entries(valueTypes)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .filter(([_, valueType]) => valueType.isUserExtendable())
       .forEach(([name, valueType]) => {
         assert(

--- a/apps/vs-code-extension/src/standard-library-file-system-provider.ts
+++ b/apps/vs-code-extension/src/standard-library-file-system-provider.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { PrimitiveValuetypes, StdLib } from '@jvalue/jayvee-language-server';
+import { StdLib } from '@jvalue/jayvee-language-server';
 import {
   EventEmitter,
   ExtensionContext,
@@ -23,7 +23,6 @@ export class StandardLibraryFileSystemProvider implements FileSystemProvider {
   onDidChangeFile = this.didChangeFile.event;
 
   constructor() {
-    this.registerBuiltinValuetypes();
     this.registerStdLib();
   }
 
@@ -34,26 +33,6 @@ export class StandardLibraryFileSystemProvider implements FileSystemProvider {
         Buffer.from(lib),
       );
     });
-  }
-
-  private registerBuiltinValuetypes() {
-    const builtinValuetypeDefinitions: string[] = [];
-    Object.values(PrimitiveValuetypes)
-      .filter((v) => v.isUserExtendable())
-      .forEach((valueType) => {
-        // TODO: filter the ones we support!
-        builtinValuetypeDefinitions.push(
-          `builtin valuetype ${valueType.getName()};`,
-        );
-      });
-
-    const joinedDocument = builtinValuetypeDefinitions.join('\n');
-    const libName = 'builtin:///stdlib/builtin-valuetypes.jv';
-
-    this.libraries.set(
-      Uri.parse(libName).toString(),
-      Buffer.from(joinedDocument),
-    );
   }
 
   static register(context: ExtensionContext) {

--- a/libs/interpreter-lib/src/parsing-util.ts
+++ b/libs/interpreter-lib/src/parsing-util.ts
@@ -6,11 +6,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { Logger } from '@jvalue/jayvee-execution';
+import { initializeWorkspace } from '@jvalue/jayvee-language-server';
 import { AstNode, LangiumDocument, LangiumServices } from 'langium';
-import {
-  DiagnosticSeverity,
-  WorkspaceFolder,
-} from 'vscode-languageserver-protocol';
+import { DiagnosticSeverity } from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 
 export enum ExitCode {
@@ -61,17 +59,6 @@ export async function extractDocumentFromString(
   await initializeWorkspace(services);
 
   return await validateDocument(document, services, logger);
-}
-
-/**
- * Initializes the workspace with all workspace folders.
- * Also loads additional required files, e.g., the standard library
- */
-async function initializeWorkspace(services: LangiumServices): Promise<void> {
-  const workspaceFolders: WorkspaceFolder[] = [];
-  await services.shared.workspace.WorkspaceManager.initializeWorkspace(
-    workspaceFolders,
-  );
 }
 
 export async function validateDocument(

--- a/libs/language-server/src/grammar/main.langium
+++ b/libs/language-server/src/grammar/main.langium
@@ -13,7 +13,7 @@ import './transform'
 entry JayveeModel:
   (
     pipelines+=PipelineDefinition
-    | valuetypes+=ValuetypeDefinition
+    | valuetypes+=(CustomValuetypeDefinition | BuiltinValuetypeDefinition)
     | constraints+=ConstraintDefinition
     | transforms+=TransformDefinition
   )*;
@@ -23,7 +23,7 @@ PipelineDefinition:
     (
       blocks+=BlockDefinition
       | pipes+=PipeDefinition
-      | valuetypes+=ValuetypeDefinition
+      | valuetypes+=CustomValuetypeDefinition
       | constraints+=ConstraintDefinition
       | transforms+=TransformDefinition
     )*

--- a/libs/language-server/src/grammar/valuetype.langium
+++ b/libs/language-server/src/grammar/valuetype.langium
@@ -5,7 +5,10 @@
 import './expression'
 import './terminal'
 
-ValuetypeDefinition:
+BuiltinValuetypeDefinition infers ValuetypeDefinition:
+  isBuiltin?='builtin' 'valuetype' name=ID ';';
+
+CustomValuetypeDefinition infers ValuetypeDefinition:
   'valuetype' name=ID 'oftype' type=ValuetypeReference '{'
     'constraints' ':' constraints=CollectionLiteral ';'
   '}';
@@ -17,17 +20,4 @@ ValuetypeAssignment:
   name=STRING 'oftype' type=ValuetypeReference;
 
 ValuetypeReference:
-  (PrimitiveValuetypeKeywordLiteral | ValuetypeDefinitionReference);
-
-// Workaround as cross-references cannot be mixed with other types
-ValuetypeDefinitionReference:
   reference=[ValuetypeDefinition];
-
-PrimitiveValuetypeKeywordLiteral:
-  keyword=PrimitiveValuetypeKeyword;
-
-PrimitiveValuetypeKeyword returns string:
-  'text'
-  | 'decimal'
-  | 'integer'
-  | 'boolean';

--- a/libs/language-server/src/lib/ast/value-definition.spec.ts
+++ b/libs/language-server/src/lib/ast/value-definition.spec.ts
@@ -1,0 +1,50 @@
+import { AstNode, LangiumDocument } from 'langium';
+import { NodeFileSystem } from 'langium/node';
+
+import { useExtension } from '..';
+import { TestLangExtension } from '../../test/extension';
+import { ParseHelperOptions, parseHelper } from '../../test/langium-utils';
+import { readJvTestAssetHelper } from '../../test/utils';
+import { createJayveeServices } from '../jayvee-module';
+
+describe('Parsing of ValuetypeDefinition', () => {
+  let parse: (
+    input: string,
+    options?: ParseHelperOptions,
+  ) => Promise<LangiumDocument<AstNode>>;
+
+  const readJvTestAsset = readJvTestAssetHelper(
+    __dirname,
+    '../../test/assets/',
+  );
+
+  beforeAll(() => {
+    useExtension(new TestLangExtension());
+    const services = createJayveeServices(NodeFileSystem).Jayvee;
+    parse = parseHelper(services);
+  });
+
+  it('should diagnose error on missing builtin keyword', async () => {
+    const text = readJvTestAsset(
+      'valuetype-definition/invalid-missing-builtin-keyword.jv',
+    );
+
+    const document = await parse(text);
+    expect(document.parseResult.parserErrors.length).toBeGreaterThanOrEqual(1);
+    expect(document.parseResult.parserErrors[0]?.message).toBe(
+      "Expecting token of type 'oftype' but found `;`.",
+    );
+  });
+
+  it('should diagnose error on unallowed body for builtin valuetypes', async () => {
+    const text = readJvTestAsset(
+      'valuetype-definition/invalid-unallowed-builtin-body.jv',
+    );
+
+    const document = await parse(text);
+    expect(document.parseResult.parserErrors.length).toBeGreaterThanOrEqual(1);
+    expect(document.parseResult.parserErrors[0]?.message).toBe(
+      "Expecting token of type ';' but found `{`.",
+    );
+  });
+});

--- a/libs/language-server/src/lib/ast/value-definition.spec.ts
+++ b/libs/language-server/src/lib/ast/value-definition.spec.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { AstNode, LangiumDocument } from 'langium';
 import { NodeFileSystem } from 'langium/node';
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/atomic-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/atomic-valuetype.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { strict as assert } from 'assert';
+
 // eslint-disable-next-line import/no-cycle
 import {
   EvaluationContext,
@@ -30,7 +32,9 @@ export class AtomicValuetype
   }
 
   getConstraints(context: EvaluationContext): ConstraintDefinition[] {
-    const constraintCollection = this.astNode.constraints;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const constraintCollection = this.astNode?.constraints;
+    assert(constraintCollection !== undefined);
     const constraintCollectionType = new CollectionValuetype(
       PrimitiveValuetypes.Constraint,
     );

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-valuetype.ts
@@ -26,6 +26,10 @@ class BooleanValuetypeImpl extends PrimitiveValuetype<boolean> {
   ): operandValue is boolean {
     return typeof operandValue === 'boolean';
   }
+
+  override isUserExtendable() {
+    return true;
+  }
 }
 
 // Only export instance to enforce singleton

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-valuetype.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
-import { PrimitiveValuetypeKeyword } from '../../../generated/ast';
 // eslint-disable-next-line import/no-cycle
 import { ValuetypeVisitor } from '../valuetype';
 
@@ -18,7 +17,7 @@ class BooleanValuetypeImpl extends PrimitiveValuetype<boolean> {
     return true;
   }
 
-  override getName(): PrimitiveValuetypeKeyword {
+  override getName(): 'boolean' {
     return 'boolean';
   }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-valuetype.ts
@@ -30,6 +30,13 @@ class BooleanValuetypeImpl extends PrimitiveValuetype<boolean> {
   override isUserExtendable() {
     return true;
   }
+
+  override getUserDoc(): string {
+    return `
+A boolean value.
+Examples: true, false
+`.trimStart();
+  }
 }
 
 // Only export instance to enforce singleton

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-valuetype.ts
@@ -35,7 +35,7 @@ class BooleanValuetypeImpl extends PrimitiveValuetype<boolean> {
     return `
 A boolean value.
 Examples: true, false
-`.trimStart();
+`.trim();
   }
 }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-valuetype.ts
@@ -26,6 +26,10 @@ class DecimalValuetypeImpl extends PrimitiveValuetype<number> {
   ): operandValue is number {
     return typeof operandValue === 'number' && Number.isFinite(operandValue);
   }
+
+  override isUserExtendable() {
+    return true;
+  }
 }
 
 // Only export instance to enforce singleton

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-valuetype.ts
@@ -30,6 +30,13 @@ class DecimalValuetypeImpl extends PrimitiveValuetype<number> {
   override isUserExtendable() {
     return true;
   }
+
+  override getUserDoc(): string {
+    return `
+A decimal value.
+Example: 3.14
+`.trimStart();
+  }
 }
 
 // Only export instance to enforce singleton

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-valuetype.ts
@@ -35,7 +35,7 @@ class DecimalValuetypeImpl extends PrimitiveValuetype<number> {
     return `
 A decimal value.
 Example: 3.14
-`.trimStart();
+`.trim();
   }
 }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-valuetype.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
-import { PrimitiveValuetypeKeyword } from '../../../generated/ast';
 // eslint-disable-next-line import/no-cycle
 import { ValuetypeVisitor } from '../valuetype';
 
@@ -18,7 +17,7 @@ class DecimalValuetypeImpl extends PrimitiveValuetype<number> {
     return true;
   }
 
-  override getName(): PrimitiveValuetypeKeyword {
+  override getName(): 'decimal' {
     return 'decimal';
   }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/integer-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/integer-valuetype.ts
@@ -40,7 +40,7 @@ class IntegerValuetypeImpl extends PrimitiveValuetype<number> {
     return `
 An integer value.
 Example: 3
-`.trimStart();
+`.trim();
   }
 }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/integer-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/integer-valuetype.ts
@@ -31,6 +31,10 @@ class IntegerValuetypeImpl extends PrimitiveValuetype<number> {
   ): operandValue is number {
     return typeof operandValue === 'number' && Number.isInteger(operandValue);
   }
+
+  override isUserExtendable() {
+    return true;
+  }
 }
 
 // Only export instance to enforce singleton

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/integer-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/integer-valuetype.ts
@@ -35,6 +35,13 @@ class IntegerValuetypeImpl extends PrimitiveValuetype<number> {
   override isUserExtendable() {
     return true;
   }
+
+  override getUserDoc(): string {
+    return `
+An integer value.
+Example: 3
+`.trimStart();
+  }
 }
 
 // Only export instance to enforce singleton

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/integer-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/integer-valuetype.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
-import { PrimitiveValuetypeKeyword } from '../../../generated/ast';
 // eslint-disable-next-line import/no-cycle
 import { Valuetype, ValuetypeVisitor } from '../valuetype';
 
@@ -23,7 +22,7 @@ class IntegerValuetypeImpl extends PrimitiveValuetype<number> {
     return true;
   }
 
-  override getName(): PrimitiveValuetypeKeyword {
+  override getName(): 'integer' {
     return 'integer';
   }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetype.ts
@@ -24,6 +24,13 @@ export abstract class PrimitiveValuetype<
   protected override doGetSupertype(): undefined {
     return undefined;
   }
+
+  /**
+   * Flag whether an atomic value type can be based on this primitive value type.
+   */
+  isUserExtendable(): boolean {
+    return false;
+  }
 }
 
 export function isPrimitiveValuetype(v: unknown): v is PrimitiveValuetype {

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetype.ts
@@ -31,6 +31,15 @@ export abstract class PrimitiveValuetype<
   isUserExtendable(): boolean {
     return false;
   }
+
+  /**
+   * The user documentation for the value type.
+   * Text only, no comment characters.
+   * Should be given for all user extendable value types @see isUserExtendable
+   */
+  getUserDoc(): string | undefined {
+    return undefined;
+  }
 }
 
 export function isPrimitiveValuetype(v: unknown): v is PrimitiveValuetype {

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetypes.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetypes.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { assertUnreachable } from 'langium';
-
-import { PrimitiveValuetypeKeywordLiteral } from '../../../generated/ast';
+import { ValuetypeReference } from '../../../generated/ast';
 
 // eslint-disable-next-line import/no-cycle
 import { Boolean, BooleanValuetype } from './boolean-valuetype';
@@ -52,16 +50,15 @@ export const PrimitiveValuetypes: {
 };
 
 export function createPrimitiveValuetype(
-  keywordLiteral: PrimitiveValuetypeKeywordLiteral,
+  builtinValuetypeReference: ValuetypeReference,
 ): PrimitiveValuetype | undefined {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const keyword = keywordLiteral?.keyword;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (keyword === undefined) {
+  const name = builtinValuetypeReference?.reference?.ref?.name;
+  if (name === undefined) {
     return undefined;
   }
 
-  switch (keyword) {
+  switch (name) {
     case 'boolean':
       return Boolean;
     case 'decimal':
@@ -71,6 +68,8 @@ export function createPrimitiveValuetype(
     case 'text':
       return Text;
     default:
-      assertUnreachable(keyword);
+      throw new Error(
+        `Found no PrimitiveValuetype for builtin valuetype "${name}"`,
+      );
   }
 }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetypes.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetypes.ts
@@ -51,13 +51,6 @@ export const PrimitiveValuetypes: {
   Transform: Transform,
 };
 
-export const BuiltinValuetypesLib = {
-  'builtin:///stdlib/builtin-valuetypes.jv': Object.values(PrimitiveValuetypes)
-    .filter((v) => v.isUserExtendable())
-    .map((valueType) => `builtin valuetype ${valueType.getName()};`)
-    .join('\n'),
-};
-
 export function createPrimitiveValuetype(
   builtinValuetype: ValuetypeDefinition,
 ): PrimitiveValuetype | undefined {

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetypes.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetypes.ts
@@ -51,6 +51,13 @@ export const PrimitiveValuetypes: {
   Transform: Transform,
 };
 
+export const BuiltinValuetypesLib = {
+  'builtin:///stdlib/builtin-valuetypes.jv': Object.values(PrimitiveValuetypes)
+    .filter((v) => v.isUserExtendable())
+    .map((valueType) => `builtin valuetype ${valueType.getName()};`)
+    .join('\n'),
+};
+
 export function createPrimitiveValuetype(
   builtinValuetype: ValuetypeDefinition,
 ): PrimitiveValuetype | undefined {

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetypes.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-valuetypes.ts
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { ValuetypeReference } from '../../../generated/ast';
+import { strict as assert } from 'assert';
+
+import { ValuetypeDefinition } from '../../../generated/ast';
 
 // eslint-disable-next-line import/no-cycle
 import { Boolean, BooleanValuetype } from './boolean-valuetype';
@@ -50,10 +52,11 @@ export const PrimitiveValuetypes: {
 };
 
 export function createPrimitiveValuetype(
-  builtinValuetypeReference: ValuetypeReference,
+  builtinValuetype: ValuetypeDefinition,
 ): PrimitiveValuetype | undefined {
+  assert(builtinValuetype.isBuiltin);
+  const name = builtinValuetype.name;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const name = builtinValuetypeReference?.reference?.ref?.name;
   if (name === undefined) {
     return undefined;
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-valuetype.ts
@@ -26,6 +26,10 @@ class TextValuetypeImpl extends PrimitiveValuetype<string> {
   ): operandValue is string {
     return typeof operandValue === 'string';
   }
+
+  override isUserExtendable() {
+    return true;
+  }
 }
 
 // Only export instance to enforce singleton

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-valuetype.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
-import { PrimitiveValuetypeKeyword } from '../../../generated/ast';
 // eslint-disable-next-line import/no-cycle
 import { ValuetypeVisitor } from '../valuetype';
 
@@ -18,7 +17,7 @@ class TextValuetypeImpl extends PrimitiveValuetype<string> {
     return true;
   }
 
-  override getName(): PrimitiveValuetypeKeyword {
+  override getName(): 'text' {
     return 'text';
   }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-valuetype.ts
@@ -30,6 +30,13 @@ class TextValuetypeImpl extends PrimitiveValuetype<string> {
   override isUserExtendable() {
     return true;
   }
+
+  override getUserDoc(): string {
+    return `
+A text value. 
+Example: "Hello World"
+`.trimStart();
+  }
 }
 
 // Only export instance to enforce singleton

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-valuetype.ts
@@ -35,7 +35,7 @@ class TextValuetypeImpl extends PrimitiveValuetype<string> {
     return `
 A text value. 
 Example: "Hello World"
-`.trimStart();
+`.trim();
   }
 }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/valuetype-util.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/valuetype-util.ts
@@ -7,9 +7,7 @@ import { assertUnreachable } from 'langium';
 import {
   ValuetypeDefinition,
   ValuetypeReference,
-  isPrimitiveValuetypeKeywordLiteral,
   isValuetypeDefinition,
-  isValuetypeDefinitionReference,
   isValuetypeReference,
 } from '../../generated/ast';
 
@@ -28,18 +26,16 @@ export function createValuetype(
   if (identifier === undefined) {
     return undefined;
   } else if (isValuetypeReference(identifier)) {
-    if (isPrimitiveValuetypeKeywordLiteral(identifier)) {
-      return createPrimitiveValuetype(identifier);
-    } else if (isValuetypeDefinitionReference(identifier)) {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      const referenced = identifier?.reference?.ref;
-      if (referenced === undefined) {
-        return undefined;
-      }
-
-      return new AtomicValuetype(referenced);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const valuetype = identifier?.reference?.ref;
+    if (valuetype === undefined) {
+      return undefined;
     }
-    assertUnreachable(identifier);
+
+    if (valuetype.isBuiltin) {
+      return createPrimitiveValuetype(identifier);
+    }
+    return new AtomicValuetype(valuetype);
   } else if (isValuetypeDefinition(identifier)) {
     return new AtomicValuetype(identifier);
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/valuetype-util.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/valuetype-util.ts
@@ -28,15 +28,11 @@ export function createValuetype(
   } else if (isValuetypeReference(identifier)) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const valuetype = identifier?.reference?.ref;
-    if (valuetype === undefined) {
-      return undefined;
-    }
-
-    if (valuetype.isBuiltin) {
+    return createValuetype(valuetype);
+  } else if (isValuetypeDefinition(identifier)) {
+    if (identifier.isBuiltin) {
       return createPrimitiveValuetype(identifier);
     }
-    return new AtomicValuetype(valuetype);
-  } else if (isValuetypeDefinition(identifier)) {
     return new AtomicValuetype(identifier);
   }
   assertUnreachable(identifier);

--- a/libs/language-server/src/lib/ast/wrappers/value-type/valuetype.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/valuetype.ts
@@ -3,10 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { type InternalValueRepresentation } from '../../expressions/internal-value-representation';
-import {
-  PrimitiveValuetypeKeywordLiteral,
-  ValuetypeDefinition,
-} from '../../generated/ast';
+import { ValuetypeDefinition } from '../../generated/ast';
 
 // eslint-disable-next-line import/no-cycle
 import { AtomicValuetype } from './atomic-valuetype';
@@ -24,9 +21,7 @@ import {
   type ValuetypeAssignmentValuetype,
 } from './primitive';
 
-export type ValuetypeAstNode =
-  | PrimitiveValuetypeKeywordLiteral
-  | ValuetypeDefinition;
+export type ValuetypeAstNode = ValuetypeDefinition;
 
 export interface VisitableValuetype {
   acceptVisitor(visitor: ValuetypeVisitor): void;

--- a/libs/language-server/src/lib/builtin-library/index.ts
+++ b/libs/language-server/src/lib/builtin-library/index.ts
@@ -2,5 +2,5 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+export { StdLib } from './stdlib';
 export * from './jayvee-workspace-manager';
-export { StdLib } from './generated/stdlib';

--- a/libs/language-server/src/lib/builtin-library/jayvee-workspace-manager.ts
+++ b/libs/language-server/src/lib/builtin-library/jayvee-workspace-manager.ts
@@ -12,9 +12,7 @@ import {
 import { WorkspaceFolder } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 
-import { PrimitiveValuetypes } from '../ast';
-
-import { StdLib } from './generated/stdlib';
+import { StdLib } from './stdlib';
 
 export class JayveeWorkspaceManager extends DefaultWorkspaceManager {
   private documentFactory: LangiumDocumentFactory;
@@ -29,30 +27,10 @@ export class JayveeWorkspaceManager extends DefaultWorkspaceManager {
     collector: (document: LangiumDocument) => void,
   ): Promise<void> {
     await super.loadAdditionalDocuments(folders, collector);
-    this.loadBuiltinValuetypes(collector);
 
     Object.entries(StdLib).forEach(([libName, libCode]) => {
       collector(this.documentFactory.fromString(libCode, URI.parse(libName)));
     });
-  }
-
-  private loadBuiltinValuetypes(
-    collector: (document: LangiumDocument) => void,
-  ) {
-    const builtinValuetypeDefinitions: string[] = [];
-    Object.values(PrimitiveValuetypes)
-      .filter((v) => v.isUserExtendable())
-      .forEach((valueType) => {
-        builtinValuetypeDefinitions.push(
-          `builtin valuetype ${valueType.getName()};`,
-        );
-      });
-
-    const joinedDocument = builtinValuetypeDefinitions.join('\n');
-    const libName = 'builtin:///stdlib/builtin-valuetypes.jv';
-    collector(
-      this.documentFactory.fromString(joinedDocument, URI.parse(libName)),
-    );
   }
 }
 

--- a/libs/language-server/src/lib/builtin-library/jayvee-workspace-manager.ts
+++ b/libs/language-server/src/lib/builtin-library/jayvee-workspace-manager.ts
@@ -12,6 +12,8 @@ import {
 import { WorkspaceFolder } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 
+import { PrimitiveValuetypes } from '../ast';
+
 import { StdLib } from './generated/stdlib';
 
 export class JayveeWorkspaceManager extends DefaultWorkspaceManager {
@@ -27,10 +29,30 @@ export class JayveeWorkspaceManager extends DefaultWorkspaceManager {
     collector: (document: LangiumDocument) => void,
   ): Promise<void> {
     await super.loadAdditionalDocuments(folders, collector);
+    this.loadBuiltinValuetypes(collector);
 
     Object.entries(StdLib).forEach(([libName, libCode]) => {
       collector(this.documentFactory.fromString(libCode, URI.parse(libName)));
     });
+  }
+
+  private loadBuiltinValuetypes(
+    collector: (document: LangiumDocument) => void,
+  ) {
+    const builtinValuetypeDefinitions: string[] = [];
+    Object.values(PrimitiveValuetypes)
+      .filter((v) => v.isUserExtendable())
+      .forEach((valueType) => {
+        builtinValuetypeDefinitions.push(
+          `builtin valuetype ${valueType.getName()};`,
+        );
+      });
+
+    const joinedDocument = builtinValuetypeDefinitions.join('\n');
+    const libName = 'builtin:///stdlib/builtin-valuetypes.jv';
+    collector(
+      this.documentFactory.fromString(joinedDocument, URI.parse(libName)),
+    );
   }
 }
 

--- a/libs/language-server/src/lib/builtin-library/jayvee-workspace-manager.ts
+++ b/libs/language-server/src/lib/builtin-library/jayvee-workspace-manager.ts
@@ -6,6 +6,7 @@ import {
   DefaultWorkspaceManager,
   LangiumDocument,
   LangiumDocumentFactory,
+  LangiumServices,
   LangiumSharedServices,
 } from 'langium';
 import { WorkspaceFolder } from 'vscode-languageserver';
@@ -31,4 +32,17 @@ export class JayveeWorkspaceManager extends DefaultWorkspaceManager {
       collector(this.documentFactory.fromString(libCode, URI.parse(libName)));
     });
   }
+}
+
+/**
+ * Initializes the workspace with all workspace folders.
+ * Also loads additional required files, e.g., the standard library
+ */
+export async function initializeWorkspace(
+  services: LangiumServices,
+): Promise<void> {
+  const workspaceFolders: WorkspaceFolder[] = [];
+  await services.shared.workspace.WorkspaceManager.initializeWorkspace(
+    workspaceFolders,
+  );
 }

--- a/libs/language-server/src/lib/builtin-library/stdlib.ts
+++ b/libs/language-server/src/lib/builtin-library/stdlib.ts
@@ -1,5 +1,12 @@
-import { BuiltinValuetypesLib } from '../ast/wrappers/value-type/primitive/primitive-valuetypes';
+import { PrimitiveValuetypes } from '../ast/wrappers/value-type/primitive/primitive-valuetypes';
 
-import { StdLib as PartialStdLib } from './generated/stdlib';
+import { PartialStdLib } from './generated/partial-stdlib';
+
+export const BuiltinValuetypesLib = {
+  'builtin:///stdlib/builtin-valuetypes.jv': Object.values(PrimitiveValuetypes)
+    .filter((v) => v.isUserExtendable())
+    .map((valueType) => `builtin valuetype ${valueType.getName()};`)
+    .join('\n'),
+};
 
 export const StdLib = { ...PartialStdLib, ...BuiltinValuetypesLib };

--- a/libs/language-server/src/lib/builtin-library/stdlib.ts
+++ b/libs/language-server/src/lib/builtin-library/stdlib.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import { PrimitiveValuetypes } from '../ast/wrappers/value-type/primitive/primitive-valuetypes';
 
 import { PartialStdLib } from './generated/partial-stdlib';

--- a/libs/language-server/src/lib/builtin-library/stdlib.ts
+++ b/libs/language-server/src/lib/builtin-library/stdlib.ts
@@ -5,8 +5,14 @@ import { PartialStdLib } from './generated/partial-stdlib';
 export const BuiltinValuetypesLib = {
   'builtin:///stdlib/builtin-valuetypes.jv': Object.values(PrimitiveValuetypes)
     .filter((v) => v.isUserExtendable())
-    .map((valueType) => `builtin valuetype ${valueType.getName()};`)
-    .join('\n'),
+    .map(
+      (valueType) =>
+        `${(valueType.getUserDoc()?.trim().split('\n') ?? [])
+          .map((t) => '// ' + t)
+          .join('\n')}
+builtin valuetype ${valueType.getName()};`,
+    )
+    .join('\n\n'),
 };
 
 export const StdLib = { ...PartialStdLib, ...BuiltinValuetypesLib };

--- a/libs/language-server/src/lib/builtin-library/stdlib.ts
+++ b/libs/language-server/src/lib/builtin-library/stdlib.ts
@@ -1,0 +1,5 @@
+import { BuiltinValuetypesLib } from '../ast/wrappers/value-type/primitive/primitive-valuetypes';
+
+import { StdLib as PartialStdLib } from './generated/stdlib';
+
+export const StdLib = { ...PartialStdLib, ...BuiltinValuetypesLib };

--- a/libs/language-server/src/lib/docs/jayvee-doc-generator.ts
+++ b/libs/language-server/src/lib/docs/jayvee-doc-generator.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { Valuetype } from '../ast/wrappers/value-type/valuetype';
 import { ConstraintMetaInformation } from '../meta-information';
 import { BlockMetaInformation } from '../meta-information/block-meta-inf';
 
@@ -11,6 +12,10 @@ export interface JayveeBlockTypeDocGenerator {
 
 export interface JayveeConstraintTypeDocGenerator {
   generateConstraintTypeDoc(metaInf: ConstraintMetaInformation): string;
+}
+
+export interface JayveeValueTypesDocGenerator {
+  generateValueTypesDoc(valueTypes: { [name: string]: Valuetype }): string;
 }
 
 export interface JayveePropertyDocGenerator {

--- a/libs/language-server/src/lib/validation/checks/jayvee-model.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/jayvee-model.spec.ts
@@ -106,6 +106,21 @@ describe('Validation of JayveeModel', () => {
     );
   });
 
+  it('should diagnose error on non unique valuetypes (naming collision with builtin)', async () => {
+    const text = readJvTestAsset(
+      'jayvee-model/invalid-duplicate-name-with-builtin-valuetype.jv',
+    );
+
+    await parseAndValidateJayveeModel(text);
+
+    expect(validationAcceptorMock).toHaveBeenCalledTimes(2);
+    expect(validationAcceptorMock).toHaveBeenCalledWith(
+      'error',
+      `The valuetypedefinition name "DuplicateValuetype" needs to be unique.`,
+      expect.any(Object),
+    );
+  });
+
   it('should diagnose error on non unique constraints', async () => {
     const text = readJvTestAsset(
       'jayvee-model/invalid-non-unique-constraints.jv',

--- a/libs/language-server/src/lib/validation/checks/transform-body.ts
+++ b/libs/language-server/src/lib/validation/checks/transform-body.ts
@@ -7,15 +7,11 @@
  */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
-import { assertUnreachable } from 'langium';
-
 import { EvaluationContext } from '../../ast/expressions/evaluation';
 import {
   TransformBody,
   TransformPortDefinition,
-  isPrimitiveValuetypeKeywordLiteral,
   isTransformPortDefinition,
-  isValuetypeDefinitionReference,
 } from '../../ast/generated/ast';
 import { ValidationContext } from '../validation-context';
 import { checkUniqueNames } from '../validation-util';
@@ -145,15 +141,10 @@ function checkAreInputsUsed(
 function isOutputPortComplete(
   portDefinition: TransformPortDefinition,
 ): boolean {
-  const valueType = portDefinition?.valueType;
+  const valueType = portDefinition?.valueType?.reference?.ref;
   if (valueType === undefined) {
     return false;
   }
 
-  if (isPrimitiveValuetypeKeywordLiteral(valueType)) {
-    return valueType?.keyword !== undefined;
-  } else if (isValuetypeDefinitionReference(valueType)) {
-    return valueType?.reference?.ref?.name !== undefined;
-  }
-  return assertUnreachable(valueType);
+  return valueType?.name !== undefined;
 }

--- a/libs/language-server/src/lib/validation/checks/valuetype-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/valuetype-definition.ts
@@ -48,6 +48,7 @@ function checkSupertypeCycle(
   const hasCycle =
     createValuetype(valuetypeDefinition)?.hasSupertypeCycle() ?? false;
   if (hasCycle) {
+    assert(!valuetypeDefinition.isBuiltin);
     context.accept(
       'error',
       'Could not construct this valuetype since there is a cycle in the (transitive) "oftype" relation.',

--- a/libs/language-server/src/stdlib/builtin-valuetypes.jv
+++ b/libs/language-server/src/stdlib/builtin-valuetypes.jv
@@ -1,0 +1,4 @@
+builtin valuetype text;
+builtin valuetype decimal;
+builtin valuetype integer;
+builtin valuetype boolean;

--- a/libs/language-server/src/stdlib/builtin-valuetypes.jv
+++ b/libs/language-server/src/stdlib/builtin-valuetypes.jv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 builtin valuetype text;
 builtin valuetype decimal;
 builtin valuetype integer;

--- a/libs/language-server/src/stdlib/builtin-valuetypes.jv
+++ b/libs/language-server/src/stdlib/builtin-valuetypes.jv
@@ -1,8 +1,0 @@
-// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
-//
-// SPDX-License-Identifier: AGPL-3.0-only
-
-builtin valuetype text;
-builtin valuetype decimal;
-builtin valuetype integer;
-builtin valuetype boolean;

--- a/libs/language-server/src/test/assets/jayvee-model/invalid-duplicate-name-with-builtin-valuetype.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/invalid-duplicate-name-with-builtin-valuetype.jv
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+valuetype DuplicateValuetype oftype text {
+	constraints: [
+		Constraint,
+	];
+}
+
+builtin valuetype DuplicateValuetype;

--- a/libs/language-server/src/test/assets/valuetype-definition/invalid-missing-builtin-keyword.jv
+++ b/libs/language-server/src/test/assets/valuetype-definition/invalid-missing-builtin-keyword.jv
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+valuetype ValueType;

--- a/libs/language-server/src/test/assets/valuetype-definition/invalid-unallowed-builtin-body.jv
+++ b/libs/language-server/src/test/assets/valuetype-definition/invalid-unallowed-builtin-body.jv
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+builtin valuetype ValueType {
+    constraints: [];
+};

--- a/libs/language-server/src/test/langium-utils.ts
+++ b/libs/language-server/src/test/langium-utils.ts
@@ -15,6 +15,8 @@ import {
 import { Diagnostic } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 
+import { initializeWorkspace } from '../lib/builtin-library/jayvee-workspace-manager';
+
 export interface ParseHelperOptions extends BuildOptions {
   documentUri?: string;
 }
@@ -39,6 +41,7 @@ export function parseHelper<T extends AstNode = AstNode>(
         uri,
       );
     services.shared.workspace.LangiumDocuments.addDocument(document);
+    await initializeWorkspace(services);
     await documentBuilder.build([document], options);
     return document;
   };

--- a/tools/scripts/language-server/generate-stdlib.mjs
+++ b/tools/scripts/language-server/generate-stdlib.mjs
@@ -10,7 +10,7 @@ import { join } from "path";
 const projectName = 'language-server';
 const stdLibInputPath = 'stdlib';
 const outputDirPath = join('lib', 'builtin-library', 'generated');
-const outputFilePath = join(outputDirPath, 'stdlib.ts');
+const outputFilePath = join(outputDirPath, 'partial-stdlib.ts');
 
 // Executing this script: node path/to/generate-stdlib.mjs
 console.log('Generating stdlib...');
@@ -33,7 +33,7 @@ const stdlibOutput = `/*********************************************************
 * DO NOT EDIT MANUALLY!
 ******************************************************************************/
 
-` + 'export const StdLib = ' + JSON.stringify(libsRecord, null, 2) + ';\n';
+` + 'export const PartialStdLib = ' + JSON.stringify(libsRecord, null, 2) + ';\n';
 if (!existsSync(outputDirPath)) {
     mkdirSync(outputDirPath, {recursive: true});
 }


### PR DESCRIPTION
Introduces `builtin valuetype`s to the language (replaces former keywords).

Not sure if we really need this, it was majorly for me learning on the job for the builtin blocks. However, users can now click on the builtin valuetypes like `text`, `decimal`, `integer`, and `boolean` and see their definition in VSCode. This would allow better in-code documentation as we can add comments on the behavior of the builting valuetypes in the standard library.

[Screencast from 07-21-2023 02:53:56 PM.webm](https://github.com/jvalue/jayvee/assets/28054628/317eb37e-7a62-402d-93ae-3744584b9e6b)

Let me know what you think! If you think it is useful I'd introduce some comments to the builtin valuetypes.
