### PR TITLE
Added CSVExtractor and GTFSExtractor to stdlib

### DIFF
--- a/libs/language-server/src/stdlib/CSVExtractor.jv
+++ b/libs/language-server/src/stdlib/CSVExtractor.jv
@@ -9,8 +9,8 @@ composite blocktype CSVExtractor {
     property enclosing oftype text: '';
     property enclosingEscape oftype text: '';
 
-    input inputName oftype None;
-    output outputName oftype Sheet;
+    input inputPort oftype None;
+    output outputPort oftype Sheet;
 
     block FileExtractor oftype HttpExtractor { url: url; }
     block FileTextInterpreter oftype TextFileInterpreter {}
@@ -21,9 +21,9 @@ composite blocktype CSVExtractor {
 		enclosingEscape: enclosingEscape;
 	}
 
-    inputName
+    inputPort
         ->FileExtractor
         ->FileTextInterpreter
         ->FileCSVInterpreter
-        ->outputName;
+        ->outputPort;
 }

--- a/libs/language-server/src/stdlib/CSVExtractor.jv
+++ b/libs/language-server/src/stdlib/CSVExtractor.jv
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// A CSVExtractor extracts a file from a given URL and interprets it as CSV
+composite blocktype CSVExtractor {
+    property url oftype text;
+    property delimiter oftype text: ',';
+    property enclosing oftype text: '';
+    property enclosingEscape oftype text: '';
+
+    input inputName oftype None;
+    output outputName oftype Sheet;
+
+    block FileExtractor oftype HttpExtractor { url: url; }
+    block FileTextInterpreter oftype TextFileInterpreter {}
+
+	block FileCSVInterpreter oftype CSVInterpreter {
+		delimiter: delimiter;
+		enclosing: enclosing;
+		enclosingEscape: enclosingEscape;
+	}
+
+    inputName
+        ->FileExtractor
+        ->FileTextInterpreter
+        ->FileCSVInterpreter
+        ->outputName;
+}

--- a/libs/language-server/src/stdlib/GTFSExtractor.jv
+++ b/libs/language-server/src/stdlib/GTFSExtractor.jv
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// A GTFSExtractor extracts a file from a given URL, interprets it as ZIP and extracts it
+composite blocktype GTFSExtractor {
+    property url oftype text;
+
+    input inputName oftype None;
+    output outputName oftype FileSystem;
+
+    block FileExtractor oftype HttpExtractor { url: url; }
+
+	block ZipArchiveInterpreter oftype ArchiveInterpreter { archiveType: "zip"; }
+
+    inputName
+        ->FileExtractor
+        ->ZipArchiveInterpreter
+        ->outputName;
+}

--- a/libs/language-server/src/stdlib/GTFSExtractor.jv
+++ b/libs/language-server/src/stdlib/GTFSExtractor.jv
@@ -6,15 +6,15 @@
 composite blocktype GTFSExtractor {
     property url oftype text;
 
-    input inputName oftype None;
-    output outputName oftype FileSystem;
+    input inputPort oftype None;
+    output outputPort oftype FileSystem;
 
     block FileExtractor oftype HttpExtractor { url: url; }
 
 	block ZipArchiveInterpreter oftype ArchiveInterpreter { archiveType: "zip"; }
 
-    inputName
+    inputPort
         ->FileExtractor
         ->ZipArchiveInterpreter
-        ->outputName;
+        ->outputPort;
 }


### PR DESCRIPTION
This PR adds a CSVExtractor and a GTFSExtractor to the stdlib. However, they are not part of the autocomplete suggestions of the VSCode extension. The same is true for the Percentage valuetype though so I assume this is as expected for now, right @georg-schwarz ?

Part of #217