### PR TITLE
Document Constraint Types in Code

### DIFF
--- a/apps/vs-code-extension/src/standard-library-file-system-provider.ts
+++ b/apps/vs-code-extension/src/standard-library-file-system-provider.ts
@@ -5,6 +5,7 @@
 import { StdLangExtension } from '@jvalue/jayvee-extensions/std/lang';
 import {
   getStdLib,
+  registerConstraints,
   useExtension as useLangExtension,
 } from '@jvalue/jayvee-language-server';
 import {
@@ -34,6 +35,7 @@ export class StandardLibraryFileSystemProvider implements FileSystemProvider {
     // The VSCode Extension needs to register the StdLangExtension,
     // otherwise the StdLib does not include the blocktype definitions.
     useLangExtension(new StdLangExtension());
+    registerConstraints();
 
     Object.entries(getStdLib()).forEach(([libName, lib]) => {
       this.libraries.set(

--- a/libs/execution/src/lib/constraints/constraint-executor-registry.ts
+++ b/libs/execution/src/lib/constraints/constraint-executor-registry.ts
@@ -46,7 +46,8 @@ export function createConstraintExecutor(
   constraint: ConstraintDefinition,
 ): ConstraintExecutor {
   if (isTypedConstraintDefinition(constraint)) {
-    const constraintType = constraint.type.name;
+    const constraintType = constraint.type.ref?.name;
+    assert(constraintType !== undefined);
     const constraintExecutor = constraintExecutorRegistry.get(constraintType);
     assert(
       constraintExecutor !== undefined,

--- a/libs/execution/src/lib/constraints/constraint-executor-registry.ts
+++ b/libs/execution/src/lib/constraints/constraint-executor-registry.ts
@@ -47,7 +47,10 @@ export function createConstraintExecutor(
 ): ConstraintExecutor {
   if (isTypedConstraintDefinition(constraint)) {
     const constraintType = constraint.type.ref?.name;
-    assert(constraintType !== undefined);
+    assert(
+      constraintType !== undefined,
+      `Could not resolve reference to constraint type of ${constraint.name}`,
+    );
     const constraintExecutor = constraintExecutorRegistry.get(constraintType);
     assert(
       constraintExecutor !== undefined,

--- a/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.ts
+++ b/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
-  ConstraintTypeLiteral,
+  BuiltinConstrainttypeDefinition,
   EvaluationContext,
   PropertyBody,
   ReferenceableBlocktypeDefinition,
@@ -63,7 +63,7 @@ function checkRuntimeParameterValueParsing(
   const enclosingPropertyBody = getEnclosingPropertyBody(runtimeParameter);
   const type:
     | Reference<ReferenceableBlocktypeDefinition>
-    | ConstraintTypeLiteral
+    | Reference<BuiltinConstrainttypeDefinition>
     | undefined =
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     enclosingPropertyBody.$container?.type;

--- a/libs/language-server/src/grammar/constraint.langium
+++ b/libs/language-server/src/grammar/constraint.langium
@@ -11,12 +11,15 @@ ConstraintDefinition:
   TypedConstraintDefinition | ExpressionConstraintDefinition;
 
 TypedConstraintDefinition:
-  'constraint' name=ID 'oftype' type=ConstraintTypeLiteral body=PropertyBody;
+  'constraint' name=ID 'oftype' type=[BuiltinConstrainttypeDefinition] body=PropertyBody;
 
 ExpressionConstraintDefinition:
   'constraint' name=ID 'on' valuetype=ValuetypeReference ':' expression=Expression ';';
 
+BuiltinConstrainttypeDefinition:
+  'builtin' 'constrainttype' name=ID '{'
+    (properties+=ConstrainttypeProperty)*
+'}';
 
-ConstraintTypeLiteral:
-  name=ID;
-
+ConstrainttypeProperty:
+    'property' name=ID 'oftype' valueType=ValuetypeReference (':' defaultValue=Expression)? ';';

--- a/libs/language-server/src/grammar/main.langium
+++ b/libs/language-server/src/grammar/main.langium
@@ -19,6 +19,7 @@ entry JayveeModel:
     | constraints+=ConstraintDefinition
     | transforms+=TransformDefinition
     | blocktypes+=ReferenceableBlocktypeDefinition
+    | constrainttypes+=BuiltinConstrainttypeDefinition
     | iotypes+=IotypeDefinition
   )*;
 

--- a/libs/language-server/src/grammar/terminal.langium
+++ b/libs/language-server/src/grammar/terminal.langium
@@ -13,7 +13,8 @@ terminal INTEGER returns number: /[0-9]+/;
 
 terminal STRING: /"[^"]*"|'[^']*'/;
 
-hidden terminal SINGLE_LINE_COMMENT: /\/\/[^\n\r]*/;
+hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;
+hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 
 terminal REGEX: /\/.+\//;
 

--- a/libs/language-server/src/lib/ast/expressions/internal-value-representation.ts
+++ b/libs/language-server/src/lib/ast/expressions/internal-value-representation.ts
@@ -52,6 +52,16 @@ export function internalValueToString(
     return String(valueRepresentation);
   }
   if (typeof valueRepresentation === 'number') {
+    if (valueRepresentation === Number.POSITIVE_INFINITY) {
+      return Number.MAX_VALUE.toLocaleString('fullwide', {
+        useGrouping: false,
+      });
+    }
+    if (valueRepresentation === Number.NEGATIVE_INFINITY) {
+      return Number.MIN_VALUE.toLocaleString('fullwide', {
+        useGrouping: false,
+      });
+    }
     return `${valueRepresentation}`;
   }
   if (typeof valueRepresentation === 'string') {

--- a/libs/language-server/src/lib/completion/jayvee-completion-provider.ts
+++ b/libs/language-server/src/lib/completion/jayvee-completion-provider.ts
@@ -20,13 +20,11 @@ import { createValuetype } from '../ast';
 import {
   BlockDefinition,
   ConstraintDefinition,
-  ConstraintTypeLiteral,
   PropertyAssignment,
   PropertyBody,
   ValuetypeReference,
   isBlockDefinition,
   isConstraintDefinition,
-  isConstraintTypeLiteral,
   isJayveeModel,
   isPropertyAssignment,
   isPropertyBody,
@@ -63,8 +61,7 @@ export class JayveeCompletionProvider extends DefaultCompletionProvider {
       }
 
       const isConstraintTypeCompletion =
-        (isConstraintDefinition(astNode) || isConstraintTypeLiteral(astNode)) &&
-        next.type === ConstraintTypeLiteral;
+        isConstraintDefinition(astNode) && next.property === 'type';
       if (isConstraintTypeCompletion) {
         return this.completionForConstraintType(acceptor);
       }

--- a/libs/language-server/src/lib/hover/jayvee-hover-provider.ts
+++ b/libs/language-server/src/lib/hover/jayvee-hover-provider.ts
@@ -7,10 +7,10 @@ import { Hover } from 'vscode-languageserver-protocol';
 
 import {
   BuiltinBlocktypeDefinition,
-  ConstraintTypeLiteral,
+  BuiltinConstrainttypeDefinition,
   PropertyAssignment,
   isBuiltinBlocktypeDefinition,
-  isConstraintTypeLiteral,
+  isBuiltinConstrainttypeDefinition,
   isPropertyAssignment,
 } from '../ast';
 import { LspDocGenerator } from '../docs/lsp-doc-generator';
@@ -24,7 +24,7 @@ export class JayveeHoverProvider extends AstNodeHoverProvider {
     if (isBuiltinBlocktypeDefinition(astNode)) {
       doc = this.getBlockTypeMarkdownDoc(astNode);
     }
-    if (isConstraintTypeLiteral(astNode)) {
+    if (isBuiltinConstrainttypeDefinition(astNode)) {
       doc = this.getConstraintTypeMarkdownDoc(astNode);
     }
     if (isPropertyAssignment(astNode)) {
@@ -56,7 +56,7 @@ export class JayveeHoverProvider extends AstNodeHoverProvider {
   }
 
   private getConstraintTypeMarkdownDoc(
-    constraintType: ConstraintTypeLiteral,
+    constraintType: BuiltinConstrainttypeDefinition,
   ): string | undefined {
     const constraintMetaInf = getMetaInformation(constraintType);
     if (constraintMetaInf === undefined) {

--- a/libs/language-server/src/lib/meta-information/meta-inf-registry.ts
+++ b/libs/language-server/src/lib/meta-information/meta-inf-registry.ts
@@ -8,10 +8,10 @@ import { Reference, isReference } from 'langium';
 import { assertUnreachable } from 'langium/lib/utils/errors';
 
 import {
-  ConstraintTypeLiteral,
+  BuiltinConstrainttypeDefinition,
   ReferenceableBlocktypeDefinition,
+  isBuiltinConstrainttypeDefinition,
   isCompositeBlocktypeDefinition,
-  isConstraintTypeLiteral,
   isReferenceableBlocktypeDefinition,
 } from '../ast/generated/ast';
 import { ConstructorClass } from '../util/constructor-class';
@@ -39,20 +39,25 @@ export function getMetaInformation(
     | undefined,
 ): BlockMetaInformation | undefined;
 export function getMetaInformation(
-  type: ConstraintTypeLiteral | undefined,
+  type:
+    | BuiltinConstrainttypeDefinition
+    | Reference<BuiltinConstrainttypeDefinition>
+    | undefined,
 ): ConstraintMetaInformation | undefined;
 export function getMetaInformation(
   type:
     | ReferenceableBlocktypeDefinition
     | Reference<ReferenceableBlocktypeDefinition>
-    | ConstraintTypeLiteral
+    | BuiltinConstrainttypeDefinition
+    | Reference<BuiltinConstrainttypeDefinition>
     | undefined,
 ): MetaInformation | undefined;
 export function getMetaInformation(
   type:
     | ReferenceableBlocktypeDefinition
     | Reference<ReferenceableBlocktypeDefinition>
-    | ConstraintTypeLiteral
+    | BuiltinConstrainttypeDefinition
+    | Reference<BuiltinConstrainttypeDefinition>
     | undefined,
 ): BlockMetaInformation | ConstraintMetaInformation | undefined {
   const dereferencedType = isReference(type) ? type.ref : type;
@@ -80,7 +85,7 @@ export function getMetaInformation(
     assert(metaInf instanceof BlockMetaInformation);
     return metaInf;
   }
-  if (isConstraintTypeLiteral(dereferencedType)) {
+  if (isBuiltinConstrainttypeDefinition(dereferencedType)) {
     assert(metaInf instanceof ConstraintMetaInformation);
     return metaInf;
   }
@@ -109,13 +114,16 @@ export function getOrFailMetaInformation(
     | Reference<ReferenceableBlocktypeDefinition>,
 ): BlockMetaInformation;
 export function getOrFailMetaInformation(
-  type: ConstraintTypeLiteral,
+  type:
+    | BuiltinConstrainttypeDefinition
+    | Reference<BuiltinConstrainttypeDefinition>,
 ): ConstraintMetaInformation;
 export function getOrFailMetaInformation(
   type:
     | ReferenceableBlocktypeDefinition
     | Reference<ReferenceableBlocktypeDefinition>
-    | ConstraintTypeLiteral,
+    | BuiltinConstrainttypeDefinition
+    | Reference<BuiltinConstrainttypeDefinition>,
 ): MetaInformation {
   const result = getMetaInformation(type);
   const typeName =

--- a/libs/language-server/src/lib/validation/checks/typed-constraint-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/typed-constraint-definition.ts
@@ -31,7 +31,7 @@ function checkConstraintType(
   if (metaInf === undefined) {
     context.accept(
       'error',
-      `Unknown constraint type '${constraintType.name ?? ''}'`,
+      `Unknown constraint type '${constraintType.$refText ?? ''}'`,
       {
         node: constraint,
         property: 'type',

--- a/libs/language-server/src/lib/validation/checks/valuetype-reference.ts
+++ b/libs/language-server/src/lib/validation/checks/valuetype-reference.ts
@@ -6,6 +6,7 @@ import { createValuetype } from '../../ast';
 import {
   ValuetypeReference,
   isBuiltinBlocktypeDefinition,
+  isBuiltinConstrainttypeDefinition,
 } from '../../ast/generated/ast';
 import { ValidationContext } from '../validation-context';
 
@@ -53,10 +54,10 @@ function checkIsValuetypeReferenceable(
     return;
   }
 
-  const isUsedInBuiltinBlocktype = isBuiltinBlocktypeDefinition(
-    valuetypeRef.$container.$container,
-  );
-  if (isUsedInBuiltinBlocktype) {
+  const isUsedInBuiltinDefinition =
+    isBuiltinBlocktypeDefinition(valuetypeRef.$container.$container) ||
+    isBuiltinConstrainttypeDefinition(valuetypeRef.$container.$container);
+  if (isUsedInBuiltinDefinition) {
     return;
   }
 


### PR DESCRIPTION
This mechanism is similar to the current jv code generation to self-document blocktypes.

Exerpt:
![image](https://github.com/jvalue/jayvee/assets/28054628/85a256ab-c719-438d-bec1-c924a78fcf11)

I noticed some issue with Jayvee having no concept for INFINITY. Still, I'd vote to integrate this feature nevertheless.
![image](https://github.com/jvalue/jayvee/assets/28054628/6684fec8-9ed6-47ba-a095-05c1c20e9aa0)
