### PR TITLE
Fixed `process.exit` not exiting tested method

### DIFF
--- a/apps/interpreter/src/examples-smoke-test.spec.ts
+++ b/apps/interpreter/src/examples-smoke-test.spec.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import {
   clearBlockExecutorRegistry,
   clearConstraintExecutorRegistry,
+  processExitMockImplementation,
 } from '@jvalue/jayvee-execution/test';
 import {
   PostgresLoaderExecutorMock,
@@ -53,14 +54,14 @@ describe('jv example smoke tests', () => {
   beforeAll(() => {
     exitSpy = jest
       .spyOn(process, 'exit')
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      .mockImplementation((code?: number) => undefined as never);
+      .mockImplementation(processExitMockImplementation);
     httpExtractorMock = new HttpExtractorExecutorMock();
     postgresLoaderMock = new PostgresLoaderExecutorMock();
     sqliteLoaderMock = new SQLiteLoaderExecutorMock();
   });
 
   afterEach(() => {
+    exitSpy.mockClear();
     httpExtractorMock.restore();
     postgresLoaderMock.restore();
     sqliteLoaderMock.restore();

--- a/libs/execution/test/utils.ts
+++ b/libs/execution/test/utils.ts
@@ -28,6 +28,13 @@ export function clearConstraintExecutorRegistry() {
   constraintExecutorRegistry.clear();
 }
 
+export function processExitMockImplementation(code?: number) {
+  if (code === undefined || code === 0) {
+    return undefined as never;
+  }
+  throw new Error(`process.exit: ${code}`);
+}
+
 export function getTestExecutionContext(
   locator: AstNodeLocator,
   document: LangiumDocument<AstNode>,


### PR DESCRIPTION
Fixed tests that stub `process.exit` to exit the tested method while not exiting test altogether.