### PR TITLE
Infinity number parsing fix

### DIFF
--- a/libs/extensions/std/exec/src/text-range-selector-executor.ts
+++ b/libs/extensions/std/exec/src/text-range-selector-executor.ts
@@ -41,7 +41,7 @@ export class TextRangeSelectorExecutor extends AbstractBlockExecutor<
 
     context.logger.logDebug(
       `Selecting lines from ${lineFrom} to ${
-        lineTo === Number.POSITIVE_INFINITY || lineTo >= numberOfLines
+        lineTo === Number.MAX_SAFE_INTEGER || lineTo >= numberOfLines
           ? 'the end'
           : `${lineTo}`
       }`,

--- a/libs/extensions/std/lang/src/text-range-selector-meta-inf.ts
+++ b/libs/extensions/std/lang/src/text-range-selector-meta-inf.ts
@@ -24,7 +24,7 @@ export class TextRangeSelectorMetaInformation extends BlockMetaInformation {
         },
         lineTo: {
           type: PrimitiveValuetypes.Integer,
-          defaultValue: Number.POSITIVE_INFINITY,
+          defaultValue: Number.MAX_SAFE_INTEGER,
           validation: greaterThanZeroValidation,
         },
       },

--- a/libs/language-server/src/lib/ast/wrappers/cell-range-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/cell-range-wrapper.ts
@@ -28,7 +28,7 @@ import {
   columnIndexAsCharacters,
 } from './util/column-id-util';
 
-export const LAST_INDEX = Number.POSITIVE_INFINITY;
+export const LAST_INDEX = Number.MAX_SAFE_INTEGER;
 
 export class CellIndex {
   constructor(

--- a/libs/language-server/src/lib/constraint/length-constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/constraint/length-constraint-meta-inf.ts
@@ -23,7 +23,7 @@ export class LengthConstraintMetaInformation extends ConstraintMetaInformation {
         },
         maxLength: {
           type: PrimitiveValuetypes.Integer,
-          defaultValue: Number.POSITIVE_INFINITY,
+          defaultValue: Number.MAX_SAFE_INTEGER,
           validation: nonNegativeValidation,
         },
       },

--- a/libs/language-server/src/lib/constraint/range-constraint-meta-inf.ts
+++ b/libs/language-server/src/lib/constraint/range-constraint-meta-inf.ts
@@ -13,7 +13,7 @@ export class RangeConstraintMetaInformation extends ConstraintMetaInformation {
       {
         lowerBound: {
           type: PrimitiveValuetypes.Decimal,
-          defaultValue: Number.NEGATIVE_INFINITY,
+          defaultValue: Number.MIN_SAFE_INTEGER,
         },
         lowerBoundInclusive: {
           type: PrimitiveValuetypes.Boolean,
@@ -21,7 +21,7 @@ export class RangeConstraintMetaInformation extends ConstraintMetaInformation {
         },
         upperBound: {
           type: PrimitiveValuetypes.Decimal,
-          defaultValue: Number.POSITIVE_INFINITY,
+          defaultValue: Number.MAX_SAFE_INTEGER,
         },
         upperBoundInclusive: {
           type: PrimitiveValuetypes.Boolean,


### PR DESCRIPTION
Replaced Number.POSITIVE_INFINITY and Number.NEGATIVE_INFINITY with Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER due to `Number.isInteger(Number.POSITIVE_INFINITY)` returning `false`