### PR TITLE
Builtin blocktype definition bug fixes

### DIFF
--- a/libs/interpreter-lib/src/parsing-util.spec.ts
+++ b/libs/interpreter-lib/src/parsing-util.spec.ts
@@ -54,7 +54,10 @@ describe('Validation of parsing-util', () => {
 
     await initializeWorkspace(services, [
       {
-        uri: process.cwd(),
+        uri: path.resolve(
+          __dirname,
+          '../test/assets/parsing-util/test-extension',
+        ),
         name: 'TestBlockTypes.jv',
       },
     ]);

--- a/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.spec.ts
+++ b/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.spec.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import * as path from 'path';
+
 import { parseValueToInternalRepresentation } from '@jvalue/jayvee-execution';
 import {
   EvaluationContext,
@@ -71,7 +73,10 @@ describe('Validation of validateRuntimeParameterLiteral', () => {
 
     await initializeWorkspace(services, [
       {
-        uri: process.cwd(),
+        uri: path.resolve(
+          __dirname,
+          '../../test/assets/runtime-parameter-literal/test-extension',
+        ),
         name: 'TestBlockTypes.jv',
       },
     ]);

--- a/libs/interpreter-lib/test/assets/parsing-util/validateDocument/valid-simplify-warning.jv
+++ b/libs/interpreter-lib/test/assets/parsing-util/validateDocument/valid-simplify-warning.jv
@@ -17,3 +17,16 @@ pipeline TestPipeline {
 
   TestExtractor -> TestPropertyBlock -> TestLoader;
 }
+
+builtin blocktype TestProperty {
+  input inPort oftype File;
+  output outPort oftype Table;
+
+  property integerProperty oftype integer: 0;
+  property decimalProperty oftype integer: 0.0;
+  property textProperty oftype text;
+  property booleanProperty oftype boolean: false;
+  property regexProperty oftype Regex: /\r?\n/;
+  property textCollectionProperty oftype Collection<text>: [];
+  property valuetypeAssignmentProperty oftype ValuetypeAssignment: "test" oftype text;
+}

--- a/libs/interpreter-lib/test/assets/runtime-parameter-literal/test-extension/TestBlockTypes.jv
+++ b/libs/interpreter-lib/test/assets/runtime-parameter-literal/test-extension/TestBlockTypes.jv
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+builtin blocktype TestProperty {
+  input inPort oftype File;
+  output outPort oftype Table;
+
+  property integerProperty oftype integer: 0;
+  property decimalProperty oftype integer: 0.0;
+  property textProperty oftype text;
+  property booleanProperty oftype boolean: false;
+  property regexProperty oftype Regex: /\r?\n/;
+  property textCollectionProperty oftype Collection<text>: [];
+  property valuetypeAssignmentProperty oftype ValuetypeAssignment: "test" oftype text;
+}

--- a/libs/language-server/src/lib/validation/checks/blocktype-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/blocktype-definition.ts
@@ -190,8 +190,7 @@ function checkPropertyDefaultValuesHasCorrectType(
     return;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  const expectedValuetype = createValuetype(property.valueType?.reference?.ref);
+  const expectedValuetype = createValuetype(property.valueType);
   assert(expectedValuetype !== undefined);
 
   if (!expectedValuetype.isInternalValueRepresentation(evaluatedExpression)) {


### PR DESCRIPTION
This PR fixes a few issues with the builtin blocktype definitions:
- [libs/language-server/src/lib/validation/checks/blocktype-definition.ts:](https://github.com/jvalue/jayvee/blob/128ffac73c5449f8752ea69e0826b7b7ea447813/libs/language-server/src/lib/validation/checks/blocktype-definition.ts) Fixed `checkPropertyDefaultValuesHasCorrectType` wrongly passing valuetype reference to `createValuetype` instead of valuetype itself
- Replaced `process.cwd()` with `path.resolve(__dirname, )` to make tests independant of working directory
- Added missing test blocktype definitions