### PR TITLE
LoadTestExtensions utils function

### DIFF
--- a/libs/interpreter-lib/src/parsing-util.spec.ts
+++ b/libs/interpreter-lib/src/parsing-util.spec.ts
@@ -8,11 +8,11 @@ import { CachedLogger } from '@jvalue/jayvee-execution';
 import {
   JayveeServices,
   createJayveeServices,
-  initializeWorkspace,
 } from '@jvalue/jayvee-language-server';
 import {
   ParseHelperOptions,
   expectNoParserAndLexerErrors,
+  loadTestExtensions,
   parseHelper,
   readJvTestAssetHelper,
 } from '@jvalue/jayvee-language-server/test';
@@ -52,14 +52,11 @@ describe('Validation of parsing-util', () => {
     // Create language services
     services = createJayveeServices(NodeFileSystem).Jayvee;
 
-    await initializeWorkspace(services, [
-      {
-        uri: path.resolve(
-          __dirname,
-          '../test/assets/parsing-util/test-extension',
-        ),
-        name: 'TestBlockTypes.jv',
-      },
+    await loadTestExtensions(services, [
+      path.resolve(
+        __dirname,
+        '../test/assets/parsing-util/test-extension/TestBlockTypes.jv',
+      ),
     ]);
 
     // Parse function for Jayvee (without validation)

--- a/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.spec.ts
+++ b/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.spec.ts
@@ -11,11 +11,11 @@ import {
   RuntimeParameterProvider,
   ValidationContext,
   createJayveeServices,
-  initializeWorkspace,
 } from '@jvalue/jayvee-language-server';
 import {
   ParseHelperOptions,
   expectNoParserAndLexerErrors,
+  loadTestExtensions,
   parseHelper,
   readJvTestAssetHelper,
   validationAcceptorMockImpl,
@@ -71,14 +71,11 @@ describe('Validation of validateRuntimeParameterLiteral', () => {
     // Create language services
     const services = createJayveeServices(NodeFileSystem).Jayvee;
 
-    await initializeWorkspace(services, [
-      {
-        uri: path.resolve(
-          __dirname,
-          '../../test/assets/runtime-parameter-literal/test-extension',
-        ),
-        name: 'TestBlockTypes.jv',
-      },
+    await loadTestExtensions(services, [
+      path.resolve(
+        __dirname,
+        '../../test/assets/runtime-parameter-literal/test-extension/TestBlockTypes.jv',
+      ),
     ]);
     locator = services.workspace.AstNodeLocator;
 

--- a/libs/language-server/src/test/utils.ts
+++ b/libs/language-server/src/test/utils.ts
@@ -2,11 +2,15 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import * as assert from 'assert';
 import { readFileSync } from 'fs';
 import * as path from 'path';
 
 import { AstNode, LangiumDocument, ValidationAcceptor } from 'langium';
+import { WorkspaceFolder } from 'vscode-languageserver-protocol';
 
+import { JayveeServices } from '../lib';
+import { initializeWorkspace } from '../lib/builtin-library/jayvee-workspace-manager';
 import { constraintMetaInfRegistry } from '../lib/meta-information/meta-inf-registry';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -45,4 +49,16 @@ export function expectNoParserAndLexerErrors(
 
 export function clearMetaInfRegistry() {
   constraintMetaInfRegistry.clear();
+}
+
+export async function loadTestExtensions(
+  services: JayveeServices,
+  testExtensionJvFiles: string[],
+) {
+  assert(testExtensionJvFiles.every((file) => file.endsWith('.jv')));
+  const extensions: WorkspaceFolder[] = testExtensionJvFiles.map((file) => ({
+    uri: path.dirname(file),
+    name: path.basename(file),
+  }));
+  return initializeWorkspace(services, extensions);
 }


### PR DESCRIPTION
Extracted the `initializeWorkspace` for test extension loading into a correspondingly named utils function for easier understanding