### PR TITLE
Execute all commands in nx jobs sequentially

### DIFF
--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -33,7 +33,8 @@
     "prepare-generator": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": ["nx run language-server:generate"]
+        "commands": ["nx run language-server:generate"],
+        "parallel": false
       }
     },
     "generate": {

--- a/apps/interpreter/project.json
+++ b/apps/interpreter/project.json
@@ -33,7 +33,8 @@
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
       "options": {
-        "commands": ["node --enable-source-maps dist/apps/interpreter/main.js"]
+        "commands": ["node --enable-source-maps dist/apps/interpreter/main.js"],
+        "parallel": false
       }
     },
     "test": {
@@ -52,7 +53,8 @@
           "node tools/scripts/interpreter/prepend-shebang.mjs interpreter main.js",
           "node tools/scripts/add-package-json-version.mjs interpreter",
           "node tools/scripts/interpreter/rewrite-version-mainjs.mjs interpreter"
-        ]
+        ],
+        "parallel": false
       }
     },
     "publish": {
@@ -61,7 +63,8 @@
       "options": {
         "commands": [
           "node tools/scripts/publish.mjs interpreter"
-        ]
+        ],
+        "parallel": false
       }
     },
     "pack": {
@@ -70,7 +73,8 @@
       "options": {
         "commands": [
           "node tools/scripts/pack.mjs interpreter"
-        ]
+        ],
+        "parallel": false
       }
     },
     "install": {
@@ -79,7 +83,8 @@
       "options": {
         "commands": [
           "npm i -g dist/apps/interpreter/jvalue-jayvee-interpreter-*.tgz"
-        ]
+        ],
+        "parallel": false
       }
     }
   },

--- a/apps/vs-code-extension/project.json
+++ b/apps/vs-code-extension/project.json
@@ -73,7 +73,8 @@
       "options": {
         "commands": [
           "code --install-extension dist/apps/vs-code-extension/jayvee.vsix"
-        ]
+        ],
+        "parallel": false
       }
     }
   },

--- a/libs/interpreter-lib/project.json
+++ b/libs/interpreter-lib/project.json
@@ -37,21 +37,24 @@
         "commands": [
           "node tools/scripts/relax-peer-dependency-versions.mjs interpreter-lib",
           "node tools/scripts/add-package-json-version.mjs interpreter-lib"
-        ]
+        ],
+        "parallel": false
       }
     },
     "publish": {
       "executor": "nx:run-commands",
       "dependsOn": ["pre-publish"],
       "options": {
-        "commands": ["node tools/scripts/publish.mjs interpreter-lib"]
+        "commands": ["node tools/scripts/publish.mjs interpreter-lib"],
+        "parallel": false
       }
     },
     "pack": {
       "executor": "nx:run-commands",
       "dependsOn": ["pre-publish"],
       "options": {
-        "commands": ["node tools/scripts/pack.mjs interpreter-lib"]
+        "commands": ["node tools/scripts/pack.mjs interpreter-lib"],
+        "parallel": false
       }
     }
   },

--- a/libs/language-server/project.json
+++ b/libs/language-server/project.json
@@ -54,21 +54,24 @@
         "commands": [
           "node tools/scripts/relax-peer-dependency-versions.mjs language-server",
           "node tools/scripts/add-package-json-version.mjs language-server"
-        ]
+        ],
+        "parallel": false
       }
     },
     "publish": {
       "executor": "nx:run-commands",
       "dependsOn": ["pre-publish"],
       "options": {
-        "commands": ["node tools/scripts/publish.mjs language-server"]
+        "commands": ["node tools/scripts/publish.mjs language-server"],
+        "parallel": false
       }
     },
     "pack": {
       "executor": "nx:run-commands",
       "dependsOn": ["pre-publish"],
       "options": {
-        "commands": ["node tools/scripts/pack.mjs language-server"]
+        "commands": ["node tools/scripts/pack.mjs language-server"],
+        "parallel": false
       }
     }
   },

--- a/libs/monaco-editor/project.json
+++ b/libs/monaco-editor/project.json
@@ -64,7 +64,8 @@
       "options": {
         "commands": [
           "node tools/scripts/publish.mjs monaco-editor"
-        ]
+        ],
+        "parallel": false
       }
     },
     "pack": {
@@ -73,7 +74,8 @@
       "options": {
         "commands": [
           "node tools/scripts/pack.mjs monaco-editor"
-        ]
+        ],
+        "parallel": false
       }
     }
   },

--- a/tools/scripts/interpreter/prepend-shebang.mjs
+++ b/tools/scripts/interpreter/prepend-shebang.mjs
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import {getOutputPath} from "../shared-util.mjs";
-import fs from "fs";
+import { getOutputPath } from '../shared-util.mjs';
+import fs from 'fs';
 
 // Executing this script: node path/to/prepend-shebang.mjs {projectName} {file}
 const [, , projectName, file] = process.argv;
@@ -11,5 +11,7 @@ const shebang = '#!/usr/bin/env node';
 
 process.chdir(getOutputPath(projectName));
 
-const previousFileContent = fs.readFileSync(file)
+console.log(`Prepending shebang to file ${process.cwd()}/${file}`);
+const previousFileContent = fs.readFileSync(file);
 fs.writeFileSync(file, `${shebang}\n${previousFileContent}`);
+console.log(`Finished appending shebang!`);


### PR DESCRIPTION
Before the fix, we executed all commands in nx jobs parallel.
This led to some issues in packaging, e.g. closes #465.

Adding the flag `"parallel": false` in all locations ensures that this issue will not be introduced by mistake again (e.g., by adding another script to an nx job)