### PR TITLE
Table numberOfRows increment on no columns

### DIFF
--- a/libs/execution/src/lib/types/io-types/table.ts
+++ b/libs/execution/src/lib/types/io-types/table.ts
@@ -44,12 +44,20 @@ export class Table implements IOTypeImplementation<IOType.TABLE> {
     this.columns.set(name, column);
   }
 
+  /**
+   * Tries to add a new row to this table.
+   * NOTE: This method will only add the row if the table has at least one column!
+   * @param row data of this row for each column
+   */
   addRow(row: TableRow): void {
     const rowLength = Object.keys(row).length;
     assert(
       rowLength === this.columns.size,
       `Added row has the wrong dimension (expected: ${this.columns.size}, actual: ${rowLength})`,
     );
+    if (rowLength === 0) {
+      return;
+    }
     assert(
       Object.keys(row).every((x) => this.hasColumn(x)),
       'Added row does not fit the columns in the table',


### PR DESCRIPTION
As discussed in https://github.com/jvalue/jayvee/pull/458#issuecomment-1790507847

This PR fixes the issue that the `numberOfRows` of a `Table` is incremented during `addRow` if the table contains no columns and the length of the row to be added is 0.
This causes the table to indicate that it contains data (because `table.getNumberOfRows() > 0`) without containing any data.

**Note: Currently this is only documented using jsdoc (and the comments/PRs in GitHub).**