### PR TITLE
[RFC] Exports, Imports, and Libraries

### DIFF
--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -27,7 +27,7 @@ This feature will foster reuse of valuetypes, blocks, and other elements.
 Inherent to this feature is a concept of how scoping and naming is handled for nested structures.
 This RFC introduces two concepts:
 
-- File imports, and
+- Element usage from other files, and
 - Libraries
 
 ## Motivation
@@ -107,37 +107,37 @@ The **qualified name** is constructed by prepending container structures in this
 
 - elements within a pipeline cannot be referenced by outside elements
 
-**Imported elements are handled as if they were defined at the root level.**
+**Used elements of different files are handled as if they were defined at the root level.**
 
-### Importing elements
+### Using elements
 
-Only `publish`ed elements can be imported into other files.
+Only `publish`ed elements can be used in other files.
 
-#### Importing published elements of a file (within the same project)
+#### Using published elements of a file (within the same project)
 
 ```
-from './path/to/location.jv' use { MyDomainSpecificValuetype1 }; // only imports the defined elements from the file, access via qualified name as if it would be defined at the root level
-from './path/to/location.jv' use { MyDomainSpecificValuetype1 called Vt1} // only imports the defined elements from the file, access via qualified name using the alias
+from './path/to/location.jv' use { MyDomainSpecificValuetype1 }; // only use the defined elements from the file, access via qualified name as if it would be defined at the root level
+from './path/to/location.jv' use { MyDomainSpecificValuetype1 called Vt1} // only use the defined elements from the file, access via qualified name using the alias
 ```
 
-References to these imported elements is by their qualified name (unless altered by an alias).
+References to these used elements is by their qualified name (unless altered by an alias).
 
-#### Importing a library (from outside of the project)
+#### Using a library (from outside of the project)
 
-Each import explicitly defines the version of the imported library.
+Each `use` explicitly defines the version of the used library.
 On version mismatch, an error is raised.
-Libraries can only be imported as a whole.
+Libraries can only be used as a whole.
 
 ```
-from './path/to/location.jv' use { MyDomainLibrary version 1.2.3 }; // only imports the named library, access via qualified name
+from './path/to/location.jv' use { MyDomainLibrary version 1.2.3 }; // only use the named library, access via qualified name
 from './path/to/location.jv' use {
   MyDomainLibrary1 version 1.2.3,
   MyDomainLibrary1 version 1.2.3
-}; // only imports the named libraries, access via qualified name
-from './path/to/location.jv' use { MyDomainLibrary version 1.2.3 called MyLibraryAlias} // only imports the named library, access via qualified name using the alias
+}; // only use the named libraries, access via qualified name
+from './path/to/location.jv' use { MyDomainLibrary version 1.2.3 called MyLibraryAlias} // only use the named library, access via qualified name using the alias
 ```
 
-References to these imported elements is by their qualified name (unless altered by an alias).
+References to these used elements is by their qualified name (unless altered by an alias).
 
 ## Drawbacks
 
@@ -150,7 +150,7 @@ References to these imported elements is by their qualified name (unless altered
 ## Alternatives
 
 - "use" syntax without braces, etc., `from './path/to/file.jv' use MyDomainLibrary1, MyDomainLibrary2`
-- different syntax for importing files and libraries
+- different syntax for using files and libraries (e.g., `import`)
 - Rather call it `module` instead of `library`
 
 ## Possible Future Changes/Enhancements

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -6,12 +6,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 # RFC 0015: Multi-file Jayvee
 
-| | |
-|---|---|
-| Feature Tag | `multi-file` |
-| Status | `DRAFT` | <!-- Possible values: DRAFT, DISCUSSION, ACCEPTED, REJECTED -->
-| Responsible | `georg-schwarz` | <!-- TODO: assign yourself as main driver of this RFC -->
-<!-- 
+|             |                 |
+| ----------- | --------------- | --------------------------------------------------------------- |
+| Feature Tag | `multi-file`    |
+| Status      | `DRAFT`         | <!-- Possible values: DRAFT, DISCUSSION, ACCEPTED, REJECTED --> |
+| Responsible | `georg-schwarz` | <!-- TODO: assign yourself as main driver of this RFC -->       |
+
+<!--
   Status Overview:
   - DRAFT: The RFC is not ready for a review and currently under change. Feel free to already ask for feedback on the structure and contents at this stage.
   - DISCUSSION: The RFC is open for discussion. Usually, we open a PR to trigger discussions.
@@ -25,11 +26,11 @@ This RFC introduces the possibility of distributing a Jayvee program over multip
 This feature will foster reuse of valuetypes, blocks, and other elements.
 Inherent to this feature is a concept of how scoping and naming is handled for nested structures.
 
-
 ## Motivation
 
-Right now, Jayvee users can only pack their whole Jayvee model into one file. 
+Right now, Jayvee users can only pack their whole Jayvee model into one file.
 The challenge is two-fold:
+
 1. Larger projects will become unmaintainable quite quickly, as the elements cannot be organized into multiple files.
 2. Without distribution to multiple files, there is no possibility to reuse models of other projects.
 
@@ -40,9 +41,10 @@ For example, we might be enable to build libraries of valuetypes that can be reu
 ### Exporting elements
 
 For exporting elements, I propose introducing a new concept called `libraries` instead of explicitly modeling an import or export per element.
-A `library` can inhibit `Valuetype`s, `Block`s, `BlockType`s,  `Constraint`s, and `Transform`s.
+A `library` can inhibit `Valuetype`s, `Block`s, `BlockType`s, `Constraint`s, and `Transform`s.
 
 **Example library**
+
 ```
 library MyDomainLibrary {
   valuetype MyDomainSpecificValuetype {
@@ -55,19 +57,20 @@ library MyDomainLibrary {
 
 Libraries are always "exported" and can be "imported" into other files.
 
-
 ### Visibility of elements in a file
 
 By introducing the concept of `libraries`, most elements can be defined on three levels in a Jayvee file:
+
 1. On the root level of the file
 2. Within a pipeline
 3. (new) Within a library
 
-The name of an element is given by its definition. 
+The name of an element is given by its definition.
 The **qualified name** is constructed by prepending container structures in this pattern: `<container name>.<element name>`, e.g., `MyDomainLibraryMyDomainLibrary.MyDomainSpecificValuetype`.
 
 **Access paths:**
-- root level elements can access 
+
+- root level elements can access
   - root level elements by their name
   - and elements of libraries by their qualified name
 - elements within a library can access
@@ -79,24 +82,25 @@ The **qualified name** is constructed by prepending container structures in this
   - and elements of libraries by their qualified name
 
 **No-access paths:**
+
 - elements within a pipeline cannot be referenced by outside elements
 - elements within a library cannot access anything outside a library (the same or a different library)
 
-
 ### Importing elements
 
-Only `libraries` and their elements can be imported into other files. 
+Only `libraries` and their elements can be imported into other files.
 Elements on the root level of a file or within a pipeline cannot be imported.
 
 ```
-from './path/to/jv-file.jv' use { MyDomainLibrary }; // only imports the named library, access via qualified name
-from './path/to/jv-file.jv' use { MyDomainLibrary1, MyDomainLibrary1 }; // only imports the named libraries, access via qualified name
-from './path/to/jv-file.jv' use { MyDomainLibrary called MyLibraryAlias} // only imports the named library, access via qualified name using the alias
+from './path/to/location.jv' use { MyDomainLibrary }; // only imports the named library, access via qualified name
+from './path/to/location.jv' use { MyDomainLibrary1, MyDomainLibrary1 }; // only imports the named libraries, access via qualified name
+from './path/to/location.jv' use { MyDomainLibrary called MyLibraryAlias} // only imports the named library, access via qualified name using the alias
 ```
 
 References to these imported elements is by their qualified name (unless altered by an alias).
 
 ## Drawbacks
+
 - Implicit knowledge required: elements in libraries are exported
 - Elements of a pipeline cannot be reused, leading to potentially more slim pipelines and a parallel library
 - The elements of a library within a file always need the qualified name (alternative: allow access via sole name within file?)
@@ -104,10 +108,12 @@ References to these imported elements is by their qualified name (unless altered
 - Langium might not support this scoping mechanism out-of-the-box (more complex implementation)
 
 ## Alternatives
+
 - Make exports explicit instead of introducing the concept of libraries
 - Make exports explicit besides introducing the concept of libraries
 - "use" syntax without braces, etc., `from './path/to/file.jv' use MyDomainLibrary1, MyDomainLibrary2`
 
 ## Possible Future Changes/Enhancements
-- build out to use libraries of other projects via a package-manager mechanism
+
+- build out to use libraries of other projects via a package-manager mechanism, e.g., by using an URL as location of a "use" statement
 - allow "using" single elements of a library instead of "using" the whole library

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -89,16 +89,9 @@ Only `libraries` and their elements can be imported into other files.
 Elements on the root level of a file or within a pipeline cannot be imported.
 
 ```
-import './path/to/jv-file.jv'; // imports all libraries of the file
-import './path/to/jv-file.jv' use { 
-  MyDomainLibrary 
-}; // only imports the named library, access via qualified name
-import './path/to/jv-file.jv' use {
-  MyDomainLibrary called MyLibraryAlias
-}; // only imports the named library, access via qualified name using the alias
-import './path/to/jv-file.jv' use {
-  MyDomainLibrary.MyDomainSpecificValuetype called MyElementAlias
-}; // only imports the named element, access via the alias
+from './path/to/jv-file.jv' use { MyDomainLibrary }; // only imports the named library, access via qualified name
+from './path/to/jv-file.jv' use { MyDomainLibrary1, MyDomainLibrary1 }; // only imports the named libraries, access via qualified name
+from './path/to/jv-file.jv' use { MyDomainLibrary called MyLibraryAlias} // only imports the named library, access via qualified name using the alias
 ```
 
 References to these imported elements is by their qualified name (unless altered by an alias).
@@ -113,6 +106,8 @@ References to these imported elements is by their qualified name (unless altered
 ## Alternatives
 - Make exports explicit instead of introducing the concept of libraries
 - Make exports explicit besides introducing the concept of libraries
+- "use" syntax without braces, etc., `from './path/to/file.jv' use MyDomainLibrary1, MyDomainLibrary2`
 
 ## Possible Future Changes/Enhancements
 - build out to use libraries of other projects via a package-manager mechanism
+- allow "using" single elements of a library instead of "using" the whole library

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -125,17 +125,16 @@ References to these used elements is by their qualified name (unless altered by 
 
 #### Using a library (from outside of the project)
 
-Each `use` explicitly defines the version of the used library.
-On version mismatch, an error is raised.
+The `use` syntax is similar to importing an element of a file.
 Libraries can only be used as a whole.
 
 ```
-from './path/to/location.jv' use { MyDomainLibrary version 1.2.3 }; // only use the named library, access via qualified name
+from './path/to/location.jv' use { MyDomainLibrary }; // only use the named library, access via qualified name
 from './path/to/location.jv' use {
-  MyDomainLibrary1 version 1.2.3,
-  MyDomainLibrary1 version 1.2.3
+  MyDomainLibrary1,
+  MyDomainLibrary1
 }; // only use the named libraries, access via qualified name
-from './path/to/location.jv' use { MyDomainLibrary version 1.2.3 called MyLibraryAlias} // only use the named library, access via qualified name using the alias
+from './path/to/location.jv' use { MyDomainLibrary called MyLibraryAlias} // only use the named library, access via qualified name using the alias
 ```
 
 References to these used elements is by their qualified name (unless altered by an alias).

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -42,11 +42,12 @@ For example, we might be enable to build libraries of valuetypes that can be reu
 
 For exporting elements, I propose introducing a new concept called `libraries` instead of explicitly modeling an import or export per element.
 A `library` can inhibit `Valuetype`s, `Block`s, `BlockType`s, `Constraint`s, and `Transform`s.
+A library has to define a version in semver syntax.
 
 **Example library**
 
 ```
-library MyDomainLibrary {
+library MyDomainLibrary version 1.2.3 {
   valuetype MyDomainSpecificValuetype {
     // ... details of valuetype
   }
@@ -89,12 +90,16 @@ The **qualified name** is constructed by prepending container structures in this
 ### Importing elements
 
 Only `libraries` and their elements can be imported into other files.
+Each import explicitly defines the version of the imported library. On version mismatch, an error is raised.
 Elements on the root level of a file or within a pipeline cannot be imported.
 
 ```
-from './path/to/location.jv' use { MyDomainLibrary }; // only imports the named library, access via qualified name
-from './path/to/location.jv' use { MyDomainLibrary1, MyDomainLibrary1 }; // only imports the named libraries, access via qualified name
-from './path/to/location.jv' use { MyDomainLibrary called MyLibraryAlias} // only imports the named library, access via qualified name using the alias
+from './path/to/location.jv' use { MyDomainLibrary version 1.2.3 }; // only imports the named library, access via qualified name
+from './path/to/location.jv' use {
+  MyDomainLibrary1 version 1.2.3,
+  MyDomainLibrary1 version 1.2.3
+}; // only imports the named libraries, access via qualified name
+from './path/to/location.jv' use { MyDomainLibrary version 1.2.3 called MyLibraryAlias} // only imports the named library, access via qualified name using the alias
 ```
 
 References to these imported elements is by their qualified name (unless altered by an alias).

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -63,14 +63,14 @@ By introducing the concept of `libraries`, most elements can be defined on three
 2. Within a pipeline
 3. (new) Within a library
 
-The name of an element is given by its definition. The **qualified name** is constructed by prepending container structures in this pattern: `<container name>.<element name>`, e.g., `MyDomainLibraryMyDomainLibrary.MyDomainSpecificValuetype`.
+The name of an element is given by its definition. 
+The **qualified name** is constructed by prepending container structures in this pattern: `<container name>.<element name>`, e.g., `MyDomainLibraryMyDomainLibrary.MyDomainSpecificValuetype`.
 
 **Access paths:**
 - root level elements can access 
   - root level elements by their name
   - and elements of libraries by their qualified name
 - elements within a library can access
-  - root level elements by their name
   - elements within the same library by their name
   - and elements of other libraries by their qualified name
 - elements within a pipeline can access
@@ -80,11 +80,13 @@ The name of an element is given by its definition. The **qualified name** is con
 
 **No-access paths:**
 - elements within a pipeline cannot be referenced by outside elements
+- elements within a library cannot access anything outside a library (the same or a different library)
 
 
 ### Importing elements
 
-Only `libraries` and their elements can be imported into other files. Elements on the root level of a file or within a pipeline cannot be imported.
+Only `libraries` and their elements can be imported into other files. 
+Elements on the root level of a file or within a pipeline cannot be imported.
 
 ```
 import './path/to/jv-file.jv'; // imports all libraries of the file

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -1,0 +1,116 @@
+<!--
+SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+# RFC 0015: Multi-file Jayvee
+
+| | |
+|---|---|
+| Feature Tag | `multi-file` |
+| Status | `DRAFT` | <!-- Possible values: DRAFT, DISCUSSION, ACCEPTED, REJECTED -->
+| Responsible | `georg-schwarz` | <!-- TODO: assign yourself as main driver of this RFC -->
+<!-- 
+  Status Overview:
+  - DRAFT: The RFC is not ready for a review and currently under change. Feel free to already ask for feedback on the structure and contents at this stage.
+  - DISCUSSION: The RFC is open for discussion. Usually, we open a PR to trigger discussions.
+  - ACCEPTED: The RFC was accepted. Create issues to prepare implementation of the RFC.
+  - REJECTED: The RFC was rejected. If another revision emerges, switch to status DRAFT.
+-->
+
+## Summary
+
+This RFC introduces the possibility of distributing a Jayvee program over multiple files.
+This feature will foster reuse of valuetypes, blocks, and other elements.
+Inherent to this feature is a concept of how scoping and naming is handled for nested structures.
+
+
+## Motivation
+
+Right now, Jayvee users can only pack their whole Jayvee model into one file. 
+The challenge is two-fold:
+1. Larger projects will become unmaintainable quite quickly, as the elements cannot be organized into multiple files.
+2. Without distribution to multiple files, there is no possibility to reuse models of other projects.
+
+For example, we might be enable to build libraries of valuetypes that can be reused across multiple projects instead of copying the code.
+
+## Explanation
+
+### Exporting elements
+
+For exporting elements, I propose introducing a new concept called `libraries` instead of explicitly modeling an import or export per element.
+A `library` can inhibit `Valuetype`s, `Block`s, `BlockType`s,  `Constraint`s, and `Transform`s.
+
+**Example library**
+```
+library MyDomainLibrary {
+  valuetype MyDomainSpecificValuetype {
+    // ... details of valuetype
+  }
+
+  // ... possibly more elements
+}
+```
+
+Libraries are always "exported" and can be "imported" into other files.
+
+
+### Visibility of elements in a file
+
+By introducing the concept of `libraries`, most elements can be defined on three levels in a Jayvee file:
+1. On the root level of the file
+2. Within a pipeline
+3. (new) Within a library
+
+The name of an element is given by its definition. The **qualified name** is constructed by prepending container structures in this pattern: `<container name>.<element name>`, e.g., `MyDomainLibraryMyDomainLibrary.MyDomainSpecificValuetype`.
+
+**Access paths:**
+- root level elements can access 
+  - root level elements by their name
+  - and elements of libraries by their qualified name
+- elements within a library can access
+  - root level elements by their name
+  - elements within the same library by their name
+  - and elements of other libraries by their qualified name
+- elements within a pipeline can access
+  - root level elements by their name
+  - elements within the same pipeline by their name
+  - and elements of libraries by their qualified name
+
+**No-access paths:**
+- elements within a pipeline cannot be referenced by outside elements
+
+
+### Importing elements
+
+Only `libraries` and their elements can be imported into other files. Elements on the root level of a file or within a pipeline cannot be imported.
+
+```
+import './path/to/jv-file.jv'; // imports all libraries of the file
+import './path/to/jv-file.jv' use { 
+  MyDomainLibrary 
+}; // only imports the named library, access via qualified name
+import './path/to/jv-file.jv' use {
+  MyDomainLibrary called MyLibraryAlias
+}; // only imports the named library, access via qualified name using the alias
+import './path/to/jv-file.jv' use {
+  MyDomainLibrary.MyDomainSpecificValuetype called MyElementAlias
+}; // only imports the named element, access via the alias
+```
+
+References to these imported elements is by their qualified name (unless altered by an alias).
+
+## Drawbacks
+- Implicit knowledge required: elements in libraries are exported
+- Elements of a pipeline cannot be reused, leading to potentially more slim pipelines and a parallel library
+- The elements of a library within a file always need the qualified name (alternative: allow access via sole name within file?)
+- We do not allow re-exporting (only by putting elements into a containing library)
+- Langium might not support this scoping mechanism out-of-the-box (more complex implementation)
+
+## Alternatives
+- Make exports explicit instead of introducing the concept of libraries
+- Make exports explicit besides introducing the concept of libraries
+
+## Possible Future Changes/Enhancements
+- build out to use libraries of other projects via a package-manager mechanism

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -118,15 +118,15 @@ Only `publish`ed elements can be used in other files.
 When using elements of a file or a library, we have to define where the elements are located.
 Jayvee provides the following possibilities:
 
-- a relative file path, e.g., `from './path/to/file.jv' use *;`
-- an HTTP URL, e.g., `from 'https://jvalue.com/my-org/my-repo' use *;`
+- a relative file path, e.g., `use * from './path/to/file.jv';`
+- an HTTP URL, e.g., `use * from 'https://jvalue.com/my-org/my-repo';`
 
 #### Using published elements of a file (within the same project)
 
 ```
-from './path/to/location.jv' use *; // use all published elements from the file, access via qualified name as if it would be defined at the root level
-from './path/to/location.jv' use { MyDomainSpecificValuetype1 }; // only use the published elements from the file, access via qualified name as if it would be defined at the root level
-from './path/to/location.jv' use { MyDomainSpecificValuetype1 called Vt1} // only use the published elements from the file, access via qualified name using the alias
+use * from './path/to/location.jv'; // use all published elements from the file, access via qualified name as if it would be defined at the root level
+use { MyDomainSpecificValuetype1 } from './path/to/location.jv'; // only use the published elements from the file, access via qualified name as if it would be defined at the root level
+use { MyDomainSpecificValuetype1 called Vt1} from './path/to/location.jv'; // only use the published elements from the file, access via qualified name using the alias
 ```
 
 References to these used elements is by their qualified name (unless altered by an alias).
@@ -137,12 +137,12 @@ The `use` syntax is similar to importing an element of a file.
 Libraries can only be used as a whole.
 
 ```
-from './path/to/location.jv' use { MyDomainLibrary }; // only use the named library, access via qualified name
-from './path/to/location.jv' use {
+use { MyDomainLibrary } from './path/to/location.jv'; // only use the named library, access via qualified name
+use {
   MyDomainLibrary1,
   MyDomainLibrary1
-}; // only use the named libraries, access via qualified name
-from './path/to/location.jv' use { MyDomainLibrary called MyLibraryAlias} // only use the named library, access via qualified name using the alias
+} from './path/to/location.jv'; // only use the named libraries, access via qualified name
+use { MyDomainLibrary called MyLibraryAlias} from './path/to/location.jv'; // only use the named library, access via qualified name using the alias
 ```
 
 References to these used elements is by their qualified name (unless altered by an alias).
@@ -157,7 +157,8 @@ References to these used elements is by their qualified name (unless altered by 
 
 ## Alternatives
 
-- "use" syntax without braces, etc., `from './path/to/file.jv' use MyDomainLibrary1, MyDomainLibrary2`
+- "use" syntax without braces, etc., `use MyDomainLibrary1, MyDomainLibrary2 from './path/to/file.jv';`
+- switch around `use` and `from`: `from 'location' use { Element };`
 - different syntax for using files and libraries (e.g., `import`)
 - Rather call it `module` instead of `library`
 
@@ -167,5 +168,5 @@ References to these used elements is by their qualified name (unless altered by 
 - allow "using" single elements of a library instead of "using" the whole library
 - allow additional usage paths, like
   - absolute file paths, and
-  - org/repo combination at a central package registry, e.g., `from 'jv:my-org/my-repo' use *;`
+  - org/repo combination at a central package registry, e.g., `use * from 'jv:my-org/my-repo';`
 - specify metadata (like the version) of a library, potentially require a version on library usage

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -51,9 +51,21 @@ Explicitly declaring an element as published allows for usage elsewhere.
 **Example publish**
 
 ```
-publish valuetype MyValueType {
+// define and publish in one syntax
+publish valuetype MyValueType1 {
   // ... details
 }
+
+// define first
+valuetype MyValueType2 {
+  // ... details
+}
+
+// publish later
+publish MyValueType2;
+
+// publish later under a different name
+publish MyValueType2 called MyValueType3;
 ```
 
 ### Bundling elements to a library for usage elsewhere (outside of the project)

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -25,7 +25,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 This RFC introduces the possibility of distributing a Jayvee program over multiple files.
 This feature will foster reuse of valuetypes, blocks, and other elements.
 Inherent to this feature is a concept of how scoping and naming is handled for nested structures.
-We introduce two concepts in this RFC:
+This RFC introduces two concepts:
 
 - File imports, and
 - Libraries
@@ -38,13 +38,13 @@ The challenge is two-fold:
 1. Larger projects will become unmaintainable quite quickly, as the elements cannot be organized into multiple files.
 2. Without distribution to multiple files, there is no possibility to reuse models of other projects.
 
-For example, we might be enable to build libraries of valuetypes that can be reused across multiple projects instead of copying the code.
+For example, users will be enable to build libraries of valuetypes that can be reused across multiple projects instead of copying the code.
 
 ## Explanation
 
 ### Exporting elements for later import
 
-For exporting single elements, I propose to introduce a new keyword `export`.
+For exporting single elements, the RFC introduces the keyword `export`.
 All elements within a file are not exportable per default.
 Explicitly declaring an element as exportable allows for later import.
 
@@ -58,7 +58,7 @@ export valuetype MyValueType {
 
 ### Bundling elements to a library for later import
 
-For bundling and exporting elements, I propose introducing a new concept called `libraries`.
+For bundling and exporting elements, the RFC introduces a new concept called `libraries`.
 A `library` can inhibit `Valuetype`s, `Block`s, `BlockType`s, `Constraint`s, and `Transform`s.
 A library has to define a version in semver syntax.
 A library has to be exported.
@@ -145,7 +145,7 @@ References to these imported elements is by their qualified name (unless altered
 - Two different sharing mechanisms (export keyword, library)
 - Elements of a pipeline cannot be reused, leading to potentially more slim pipelines and a parallel library
 - The elements of a library within a file always need the qualified name (alternative: allow access via sole name within file?)
-- We do not allow re-exporting (only by putting elements into a containing library)
+- The RFC does not allow re-exporting (only by putting elements into a containing library)
 - Langium might not support this scoping mechanism out-of-the-box (more complex implementation)
 
 ## Alternatives

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -42,39 +42,38 @@ For example, users will be enable to build libraries of valuetypes that can be r
 
 ## Explanation
 
-### Exporting elements for later import
+### Publishing elements for usage elsewhere (within the project)
 
-For exporting single elements, the RFC introduces the keyword `export`.
-All elements within a file are not exportable per default.
-Explicitly declaring an element as exportable allows for later import.
+For publishing single elements, the RFC introduces the keyword `publish`.
+All elements within a file are not published per default.
+Explicitly declaring an element as published allows for usage elsewhere.
 
-**Example export**
+**Example publish**
 
 ```
-export valuetype MyValueType {
+publish valuetype MyValueType {
   // ... details
 }
 ```
 
-### Bundling elements to a library for later import
+### Bundling elements to a library for usage elsewhere (outside of the project)
 
-For bundling and exporting elements, the RFC introduces a new concept called `libraries`.
+For bundling and publishing elements, the RFC introduces a new concept called `libraries`.
 A `library` can inhibit `Valuetype`s, `Block`s, `BlockType`s, `Constraint`s, and `Transform`s.
-A library has to define a version in semver syntax.
-A library has to be exported.
-They serve as entry point to a collection of files (local or remote), similarly to JavaScript's `index.js` mechanism.
+A library is published per default.
+All elements within a library have to use the `publish` keyword.
 
 **Example library**
 
 ```
-export library MyDomainLibrary version 1.2.3 {
+library MyDomainLibrary {
   // definition of a new valuetype as part of the library
-  valuetype MyDomainSpecificValuetype1 {
+  publish valuetype MyDomainSpecificValuetype1 {
     // ... details of valuetype
   }
 
   // reference to an existing valuetype to make it part of the library
-  include MyDomainSpecificValuetype2;
+  publish MyDomainSpecificValuetype2;
 
   // ... possibly more elements
 }
@@ -112,9 +111,9 @@ The **qualified name** is constructed by prepending container structures in this
 
 ### Importing elements
 
-Only `export`ed elements can be imported into other files.
+Only `publish`ed elements can be imported into other files.
 
-#### Importing exported elements of a file
+#### Importing published elements of a file (within the same project)
 
 ```
 from './path/to/location.jv' use { MyDomainSpecificValuetype1 }; // only imports the defined elements from the file, access via qualified name as if it would be defined at the root level
@@ -123,7 +122,7 @@ from './path/to/location.jv' use { MyDomainSpecificValuetype1 called Vt1} // onl
 
 References to these imported elements is by their qualified name (unless altered by an alias).
 
-#### Importing a library
+#### Importing a library (from outside of the project)
 
 Each import explicitly defines the version of the imported library.
 On version mismatch, an error is raised.
@@ -142,10 +141,10 @@ References to these imported elements is by their qualified name (unless altered
 
 ## Drawbacks
 
-- Two different sharing mechanisms (export keyword, library)
+- Two different sharing mechanisms (`publish` keyword, `library` concept`)
 - Elements of a pipeline cannot be reused, leading to potentially more slim pipelines and a parallel library
 - The elements of a library within a file always need the qualified name (alternative: allow access via sole name within file?)
-- The RFC does not allow re-exporting (only by putting elements into a containing library)
+- The RFC does not allow re-publishing (only by putting elements into a containing library)
 - Langium might not support this scoping mechanism out-of-the-box (more complex implementation)
 
 ## Alternatives

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -113,6 +113,14 @@ The **qualified name** is constructed by prepending container structures in this
 
 Only `publish`ed elements can be used in other files.
 
+#### Usage paths
+
+When using elements of a file or a library, we have to define where the elements are located.
+Jayvee provides the following possibilities:
+
+- a relative file path, e.g., `from './path/to/file.jv' use *;`
+- an HTTP URL, e.g., `from 'https://jvalue.com/my-org/my-repo' use *;`
+
 #### Using published elements of a file (within the same project)
 
 ```
@@ -157,3 +165,6 @@ References to these used elements is by their qualified name (unless altered by 
 
 - build out to use libraries of other projects via a package-manager mechanism, e.g., by using an URL as location of a "use" statement
 - allow "using" single elements of a library instead of "using" the whole library
+- allow additional usage paths, like
+  - absolute file paths, and
+  - org/repo combination at a central package registry, e.g., `from 'jv:my-org/my-repo' use *;`

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 |             |                 |
 | ----------- | --------------- | --------------------------------------------------------------- |
 | Feature Tag | `multi-file`    |
-| Status      | `DRAFT`         | <!-- Possible values: DRAFT, DISCUSSION, ACCEPTED, REJECTED --> |
+| Status      | `DISCUSSION`    | <!-- Possible values: DRAFT, DISCUSSION, ACCEPTED, REJECTED --> |
 | Responsible | `georg-schwarz` | <!-- TODO: assign yourself as main driver of this RFC -->       |
 
 <!--

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -116,8 +116,9 @@ Only `publish`ed elements can be used in other files.
 #### Using published elements of a file (within the same project)
 
 ```
-from './path/to/location.jv' use { MyDomainSpecificValuetype1 }; // only use the defined elements from the file, access via qualified name as if it would be defined at the root level
-from './path/to/location.jv' use { MyDomainSpecificValuetype1 called Vt1} // only use the defined elements from the file, access via qualified name using the alias
+from './path/to/location.jv' use *; // use all published elements from the file, access via qualified name as if it would be defined at the root level
+from './path/to/location.jv' use { MyDomainSpecificValuetype1 }; // only use the published elements from the file, access via qualified name as if it would be defined at the root level
+from './path/to/location.jv' use { MyDomainSpecificValuetype1 called Vt1} // only use the published elements from the file, access via qualified name using the alias
 ```
 
 References to these used elements is by their qualified name (unless altered by an alias).

--- a/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
+++ b/rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md
@@ -168,3 +168,4 @@ References to these used elements is by their qualified name (unless altered by 
 - allow additional usage paths, like
   - absolute file paths, and
   - org/repo combination at a central package registry, e.g., `from 'jv:my-org/my-repo' use *;`
+- specify metadata (like the version) of a library, potentially require a version on library usage


### PR DESCRIPTION
This PR is a reissue of #422.

## Major Changes
- Introduce two instead of one concept to enable multi-file Jayvee: exports and libraries for bundling of elements