### PR TITLE
Trivial Local File Import

### DIFF
--- a/example/electric-vehicles.jv
+++ b/example/electric-vehicles.jv
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+// TODO: remove after implementation
+import { X } from './import-test.jv';
+
 // Example 2: Electric Vehicles
 // Learning goals:
 // - Understand further core concepts transforms and valuetypes
@@ -35,8 +38,8 @@ pipeline ElectricVehiclesPipeline {
 
 	// 3. After the pipeline structure, we define the blocks used.
 	block ElectricVehiclesHttpExtractor oftype HttpExtractor {
-		url: "https://data.wa.gov/api/views/f6w7-q2d2/rows.csv?accessType=DOWNLOAD";
-	}
+	url: "https://data.wa.gov/api/views/f6w7-q2d2/rows.csv?accessType=DOWNLOAD";
+}
 
 	block ElectricVehiclesTextFileInterpreter oftype TextFileInterpreter { }
 
@@ -52,7 +55,7 @@ pipeline ElectricVehiclesPipeline {
 			"County" oftype text,
 			"City" oftype text,
 			"State" oftype UsStateCode,
-			"Postal Code" oftype text,
+			"Postal Code" oftype X,
 			"Model Year" oftype integer,
 			"Make" oftype text,
 			"Model" oftype text,

--- a/example/import-test.jv
+++ b/example/import-test.jv
@@ -1,0 +1,3 @@
+valuetype X oftype text {
+	constraints: [];
+}

--- a/libs/interpreter-lib/src/parsing-util.ts
+++ b/libs/interpreter-lib/src/parsing-util.ts
@@ -8,7 +8,10 @@ import * as path from 'path';
 import { Logger } from '@jvalue/jayvee-execution';
 import { initializeWorkspace } from '@jvalue/jayvee-language-server';
 import { AstNode, LangiumDocument, LangiumServices } from 'langium';
-import { DiagnosticSeverity } from 'vscode-languageserver-protocol';
+import {
+  DiagnosticSeverity,
+  WorkspaceFolder,
+} from 'vscode-languageserver-protocol';
 import { URI } from 'vscode-uri';
 
 export enum ExitCode {
@@ -41,7 +44,15 @@ export async function extractDocumentFromFile(
       URI.file(path.resolve(fileName)),
     );
 
-  await initializeWorkspace(services);
+  // TODO: check where else is initializeWorkspace is called and needs adding workspace folders
+  const folders: WorkspaceFolder[] = [
+    {
+      uri: URI.file(path.resolve(path.dirname(fileName))).toString(),
+      name: 'main',
+    },
+  ];
+
+  await initializeWorkspace(services, folders);
 
   return await validateDocument(document, services, logger);
 }

--- a/libs/language-server/src/grammar/main.langium
+++ b/libs/language-server/src/grammar/main.langium
@@ -14,7 +14,8 @@ import './iotype'
 
 entry JayveeModel:
   (
-    pipelines+=PipelineDefinition
+    imports+=ImportDefinition
+    | pipelines+=PipelineDefinition
     | valuetypes+=(CustomValuetypeDefinition | BuiltinValuetypeDefinition)
     | constraints+=ConstraintDefinition
     | transforms+=TransformDefinition
@@ -22,6 +23,21 @@ entry JayveeModel:
     | constrainttypes+=BuiltinConstrainttypeDefinition
     | iotypes+=IotypeDefinition
   )*;
+
+ImportDefinition:
+  // TODO: rename import to "use" and make sure there is no conflict with transformations
+  // TODO: validations
+  'import' '{' elements+=[ImportableElementDefinition] (',' elements+=(ImportableElementDefinition))* '}' 'from' location=STRING ';';
+
+ImportableElementDefinition:
+  PipelineDefinition
+    | CustomValuetypeDefinition 
+    | BuiltinValuetypeDefinition
+    | ConstraintDefinition
+    | TransformDefinition
+    | ReferenceableBlocktypeDefinition
+    | BuiltinConstrainttypeDefinition
+    | IotypeDefinition;
 
 PipelineDefinition:
   'pipeline' name=ID '{'

--- a/libs/language-server/src/lib/jayvee-module.ts
+++ b/libs/language-server/src/lib/jayvee-module.ts
@@ -22,6 +22,7 @@ import { JayveeWorkspaceManager } from './builtin-library/jayvee-workspace-manag
 import { JayveeCompletionProvider } from './completion/jayvee-completion-provider';
 import { JayveeHoverProvider } from './hover/jayvee-hover-provider';
 import { JayveeValueConverter } from './jayvee-value-converter';
+import { JayveeScopeProvider } from './services/jayvee-scope-provider';
 import { RuntimeParameterProvider } from './services/runtime-parameter-provider';
 import { JayveeValidationRegistry } from './validation/validation-registry';
 
@@ -64,6 +65,9 @@ export const JayveeModule: Module<
       new JayveeCompletionProvider(services),
     HoverProvider: (services: LangiumServices) =>
       new JayveeHoverProvider(services),
+  },
+  references: {
+    ScopeProvider: (services) => new JayveeScopeProvider(services),
   },
   RuntimeParameterProvider: () => new RuntimeParameterProvider(),
 };

--- a/libs/language-server/src/lib/services/jayvee-scope-provider.ts
+++ b/libs/language-server/src/lib/services/jayvee-scope-provider.ts
@@ -1,0 +1,97 @@
+import {
+  DefaultScopeProvider,
+  EMPTY_SCOPE,
+  LangiumDocuments,
+  LangiumServices,
+  ReferenceInfo,
+  Scope,
+  StreamScope,
+  equalURI,
+  getContainerOfType,
+  getDocument,
+  stream,
+} from 'langium';
+import {
+  AbstractType,
+  Interface,
+  Type,
+} from 'langium/lib/grammar/generated/ast';
+import { URI, Utils } from 'vscode-uri';
+
+import { ImportDefinition, JayveeModel, isJayveeModel } from '../ast';
+
+export class JayveeScopeProvider extends DefaultScopeProvider {
+  constructor(services: LangiumServices) {
+    super(services);
+  }
+
+  protected override getGlobalScope(
+    referenceType: string,
+    context: ReferenceInfo,
+  ): Scope {
+    const model = getContainerOfType(context.container, isJayveeModel);
+    if (!model) {
+      return EMPTY_SCOPE;
+    }
+
+    const importedUris = stream(model.imports)
+      .map(resolveImportUri)
+      .nonNullable();
+
+    const importedElements = this.indexManager
+      .allElements(referenceType)
+      .filter((destination) => {
+        const isBuiltinElement = destination.documentUri.scheme === 'builtin';
+        const isInCorrectFile = importedUris.some((importedUri) =>
+          equalURI(destination.documentUri, importedUri),
+        );
+
+        return isBuiltinElement || isInCorrectFile;
+      });
+
+    if (referenceType !== AbstractType) {
+      return new StreamScope(importedElements);
+    }
+
+    return new StreamScope( // TODO: do we need this?
+      importedElements.filter(
+        (destination) =>
+          destination.type === Interface || destination.type === Type,
+      ),
+    );
+  }
+}
+
+export function resolveImportUri(imp: ImportDefinition): URI | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const importPath = imp?.location;
+  if (
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    importPath === undefined ||
+    importPath.length === 0 ||
+    !importPath.endsWith('.jv') // TODO: get from somewhere else
+  ) {
+    return undefined;
+  }
+  const dirURI = Utils.dirname(getDocument(imp).uri);
+  return Utils.resolvePath(dirURI, importPath);
+}
+
+export function resolveImport(
+  documents: LangiumDocuments,
+  imp: ImportDefinition,
+): JayveeModel | undefined {
+  const resolvedURI = resolveImportUri(imp);
+  try {
+    if (resolvedURI) {
+      const resolvedDocument = documents.getOrCreateDocument(resolvedURI);
+      const node = resolvedDocument.parseResult.value;
+      if (isJayveeModel(node)) {
+        return node;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}


### PR DESCRIPTION
Explores technical implementations of #474.

Introduces a trivial file import mechanism.
All elements of files are exported (thus "trivial").

## TODOs
- [ ] adjust to whatever syntax #474 will settle on
- [ ] fix tests
- [ ] add documentation
- [ ] ensure the mechanism works when starting the interpreter from different locations (not only within work dir)
- [ ] check whether transitive imports are working

## Next steps
- limit accessible elements to ones that were made accessible explicitly (e.g., `export` keyword)