### PR TITLE
Distribute pipeline and block grammar to separate files

### DIFF
--- a/libs/language-server/src/grammar/block.langium
+++ b/libs/language-server/src/grammar/block.langium
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import './property'
+import './blocktype'
+import './terminal'
+
+BlockDefinition:
+  'block' name=ID 'oftype' type=[ReferenceableBlocktypeDefinition] body=PropertyBody;

--- a/libs/language-server/src/grammar/blocktype.langium
+++ b/libs/language-server/src/grammar/blocktype.langium
@@ -7,6 +7,7 @@ import './iotype'
 import './terminal'
 import './transform'
 import './valuetype'
+import './block'
 import './main'
 
 ReferenceableBlocktypeDefinition:

--- a/libs/language-server/src/grammar/main.langium
+++ b/libs/language-server/src/grammar/main.langium
@@ -5,6 +5,7 @@
 grammar Jayvee
 
 import './blocktype'
+import './pipeline'
 import './terminal'
 import './property'
 import './valuetype'
@@ -23,28 +24,4 @@ entry JayveeModel:
     | iotypes+=IotypeDefinition
   )*;
 
-PipelineDefinition:
-  'pipeline' name=ID '{'
-    (
-      blocks+=BlockDefinition
-      | pipes+=PipeDefinition
-      | valuetypes+=CustomValuetypeDefinition
-      | constraints+=ConstraintDefinition
-      | transforms+=TransformDefinition
-    )*
-  '}';
 
-BlockDefinition:
-  'block' name=ID 'oftype' type=[ReferenceableBlocktypeDefinition] body=PropertyBody;
-
-PipeDefinition:
-  SinglePipeDefinition | ChainedPipeDefinition;
-
-SinglePipeDefinition:
-  'pipe' '{'
-    'from' ':' from=[BlockDefinition] ';'
-    'to' ':' to=[BlockDefinition] ';'
-  '}';
-
-ChainedPipeDefinition:
-    blocks+=[BlockDefinition] ('->' blocks+=[BlockDefinition])+ ';';

--- a/libs/language-server/src/grammar/pipeline.langium
+++ b/libs/language-server/src/grammar/pipeline.langium
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import './block'
+import './transform'
+import './valuetype'
+import './constraint'
+import './terminal'
+
+PipelineDefinition:
+  'pipeline' name=ID '{'
+    (
+      blocks+=BlockDefinition
+      | pipes+=PipeDefinition
+      | valuetypes+=CustomValuetypeDefinition
+      | constraints+=ConstraintDefinition
+      | transforms+=TransformDefinition
+    )*
+  '}';
+
+PipeDefinition:
+  SinglePipeDefinition | ChainedPipeDefinition;
+
+SinglePipeDefinition:
+  'pipe' '{'
+    'from' ':' from=[BlockDefinition] ';'
+    'to' ':' to=[BlockDefinition] ';'
+  '}';
+
+ChainedPipeDefinition:
+    blocks+=[BlockDefinition] ('->' blocks+=[BlockDefinition])+ ';';


### PR DESCRIPTION
For the sake of navigability, every language concept should have its own file.