### PR TITLE
Adapted number regex to allow scientific notation

### DIFF
--- a/libs/execution/src/lib/types/valuetypes/internal-representation-parsing.ts
+++ b/libs/execution/src/lib/types/valuetypes/internal-representation-parsing.ts
@@ -11,7 +11,7 @@ import {
   ValuetypeVisitor,
 } from '@jvalue/jayvee-language-server';
 
-const NUMBER_REGEX = /^[+-]?([0-9]*[,\\.])?[0-9]+([eE][+\\-]?\d+)?$/;
+const NUMBER_REGEX = /^[+-]?([0-9]*[,.])?[0-9]+([eE][+-]?\d+)?$/;
 
 const TRUE_REGEX = /^true$/i;
 const FALSE_REGEX = /^false$/i;


### PR DESCRIPTION
Allows parsing numbers in scientific notation, both integers like 1.904761905e+20 or decimals like 8.1e-5.

Closes https://github.com/jvalue/jayvee/issues/488