### PR TITLE
Navigate Pipeline via Pipes instead of Blocks

### DIFF
--- a/example/gtfs-static.jv
+++ b/example/gtfs-static.jv
@@ -14,79 +14,78 @@ pipeline GtfsPipeline {
 	// 2. The origin for multiple pipe sequences is a zip
 	// file. Each csv file in this zip is further processed 
 	// by its own sequence of blocks and pipes.
-	GTFSSampleFeedExtractor -> ZipArchiveInterpreter;
 
-	ZipArchiveInterpreter
+	GTFSSampleFeedExtractor
 		-> AgencyFilePicker
 		-> AgencyTextFileInterpreter
 		-> AgencyCSVInterpreter
 		-> AgencyTableInterpreter
 		-> AgencyLoader;
 
-	ZipArchiveInterpreter	
+	GTFSSampleFeedExtractor	
 		-> CalendarDatesFilePicker
 		-> CalendarDatesTextFileInterpreter
 		-> CalendarDatesCSVInterpreter
 		-> CalendarDatesTableInterpreter
 		-> CalendarDatesLoader;
 
-	ZipArchiveInterpreter	
+	GTFSSampleFeedExtractor	
 		-> CalendarFilePicker
 		-> CalendarTextFileInterpreter
 		-> CalendarCSVInterpreter
 		-> CalendarTableInterpreter
 		-> CalendarLoader;
 
-	ZipArchiveInterpreter	
+	GTFSSampleFeedExtractor	
 		-> FareAttributesFilePicker
 		-> FareAttributesTextFileInterpreter
 		-> FareAttributesCSVInterpreter
 		-> FareAttributesTableInterpreter
 		-> FareAttributesLoader;
 
-	ZipArchiveInterpreter	
+	GTFSSampleFeedExtractor	
 		-> FareRulesFilePicker
 		-> FareRulesTextFileInterpreter
 		-> FareRulesCSVInterpreter
 		-> FareRulesTableInterpreter
 		-> FareRulesLoader;
 
-	ZipArchiveInterpreter	
+	GTFSSampleFeedExtractor	
 		-> FrequenciesFilePicker
 		-> FrequenciesTextFileInterpreter
 		-> FrequenciesCSVInterpreter
 		-> FrequenciesTableInterpreter
 		-> FrequenciesLoader;
 
-	ZipArchiveInterpreter			
+	GTFSSampleFeedExtractor			
 		-> RoutesFilePicker
 		-> RoutesTextFileInterpreter
 		-> RoutesCSVInterpreter 
 		-> RoutesTableInterpreter 
 		-> RoutesLoader;
 
-	ZipArchiveInterpreter			
+	GTFSSampleFeedExtractor			
 		-> ShapesFilePicker
 		-> ShapesTextFileInterpreter
 		-> ShapesCSVInterpreter 
 		-> ShapesTableInterpreter 
 		-> ShapesLoader;
 
-	ZipArchiveInterpreter	
+	GTFSSampleFeedExtractor	
 		-> StopTimesFilePicker
 		-> StopTimesTextFileInterpreter
 		-> StopTimesCSVInterpreter
 		-> StopTimesTableInterpreter 
 		-> StopTimesLoader;
 
-	ZipArchiveInterpreter
+	GTFSSampleFeedExtractor
 		-> StopsFilePicker 
 		-> StopsTextFileInterpreter
 		-> StopsCSVInterpreter 
 		-> StopsTableInterpreter 
 		-> StopsLoader;
 
-	ZipArchiveInterpreter	
+	GTFSSampleFeedExtractor	
 		-> TripsFilePicker 
 		-> TripsTextFileInterpreter
 		-> TripsCSVInterpreter 
@@ -94,12 +93,8 @@ pipeline GtfsPipeline {
 		-> TripsLoader;
 
 	// 3. As a first step, we download the zip file and interpret it.
-	block GTFSSampleFeedExtractor oftype HttpExtractor {
+	block GTFSSampleFeedExtractor oftype GTFSExtractor {
 		url: "https://developers.google.com/static/transit/gtfs/examples/sample-feed.zip";
-	}
-
-	block ZipArchiveInterpreter oftype ArchiveInterpreter {
-		archiveType: "zip";
 	}
 
 	// 4. Next, we pick several csv files (with the file extension ".txt") 

--- a/libs/execution/src/lib/blocks/block-execution-util.ts
+++ b/libs/execution/src/lib/blocks/block-execution-util.ts
@@ -54,7 +54,7 @@ export async function executeBlocks(
   for (const blockData of executionOrder) {
     const block = blockData.block;
     const parentData = pipelineWrapper
-      .getPredecessorBlocks(block)
+      .followIngoingPipes(block)
       .map((parent) =>
         executionOrder.find((blockData) => parent === blockData.block),
       );

--- a/libs/execution/src/lib/blocks/block-execution-util.ts
+++ b/libs/execution/src/lib/blocks/block-execution-util.ts
@@ -50,7 +50,7 @@ export async function executeBlocks(
   for (const blockData of executionOrder) {
     const block = blockData.block;
     const parentData = pipelineWrapper
-      .followIngoingPipes(block)
+      .getParentBlocks(block)
       .map((parent) =>
         executionOrder.find((blockData) => parent === blockData.block),
       );

--- a/libs/execution/src/lib/blocks/block-execution-util.ts
+++ b/libs/execution/src/lib/blocks/block-execution-util.ts
@@ -34,20 +34,16 @@ export interface ExecutionOrderItem {
  */
 export async function executeBlocks(
   executionContext: ExecutionContext,
-  compositeBlockTypeDefinition:
-    | CompositeBlocktypeDefinition
-    | PipelineDefinition,
+  pipesContainer: CompositeBlocktypeDefinition | PipelineDefinition,
   initialInputValue: IOTypeImplementation | undefined = undefined,
 ): Promise<R.Result<ExecutionOrderItem[]>> {
-  const pipelineWrapper = new PipelineWrapper(compositeBlockTypeDefinition);
+  const pipelineWrapper = new PipelineWrapper(pipesContainer);
   const executionOrder: {
     block: BlockDefinition;
     value: IOTypeImplementation | null;
-  }[] = getBlocksInTopologicalSorting(compositeBlockTypeDefinition).map(
-    (block) => {
-      return { block: block, value: NONE };
-    },
-  );
+  }[] = getBlocksInTopologicalSorting(pipesContainer).map((block) => {
+    return { block: block, value: NONE };
+  });
 
   let isFirstBlock = true;
 

--- a/libs/execution/src/lib/blocks/block-execution-util.ts
+++ b/libs/execution/src/lib/blocks/block-execution-util.ts
@@ -7,7 +7,6 @@ import {
   CompositeBlocktypeDefinition,
   PipelineDefinition,
   PipelineWrapper,
-  getBlocksInTopologicalSorting,
 } from '@jvalue/jayvee-language-server';
 
 import { ExecutionContext } from '../execution-context';
@@ -41,7 +40,7 @@ export async function executeBlocks(
   const executionOrder: {
     block: BlockDefinition;
     value: IOTypeImplementation | null;
-  }[] = getBlocksInTopologicalSorting(pipesContainer).map((block) => {
+  }[] = pipelineWrapper.getBlocksInTopologicalSorting().map((block) => {
     return { block: block, value: NONE };
   });
 

--- a/libs/execution/src/lib/blocks/composite-block-executor.ts
+++ b/libs/execution/src/lib/blocks/composite-block-executor.ts
@@ -16,13 +16,12 @@ import {
   createValuetype,
   evaluateExpression,
   evaluatePropertyValue,
-  getBlocksInTopologicalSorting,
   getIOType,
   isCompositeBlocktypeDefinition,
 } from '@jvalue/jayvee-language-server';
 
 import { ExecutionContext } from '../execution-context';
-import { IOTypeImplementation, NONE } from '../types';
+import { IOTypeImplementation } from '../types';
 
 // eslint-disable-next-line import/no-cycle
 import { executeBlocks } from './block-execution-util';
@@ -69,15 +68,9 @@ export function createCompositeBlockExecutor(
 
       this.addVariablesToContext(block, blockTypeReference.properties, context);
 
-      const executionOrder = getBlocksInTopologicalSorting(
-        blockTypeReference,
-      ).map((block) => {
-        return { block: block, value: NONE };
-      });
-
       const executionResult = await executeBlocks(
         context,
-        executionOrder,
+        blockTypeReference,
         input,
       );
 

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -255,7 +255,7 @@ export function logPipelineOverview(
       block.name
     } (${blockTypeName})`;
     const childString = pipelineWrapper
-      .getSuccessorBlocks(block)
+      .followOutgoingPipes(block)
       .map((child) => toString(child, depth + 1))
       .join('\n');
     return blockString + '\n' + childString;

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -255,7 +255,7 @@ export function logPipelineOverview(
       block.name
     } (${blockTypeName})`;
     const childString = pipelineWrapper
-      .followOutgoingPipes(block)
+      .getChildBlocks(block)
       .map((child) => toString(child, depth + 1))
       .join('\n');
     return blockString + '\n' + childString;

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -9,7 +9,6 @@ import {
   DebugGranularity,
   ExecutionContext,
   Logger,
-  NONE,
   executeBlocks,
   isDebugGranularity,
   logExecutionDuration,
@@ -24,11 +23,9 @@ import {
   JayveeModel,
   JayveeServices,
   PipelineDefinition,
+  PipelineWrapper,
   RuntimeParameterProvider,
-  collectChildren,
-  collectStartingBlocks,
   createJayveeServices,
-  getBlocksInTopologicalSorting,
   initializeWorkspace,
 } from '@jvalue/jayvee-language-server';
 import * as chalk from 'chalk';
@@ -228,12 +225,7 @@ async function runPipeline(
 
   const startTime = new Date();
 
-  const executionOrder = getBlocksInTopologicalSorting(pipeline).map(
-    (block) => {
-      return { block: block, value: NONE };
-    },
-  );
-  const executionResult = await executeBlocks(executionContext, executionOrder);
+  const executionResult = await executeBlocks(executionContext, pipeline);
 
   if (R.isErr(executionResult)) {
     const diagnosticError = executionResult.left;
@@ -254,13 +246,16 @@ export function logPipelineOverview(
   runtimeParameterProvider: RuntimeParameterProvider,
   logger: Logger,
 ) {
+  const pipelineWrapper = new PipelineWrapper(pipeline);
+
   const toString = (block: BlockDefinition, depth = 0): string => {
     const blockTypeName = block.type.ref?.name;
     assert(blockTypeName !== undefined);
     const blockString = `${'\t'.repeat(depth)} -> ${
       block.name
     } (${blockTypeName})`;
-    const childString = collectChildren(block)
+    const childString = pipelineWrapper
+      .getSuccessorBlocks(block)
       .map((child) => toString(child, depth + 1))
       .join('\n');
     return blockString + '\n' + childString;
@@ -280,7 +275,7 @@ export function logPipelineOverview(
   linesBuffer.push(
     `\tBlocks (${pipeline.blocks.length} blocks with ${pipeline.pipes.length} pipes):`,
   );
-  for (const block of collectStartingBlocks(pipeline)) {
+  for (const block of pipelineWrapper.getStartingBlocks()) {
     linesBuffer.push(toString(block, 1));
   }
   logger.logInfo(linesBuffer.join('\n'));

--- a/libs/language-server/src/lib/ast/model-util.ts
+++ b/libs/language-server/src/lib/ast/model-util.ts
@@ -53,10 +53,10 @@ export function getBlocksInTopologicalSorting(
 
     sortedNodes.push(node);
 
-    for (const childNode of pipelineWrapper.getSuccessorBlocks(node)) {
+    for (const childNode of pipelineWrapper.followOutgoingPipes(node)) {
       // Mark edges between parent and child as visited
       pipelineWrapper
-        .getPredecessorPipes(childNode)
+        .getIngoingPipes(childNode)
         .filter((e) => e.from === node)
         .forEach((e) => {
           unvisitedEdges = unvisitedEdges.filter((edge) => !edge.equals(e));
@@ -64,7 +64,7 @@ export function getBlocksInTopologicalSorting(
 
       // If all edges to the child have been visited
       const notRemovedEdges = pipelineWrapper
-        .getPredecessorPipes(childNode)
+        .getIngoingPipes(childNode)
         .filter((e) => unvisitedEdges.some((edge) => edge.equals(e)));
       if (notRemovedEdges.length === 0) {
         // Insert it into currentBlocks

--- a/libs/language-server/src/lib/ast/model-util.ts
+++ b/libs/language-server/src/lib/ast/model-util.ts
@@ -53,7 +53,7 @@ export function getBlocksInTopologicalSorting(
 
     sortedNodes.push(node);
 
-    for (const childNode of pipelineWrapper.followOutgoingPipes(node)) {
+    for (const childNode of pipelineWrapper.getChildBlocks(node)) {
       // Mark edges between parent and child as visited
       pipelineWrapper
         .getIngoingPipes(childNode)

--- a/libs/language-server/src/lib/ast/wrappers/index.ts
+++ b/libs/language-server/src/lib/ast/wrappers/index.ts
@@ -10,3 +10,6 @@ export * from './ast-node-wrapper';
 export * from './cell-range-wrapper';
 
 export * from './typed-object';
+
+export * from './pipe-wrapper';
+export * from './pipeline-wrapper';

--- a/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
@@ -52,23 +52,23 @@ export class PipelineWrapper
     return this.getStartingBlockPipes().map((p) => p.from);
   }
 
-  getSuccessorPipes(blockDefinition: BlockDefinition): PipeWrapper[] {
+  getOutgoingPipes(blockDefinition: BlockDefinition): PipeWrapper[] {
     return this.allPipes.filter((pipe) => {
       return pipe.from === blockDefinition;
     });
   }
 
-  getSuccessorBlocks(blockDefinition: BlockDefinition): BlockDefinition[] {
-    return this.getSuccessorPipes(blockDefinition).map((p) => p.to);
+  followOutgoingPipes(blockDefinition: BlockDefinition): BlockDefinition[] {
+    return this.getOutgoingPipes(blockDefinition).map((p) => p.to);
   }
 
-  getPredecessorPipes(blockDefinition: BlockDefinition): PipeWrapper[] {
+  getIngoingPipes(blockDefinition: BlockDefinition): PipeWrapper[] {
     return this.allPipes.filter((pipe) => {
       return pipe.to === blockDefinition;
     });
   }
 
-  getPredecessorBlocks(blockDefinition: BlockDefinition): BlockDefinition[] {
-    return this.getPredecessorPipes(blockDefinition).map((p) => p.from);
+  followIngoingPipes(blockDefinition: BlockDefinition): BlockDefinition[] {
+    return this.getIngoingPipes(blockDefinition).map((p) => p.from);
   }
 }

--- a/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
@@ -1,0 +1,74 @@
+import {
+  BlockDefinition,
+  CompositeBlocktypeDefinition,
+  PipelineDefinition,
+} from '../generated/ast';
+
+import { AstNodeWrapper } from './ast-node-wrapper';
+import { PipeWrapper, createWrappersFromPipeChain } from './pipe-wrapper';
+
+export class PipelineWrapper
+  implements AstNodeWrapper<PipelineDefinition | CompositeBlocktypeDefinition>
+{
+  public readonly astNode: PipelineDefinition | CompositeBlocktypeDefinition;
+
+  allPipes: PipeWrapper[] = [];
+
+  constructor(
+    pipelineDefinition: PipelineDefinition | CompositeBlocktypeDefinition,
+  ) {
+    this.astNode = pipelineDefinition;
+
+    this.allPipes = pipelineDefinition.pipes.flatMap((pipe) =>
+      createWrappersFromPipeChain(pipe),
+    );
+  }
+
+  static canBeWrapped(pipelineDefinition: PipelineDefinition): boolean {
+    for (const pipeDefinition of pipelineDefinition.pipes) {
+      for (
+        let chainIndex = 0;
+        chainIndex < pipeDefinition.blocks.length - 1;
+        ++chainIndex
+      ) {
+        if (!PipeWrapper.canBeWrapped(pipeDefinition, chainIndex)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  getStartingBlockPipes(): PipeWrapper[] {
+    return this.allPipes.filter((pipe) => {
+      const fromBlock = pipe.from;
+      const isToOfOtherPipe =
+        this.allPipes.filter((p) => p.to === fromBlock).length > 0;
+      return !isToOfOtherPipe;
+    });
+  }
+
+  getStartingBlocks(): BlockDefinition[] {
+    return this.getStartingBlockPipes().map((p) => p.from);
+  }
+
+  getSuccessorPipes(blockDefinition: BlockDefinition): PipeWrapper[] {
+    return this.allPipes.filter((pipe) => {
+      return pipe.from === blockDefinition;
+    });
+  }
+
+  getSuccessorBlocks(blockDefinition: BlockDefinition): BlockDefinition[] {
+    return this.getSuccessorPipes(blockDefinition).map((p) => p.to);
+  }
+
+  getPredecessorPipes(blockDefinition: BlockDefinition): PipeWrapper[] {
+    return this.allPipes.filter((pipe) => {
+      return pipe.to === blockDefinition;
+    });
+  }
+
+  getPredecessorBlocks(blockDefinition: BlockDefinition): BlockDefinition[] {
+    return this.getPredecessorPipes(blockDefinition).map((p) => p.from);
+  }
+}

--- a/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
@@ -13,16 +13,15 @@ import {
 import { AstNodeWrapper } from './ast-node-wrapper';
 import { PipeWrapper, createWrappersFromPipeChain } from './pipe-wrapper';
 
-export class PipelineWrapper
-  implements AstNodeWrapper<PipelineDefinition | CompositeBlocktypeDefinition>
+export class PipelineWrapper<
+  T extends PipelineDefinition | CompositeBlocktypeDefinition,
+> implements AstNodeWrapper<T>
 {
-  public readonly astNode: PipelineDefinition | CompositeBlocktypeDefinition;
+  public readonly astNode: T;
 
   allPipes: PipeWrapper[] = [];
 
-  constructor(
-    pipesContainer: PipelineDefinition | CompositeBlocktypeDefinition,
-  ) {
+  constructor(pipesContainer: T) {
     this.astNode = pipesContainer;
 
     this.allPipes = pipesContainer.pipes.flatMap((pipe) =>

--- a/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
@@ -53,7 +53,12 @@ export class PipelineWrapper
   }
 
   getStartingBlocks(): BlockDefinition[] {
-    return this.getStartingBlockPipes().map((p) => p.from);
+    const startingBlocks = this.getStartingBlockPipes().map((p) => p.from);
+
+    // Special case: the extractor is reused for multiple paths
+    // Thus, we remove duplicates
+    const withoutDuplicates = [...new Set(startingBlocks)];
+    return withoutDuplicates;
   }
 
   getOutgoingPipes(blockDefinition: BlockDefinition): PipeWrapper[] {

--- a/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import {
   BlockDefinition,
   CompositeBlocktypeDefinition,

--- a/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
@@ -47,9 +47,9 @@ export class PipelineWrapper
 
   getStartingBlockPipes(): PipeWrapper[] {
     return this.allPipes.filter((pipe) => {
-      const fromBlock = pipe.from;
+      const parentBlock = pipe.from;
       const isToOfOtherPipe =
-        this.allPipes.filter((p) => p.to === fromBlock).length > 0;
+        this.allPipes.filter((p) => p.to === parentBlock).length > 0;
       return !isToOfOtherPipe;
     });
   }
@@ -69,7 +69,7 @@ export class PipelineWrapper
     });
   }
 
-  followOutgoingPipes(blockDefinition: BlockDefinition): BlockDefinition[] {
+  getChildBlocks(blockDefinition: BlockDefinition): BlockDefinition[] {
     return this.getOutgoingPipes(blockDefinition).map((p) => p.to);
   }
 
@@ -79,7 +79,7 @@ export class PipelineWrapper
     });
   }
 
-  followIngoingPipes(blockDefinition: BlockDefinition): BlockDefinition[] {
+  getParentBlocks(blockDefinition: BlockDefinition): BlockDefinition[] {
     return this.getIngoingPipes(blockDefinition).map((p) => p.from);
   }
 }

--- a/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
@@ -19,17 +19,19 @@ export class PipelineWrapper
   allPipes: PipeWrapper[] = [];
 
   constructor(
-    pipelineDefinition: PipelineDefinition | CompositeBlocktypeDefinition,
+    pipesContainer: PipelineDefinition | CompositeBlocktypeDefinition,
   ) {
-    this.astNode = pipelineDefinition;
+    this.astNode = pipesContainer;
 
-    this.allPipes = pipelineDefinition.pipes.flatMap((pipe) =>
+    this.allPipes = pipesContainer.pipes.flatMap((pipe) =>
       createWrappersFromPipeChain(pipe),
     );
   }
 
-  static canBeWrapped(pipelineDefinition: PipelineDefinition): boolean {
-    for (const pipeDefinition of pipelineDefinition.pipes) {
+  static canBeWrapped(
+    pipesContainer: PipelineDefinition | CompositeBlocktypeDefinition,
+  ): boolean {
+    for (const pipeDefinition of pipesContainer.pipes) {
       for (
         let chainIndex = 0;
         chainIndex < pipeDefinition.blocks.length - 1;

--- a/libs/language-server/src/lib/validation/checks/block-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/block-definition.ts
@@ -31,7 +31,10 @@ function checkPipesOfBlock(
   whatToCheck: 'input' | 'output',
   context: ValidationContext,
 ): void {
-  if (!BlockTypeWrapper.canBeWrapped(block?.type)) {
+  if (
+    !BlockTypeWrapper.canBeWrapped(block?.type) ||
+    !PipelineWrapper.canBeWrapped(block.$container)
+  ) {
     return;
   }
   const blockType = new BlockTypeWrapper(block?.type);
@@ -98,6 +101,7 @@ function collectPipes(
   whatToCheck: 'input' | 'output',
 ): PipeWrapper[] {
   const pipelineWrapper = new PipelineWrapper(block.$container);
+
   let pipes: PipeWrapper[];
   switch (whatToCheck) {
     case 'input': {

--- a/libs/language-server/src/lib/validation/checks/block-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/block-definition.ts
@@ -101,11 +101,11 @@ function collectPipes(
   let pipes: PipeWrapper[];
   switch (whatToCheck) {
     case 'input': {
-      pipes = pipelineWrapper.getPredecessorPipes(block);
+      pipes = pipelineWrapper.getIngoingPipes(block);
       break;
     }
     case 'output': {
-      pipes = pipelineWrapper.getSuccessorPipes(block);
+      pipes = pipelineWrapper.getOutgoingPipes(block);
       break;
     }
     default: {

--- a/libs/language-server/src/lib/validation/checks/block-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/block-definition.ts
@@ -9,14 +9,11 @@
 
 import { assertUnreachable } from 'langium';
 
+import { PipelineWrapper } from '../../ast';
 import {
   BlockDefinition,
   isCompositeBlocktypeDefinition,
 } from '../../ast/generated/ast';
-import {
-  collectIngoingPipes,
-  collectOutgoingPipes,
-} from '../../ast/model-util';
 import { PipeWrapper } from '../../ast/wrappers/pipe-wrapper';
 import { BlockTypeWrapper } from '../../ast/wrappers/typed-object/blocktype-wrapper';
 import { ValidationContext } from '../validation-context';
@@ -100,14 +97,15 @@ function collectPipes(
   block: BlockDefinition,
   whatToCheck: 'input' | 'output',
 ): PipeWrapper[] {
+  const pipelineWrapper = new PipelineWrapper(block.$container);
   let pipes: PipeWrapper[];
   switch (whatToCheck) {
     case 'input': {
-      pipes = collectIngoingPipes(block);
+      pipes = pipelineWrapper.getPredecessorPipes(block);
       break;
     }
     case 'output': {
-      pipes = collectOutgoingPipes(block);
+      pipes = pipelineWrapper.getSuccessorPipes(block);
       break;
     }
     default: {

--- a/libs/language-server/src/lib/validation/checks/pipeline-definition.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/pipeline-definition.spec.ts
@@ -63,9 +63,24 @@ describe('Validation of PipelineDefinition', () => {
     validationAcceptorMock.mockReset();
   });
 
-  it('should diagnose error on missing extractor block', async () => {
+  it('should diagnose error on missing starting block (no blocks)', async () => {
     const text = readJvTestAsset(
       'pipeline-definition/invalid-empty-pipeline.jv',
+    );
+
+    await parseAndValidatePipeline(text);
+
+    expect(validationAcceptorMock).toHaveBeenCalledTimes(1);
+    expect(validationAcceptorMock).toHaveBeenCalledWith(
+      'error',
+      `An extractor block is required for this pipeline`,
+      expect.any(Object),
+    );
+  });
+
+  it('should diagnose error on missing starting block (no pipes)', async () => {
+    const text = readJvTestAsset(
+      'pipeline-definition/invalid-pipeline-only-blocks.jv',
     );
 
     await parseAndValidatePipeline(text);

--- a/libs/language-server/src/lib/validation/checks/pipeline-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/pipeline-definition.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { PipelineWrapper } from '../../ast';
 import { PipelineDefinition } from '../../ast/generated/ast';
-import { collectStartingBlocks } from '../../ast/model-util';
 import { ValidationContext } from '../validation-context';
 import { checkUniqueNames } from '../validation-util';
 
@@ -22,7 +22,8 @@ function checkStartingBlocks(
   pipeline: PipelineDefinition,
   context: ValidationContext,
 ): void {
-  const startingBlocks = collectStartingBlocks(pipeline);
+  const pipelineWrapper = new PipelineWrapper(pipeline);
+  const startingBlocks = pipelineWrapper.getStartingBlocks();
   if (startingBlocks.length === 0) {
     context.accept(
       'error',

--- a/libs/language-server/src/lib/validation/checks/pipeline-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/pipeline-definition.ts
@@ -22,7 +22,11 @@ function checkStartingBlocks(
   pipeline: PipelineDefinition,
   context: ValidationContext,
 ): void {
+  if (PipelineWrapper.canBeWrapped(pipeline)) {
+    return;
+  }
   const pipelineWrapper = new PipelineWrapper(pipeline);
+
   const startingBlocks = pipelineWrapper.getStartingBlocks();
   if (startingBlocks.length === 0) {
     context.accept(

--- a/libs/language-server/src/lib/validation/checks/pipeline-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/pipeline-definition.ts
@@ -22,7 +22,7 @@ function checkStartingBlocks(
   pipeline: PipelineDefinition,
   context: ValidationContext,
 ): void {
-  if (PipelineWrapper.canBeWrapped(pipeline)) {
+  if (!PipelineWrapper.canBeWrapped(pipeline)) {
     return;
   }
   const pipelineWrapper = new PipelineWrapper(pipeline);

--- a/libs/language-server/src/test/assets/pipeline-definition/invalid-pipeline-only-blocks.jv
+++ b/libs/language-server/src/test/assets/pipeline-definition/invalid-pipeline-only-blocks.jv
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline Pipeline {
+  block TestExtractor oftype TestFileExtractor {}
+}
+
+builtin blocktype TestFileExtractor {
+  input inPort oftype None;
+  output outPort oftype File;
+}

--- a/libs/language-server/src/test/assets/pipeline-definition/valid-pipeline.jv
+++ b/libs/language-server/src/test/assets/pipeline-definition/valid-pipeline.jv
@@ -3,11 +3,18 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 pipeline Pipeline {
-  block TestExtractor oftype TestFileExtractor {
-  }
+  TestExtractor -> TestLoader;
+
+  block TestExtractor oftype TestFileExtractor {}
+  block TestLoader oftype TestFileLoader {}
 }
 
 builtin blocktype TestFileExtractor {
   input inPort oftype None;
   output outPort oftype File;
+}
+
+builtin blocktype TestFileLoader {
+  input inPort oftype File;
+  output outPort oftype None;
 }


### PR DESCRIPTION
Until now, we have navigated over all blocks within a pipeline and connected them via pipes to get our execution order.
However, #485 will change that by allowing block definitions outside of pipelines, raising the necessity to iterate purely over the pipes with a pipeline.

This PR introduces a `PipelineWrapper` in the already existing of `AstNodeWrapper`s that inhibits the functionality to navigate over a pipeline and replaces the existing helper methods in the `model-util`.

The PR should not change the behavior of Jayvee besides:
- Pipelines with one block but no pipes were previously valid, which is not the case anymore (see adapted tests).

## TODOs:

- [x] make it work for `Pipelines`
- [x] make it work for `CompositeBlockTypes` (=> showcased by gtfs-static example)