### PR TITLE
Add `--parse-only` flag

### DIFF
--- a/apps/interpreter/src/index.ts
+++ b/apps/interpreter/src/index.ts
@@ -58,7 +58,7 @@ program
     undefined,
   )
   .option(
-    '--parse-only',
+    '-po, --parse-only',
     'Only parses the model without running it. Exits with 0 if the model is valid, with 1 otherwise.',
     false,
   )

--- a/apps/interpreter/src/index.ts
+++ b/apps/interpreter/src/index.ts
@@ -57,6 +57,11 @@ program
     `Sets the target blocks of the of block debug logging, separated by comma. If not given, all blocks are targeted.`,
     undefined,
   )
+  .option(
+    '--parse-only',
+    'Only parses the model without running it. Exits with 0 if the model is valid, with 1 otherwise.',
+    false,
+  )
   .description('Run a Jayvee file')
   .action(runAction);
 

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -1,0 +1,44 @@
+import * as process from 'process';
+import { runAction } from './run-action';
+import { RunOptions } from '@jvalue/jayvee-interpreter-lib';
+import * as path from 'path';
+
+describe('Parse Only', () => {
+  const baseDir = path.resolve(__dirname, '../../../example/');
+
+  const defaultOptions: RunOptions = {
+    env: new Map<string, string>(),
+    debug: false,
+    debugGranularity: 'minimal',
+    debugTarget: undefined,
+    parseOnly: true,
+  };
+
+  beforeEach(() => {
+    jest.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error();
+    });
+  });
+
+  it('should exit with 0 on a valid option', async () => {
+    await expect(
+      runAction(path.resolve(baseDir, 'cars.jv'), {
+        ...defaultOptions,
+      }),
+    ).rejects.toBeDefined();
+
+    expect(process.exit).toBeCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('should exit with 1 on error', async () => {
+    await expect(
+      runAction(path.resolve(baseDir, 'cars.jv'), {
+        ...defaultOptions,
+      }),
+    ).rejects.toBeDefined();
+
+    expect(process.exit).toBeCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+});

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import * as process from 'process';
-import { runAction } from './run-action';
-import { RunOptions } from '@jvalue/jayvee-interpreter-lib';
 import * as path from 'path';
+import * as process from 'process';
+
+import { RunOptions } from '@jvalue/jayvee-interpreter-lib';
+
+import { runAction } from './run-action';
 
 describe('Parse Only', () => {
   const baseDir = path.resolve(__dirname, '../../../example/');

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -11,9 +11,22 @@ import {
   clearBlockExecutorRegistry,
   clearConstraintExecutorRegistry,
 } from '@jvalue/jayvee-execution/test';
-import { RunOptions } from '@jvalue/jayvee-interpreter-lib';
+import {
+  RunOptions,
+  interpretModel,
+  interpretString,
+} from '@jvalue/jayvee-interpreter-lib';
 
 import { runAction } from './run-action';
+
+jest.mock('@jvalue/jayvee-interpreter-lib', () => {
+  const original: object = jest.requireActual('@jvalue/jayvee-interpreter-lib'); // Step 2.
+  return {
+    ...original,
+    interpretModel: jest.fn(),
+    interpretString: jest.fn(),
+  };
+});
 
 describe('Parse Only', () => {
   const baseDir = path.resolve(__dirname, '../../../example/');
@@ -34,6 +47,12 @@ describe('Parse Only', () => {
       // eslint-disable-next-line require-atomic-updates
       tempFile = undefined;
     }
+  });
+
+  afterEach(() => {
+    // Assert that model is not executed
+    expect(interpretString).not.toBeCalled();
+    expect(interpretModel).not.toBeCalled();
   });
 
   beforeEach(() => {

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import * as process from 'process';
 import { runAction } from './run-action';
 import { RunOptions } from '@jvalue/jayvee-interpreter-lib';

--- a/apps/interpreter/src/run-action.ts
+++ b/apps/interpreter/src/run-action.ts
@@ -28,7 +28,7 @@ export async function runAction(
     );
   if (options.parseOnly === true) {
     const { model, services } = await parseModel(extractAstNodeFn, options);
-    const exitCode = model && services ? 0 : 1;
+    const exitCode = model != null && services != null ? 0 : 1;
     process.exit(exitCode);
   }
   const exitCode = await interpretModel(extractAstNodeFn, options);

--- a/apps/interpreter/src/run-action.ts
+++ b/apps/interpreter/src/run-action.ts
@@ -7,8 +7,10 @@ import {
   RunOptions,
   extractAstNodeFromFile,
   interpretModel,
+  parseModel,
 } from '@jvalue/jayvee-interpreter-lib';
 import { JayveeModel, JayveeServices } from '@jvalue/jayvee-language-server';
+import * as process from 'process';
 
 export async function runAction(
   fileName: string,
@@ -23,6 +25,11 @@ export async function runAction(
       services,
       loggerFactory.createLogger(),
     );
+  if (options.parseOnly) {
+    const { model, services } = await parseModel(extractAstNodeFn, options);
+    const exitCode = model && services ? 0 : 1;
+    process.exit(exitCode);
+  }
   const exitCode = await interpretModel(extractAstNodeFn, options);
   process.exit(exitCode);
 }

--- a/apps/interpreter/src/run-action.ts
+++ b/apps/interpreter/src/run-action.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import * as process from 'process';
+
 import {
   LoggerFactory,
   RunOptions,
@@ -10,7 +12,6 @@ import {
   parseModel,
 } from '@jvalue/jayvee-interpreter-lib';
 import { JayveeModel, JayveeServices } from '@jvalue/jayvee-language-server';
-import * as process from 'process';
 
 export async function runAction(
   fileName: string,
@@ -25,7 +26,7 @@ export async function runAction(
       services,
       loggerFactory.createLogger(),
     );
-  if (options.parseOnly) {
+  if (options.parseOnly === true) {
     const { model, services } = await parseModel(extractAstNodeFn, options);
     const exitCode = model && services ? 0 : 1;
     process.exit(exitCode);

--- a/apps/interpreter/test/assets/broken-model.jv
+++ b/apps/interpreter/test/assets/broken-model.jv
@@ -1,0 +1,50 @@
+pipeline CarsPipeline {
+    // Try using a CoolCarsExtractor although we only have normal cars.
+    // This fill result in an error during parsing.
+	CoolCarsExtractor -> CarsTextFileInterpreter;
+
+	CarsTextFileInterpreter
+		-> CarsCSVInterpreter
+		-> NameHeaderWriter
+	   	-> CarsTableInterpreter
+		-> CarsLoader;
+
+	block CarsExtractor oftype HttpExtractor {
+		url: "https://gist.githubusercontent.com/noamross/e5d3e859aa0c794be10b/raw/b999fb4425b54c63cab088c0ce2c0d6ce961a563/cars.csv";
+	}
+
+	block CarsTextFileInterpreter oftype TextFileInterpreter { }
+
+	block CarsCSVInterpreter oftype CSVInterpreter {
+		enclosing: '"';
+	}
+
+	block NameHeaderWriter oftype CellWriter {
+		at: cell A1;
+		write: ["name"];
+	}
+
+	block CarsTableInterpreter oftype TableInterpreter {
+		header: true;
+		columns: [
+			"name" oftype text,
+			"mpg" oftype decimal,
+			"cyl" oftype integer,
+			"disp" oftype decimal,
+			"hp" oftype integer,
+			"drat" oftype decimal,
+			"wt" oftype decimal,
+			"qsec" oftype decimal,
+			"vs" oftype integer,
+			"am" oftype integer,
+			"gear" oftype integer,
+			"carb" oftype integer
+		];
+	}
+
+	block CarsLoader oftype SQLiteLoader {
+		table: "Cars";
+		file: "./cars.sqlite";
+	}
+
+}

--- a/apps/interpreter/test/assets/broken-model.jv
+++ b/apps/interpreter/test/assets/broken-model.jv
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 pipeline CarsPipeline {
     // Try using a CoolCarsExtractor although we only have normal cars.
     // This fill result in an error during parsing.

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -7,12 +7,12 @@ import { strict as assert } from 'assert';
 import * as R from '@jvalue/jayvee-execution';
 import {
   DebugGranularity,
-  executeBlocks,
   ExecutionContext,
-  isDebugGranularity,
-  logExecutionDuration,
   Logger,
   NONE,
+  executeBlocks,
+  isDebugGranularity,
+  logExecutionDuration,
   parseValueToInternalRepresentation,
   registerDefaultConstraintExecutors,
   useExtension as useExecutionExtension,
@@ -20,16 +20,16 @@ import {
 import { StdExecExtension } from '@jvalue/jayvee-extensions/std/exec';
 import {
   BlockDefinition,
-  collectChildren,
-  collectStartingBlocks,
-  createJayveeServices,
   EvaluationContext,
-  getBlocksInTopologicalSorting,
-  initializeWorkspace,
   JayveeModel,
   JayveeServices,
   PipelineDefinition,
   RuntimeParameterProvider,
+  collectChildren,
+  collectStartingBlocks,
+  createJayveeServices,
+  getBlocksInTopologicalSorting,
+  initializeWorkspace,
 } from '@jvalue/jayvee-language-server';
 import * as chalk from 'chalk';
 import { NodeFileSystem } from 'langium/node';


### PR DESCRIPTION
This PR adds a `--parse-only` flag to the interpreter. Using this flag, the app just parses (and therefore validates) the given Jayvee model without executing it.

The process (when called with `--parse-only`) ends with `0` in case of valid model, with `1` otherwise.