### PR TITLE
Refactor block validation multiple pipe inputs

### DIFF
--- a/libs/language-server/src/lib/validation/checks/block-definition.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/block-definition.spec.ts
@@ -76,22 +76,6 @@ describe('Validation of BlockDefinition', () => {
     );
   });
 
-  it('should diagnose error on block as input for multiple pipes', async () => {
-    const text = readJvTestAsset(
-      'block-definition/invalid-block-as-multiple-pipe-inputs.jv',
-    );
-
-    await parseAndValidateBlock(text);
-
-    expect(validationAcceptorMock).toHaveBeenCalledTimes(2);
-    expect(validationAcceptorMock).toHaveBeenNthCalledWith(
-      2,
-      'error',
-      'At most one pipe can be connected to the input of a TestTableLoader',
-      expect.any(Object),
-    );
-  });
-
   it('should have no error on valid block definition', async () => {
     const text = readJvTestAsset('block-definition/valid-block-definition.jv');
 

--- a/libs/language-server/src/lib/validation/checks/block-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/block-definition.ts
@@ -40,18 +40,6 @@ function checkPipesOfBlock(
   const blockType = new BlockTypeWrapper(block?.type);
   const pipes = collectPipes(block, whatToCheck);
 
-  const hasMultipleInputPorts = pipes.length > 1 && whatToCheck === 'input';
-  if (hasMultipleInputPorts) {
-    for (const pipe of pipes) {
-      context.accept(
-        'error',
-        `At most one pipe can be connected to the ${whatToCheck} of a ${blockType.type}`,
-        pipe.getToDiagnostic(),
-      );
-    }
-    return;
-  }
-
   if (pipes.length === 0) {
     const isLastBlockOfCompositeBlocktype =
       isCompositeBlocktypeDefinition(block.$container) &&

--- a/libs/language-server/src/lib/validation/checks/composite-blocktype-definition.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/composite-blocktype-definition.spec.ts
@@ -115,4 +115,27 @@ describe('Validation of CompositeBlocktypeDefinition', () => {
 
     expect(validationAcceptorMock).toHaveBeenCalledTimes(0);
   });
+
+  it('should diagnose error on block as input for multiple pipes', async () => {
+    const text = readJvTestAsset(
+      'composite-blocktype-definition/invalid-block-as-multiple-pipe-inputs.jv',
+    );
+
+    await parseAndValidateBlocktype(text);
+
+    // first 2 errors for multiple pipelines in test file
+    expect(validationAcceptorMock).toHaveBeenCalledTimes(4);
+    expect(validationAcceptorMock).toHaveBeenNthCalledWith(
+      3,
+      'error',
+      'At most one pipe can be connected to the input of a block. Currently, the following 2 blocks are connected via pipes: "BlockFrom1", "BlockFrom2"',
+      expect.any(Object),
+    );
+    expect(validationAcceptorMock).toHaveBeenNthCalledWith(
+      4,
+      'error',
+      'At most one pipe can be connected to the input of a block. Currently, the following 2 blocks are connected via pipes: "BlockFrom1", "BlockFrom2"',
+      expect.any(Object),
+    );
+  });
 });

--- a/libs/language-server/src/lib/validation/checks/composite-blocktype-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/composite-blocktype-definition.ts
@@ -7,6 +7,7 @@ import { CompositeBlocktypeDefinition } from '../../ast/generated/ast';
 import { ValidationContext } from '../validation-context';
 
 import { validateBlocktypeDefinition } from './blocktype-definition';
+import { checkMultipleBlockInputs } from './pipeline-definition';
 
 export function validateCompositeBlockTypeDefinition(
   blockType: CompositeBlocktypeDefinition,
@@ -16,6 +17,8 @@ export function validateCompositeBlockTypeDefinition(
   validateBlocktypeDefinition(blockType, validationContext, evaluationContext);
   checkHasPipeline(blockType, validationContext);
   checkExactlyOnePipeline(blockType, validationContext);
+
+  checkMultipleBlockInputs(blockType, validationContext);
 }
 
 function checkHasPipeline(

--- a/libs/language-server/src/lib/validation/checks/pipeline-definition.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/pipeline-definition.spec.ts
@@ -100,4 +100,20 @@ describe('Validation of PipelineDefinition', () => {
 
     expect(validationAcceptorMock).toHaveBeenCalledTimes(0);
   });
+
+  it('should diagnose error on block as input for multiple pipes', async () => {
+    const text = readJvTestAsset(
+      'pipeline-definition/invalid-block-as-multiple-pipe-inputs.jv',
+    );
+
+    await parseAndValidatePipeline(text);
+
+    expect(validationAcceptorMock).toHaveBeenCalledTimes(2);
+    expect(validationAcceptorMock).toHaveBeenNthCalledWith(
+      2,
+      'error',
+      'At most one pipe can be connected to the input of a block. Currently, the following 2 blocks are connected via pipes: "BlockFrom1", "BlockFrom2"',
+      expect.any(Object),
+    );
+  });
 });

--- a/libs/language-server/src/lib/validation/checks/pipeline-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/pipeline-definition.ts
@@ -2,8 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { PipelineWrapper } from '../../ast';
-import { PipelineDefinition } from '../../ast/generated/ast';
+import { PipeWrapper, PipelineWrapper } from '../../ast';
+import {
+  BlockDefinition,
+  CompositeBlocktypeDefinition,
+  PipelineDefinition,
+} from '../../ast/generated/ast';
 import { ValidationContext } from '../validation-context';
 import { checkUniqueNames } from '../validation-util';
 
@@ -16,6 +20,8 @@ export function validatePipelineDefinition(
   checkUniqueNames(pipeline.transforms, context);
   checkUniqueNames(pipeline.valuetypes, context);
   checkUniqueNames(pipeline.constraints, context);
+
+  checkMultipleBlockInputs(pipeline, context);
 }
 
 function checkStartingBlocks(
@@ -38,4 +44,78 @@ function checkStartingBlocks(
       },
     );
   }
+}
+
+export function checkMultipleBlockInputs(
+  pipeline: PipelineDefinition | CompositeBlocktypeDefinition,
+  context: ValidationContext,
+): void {
+  if (!PipelineWrapper.canBeWrapped(pipeline)) {
+    return;
+  }
+  const pipelineWrapper = new PipelineWrapper(pipeline);
+
+  const startingBlocks = pipelineWrapper.getStartingBlocks();
+  let alreadyMarkedPipes: PipeWrapper[] = [];
+  for (const startingBlock of startingBlocks) {
+    alreadyMarkedPipes = doCheckMultipleBlockInputs(
+      pipelineWrapper,
+      startingBlock,
+      alreadyMarkedPipes,
+      context,
+    );
+  }
+}
+
+/**
+ * Inner method to check recursively whether blocks in a pipeline have multiple inputs
+ * @param pipelineWrapper The wrapping pipeline
+ * @param block The current block
+ * @param alreadyMarkedPipes List of already visited pipes to avoid duplicate errors
+ * @param context The validation context
+ * @returns the updated @alreadyMarkedPipes with all marked pipes
+ */
+function doCheckMultipleBlockInputs(
+  pipelineWrapper: PipelineWrapper<
+    PipelineDefinition | CompositeBlocktypeDefinition
+  >,
+  block: BlockDefinition,
+  alreadyMarkedPipes: Array<PipeWrapper>,
+  context: ValidationContext,
+): Array<PipeWrapper> {
+  const pipesFromParents = pipelineWrapper.getIngoingPipes(block);
+  if (pipesFromParents.length > 1) {
+    const parentBlockNames = pipesFromParents.map(
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      (pipe) => '"' + pipe.from?.name + '"',
+    );
+    for (const pipe of pipesFromParents) {
+      const wasAlreadyMarked = alreadyMarkedPipes.some((x) => pipe.equals(x));
+      if (wasAlreadyMarked) {
+        continue;
+      }
+
+      context.accept(
+        'error',
+        `At most one pipe can be connected to the input of a block. Currently, the following ${
+          pipesFromParents.length
+        } blocks are connected via pipes: ${parentBlockNames.join(', ')}`,
+        pipe.getToDiagnostic(),
+      );
+
+      alreadyMarkedPipes.push(pipe);
+    }
+  }
+
+  const children = pipelineWrapper.getChildBlocks(block);
+  for (const child of children) {
+    alreadyMarkedPipes = doCheckMultipleBlockInputs(
+      pipelineWrapper,
+      child,
+      alreadyMarkedPipes,
+      context,
+    );
+  }
+
+  return alreadyMarkedPipes;
 }

--- a/libs/language-server/src/test/assets/composite-blocktype-definition/invalid-block-as-multiple-pipe-inputs.jv
+++ b/libs/language-server/src/test/assets/composite-blocktype-definition/invalid-block-as-multiple-pipe-inputs.jv
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+composite blocktype TestBlockType {
+  input inPort oftype None;
+  output outPort oftype None;
+
+  block BlockTo oftype TestTableLoader { }
+
+  block BlockFrom1 oftype TestFileExtractor { }
+
+  block BlockFrom2 oftype TestFileExtractor { }
+
+  inPort -> BlockFrom1 -> BlockTo -> outPort;
+  inPort -> BlockFrom2 -> BlockTo -> outPort;
+}
+
+builtin blocktype TestFileExtractor {
+  input inPort oftype None;
+  output outPort oftype Table;
+}
+
+builtin blocktype TestTableLoader {
+  input inPort oftype Table;
+  output outPort oftype None;
+}

--- a/libs/language-server/src/test/assets/composite-blocktype-definition/invalid-composite-blocktype-multiple-pipelines.jv
+++ b/libs/language-server/src/test/assets/composite-blocktype-definition/invalid-composite-blocktype-multiple-pipelines.jv
@@ -5,23 +5,19 @@
 composite blocktype TestBlock {
 
     input inputName oftype None;
-    output outputName oftype Sheet;
+    output outputName oftype TextFile;
 
     block FileExtractor oftype HttpExtractor { url: 'url'; }
-    block FileTextInterpreter oftype TextFileInterpreter {}
-
-    block FileCSVInterpreter oftype CSVInterpreter {
-    }
+    block FileTextInterpreter1 oftype TextFileInterpreter {}
+    block FileTextInterpreter2 oftype TextFileInterpreter {}
 
     inputName
         ->FileExtractor
-        ->FileTextInterpreter
-        ->FileCSVInterpreter
+        ->FileTextInterpreter1
         ->outputName;
         
     inputName
         ->FileExtractor
-        ->FileTextInterpreter
-        ->FileCSVInterpreter
+        ->FileTextInterpreter2
         ->outputName;
 }

--- a/libs/language-server/src/test/assets/pipeline-definition/invalid-block-as-multiple-pipe-inputs.jv
+++ b/libs/language-server/src/test/assets/pipeline-definition/invalid-block-as-multiple-pipe-inputs.jv
@@ -3,15 +3,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 pipeline Pipeline {
-  block BlockTo oftype TestTableLoader {
-  }
+  block BlockTo oftype TestTableLoader { }
 
-  block BlockFrom oftype TestFileExtractor {
-  }
+  block BlockFrom1 oftype TestFileExtractor { }
 
-  BlockFrom -> BlockTo;
+  block BlockFrom2 oftype TestFileExtractor { }
 
-  BlockFrom -> BlockTo;
+  BlockFrom1 -> BlockTo;
+
+  BlockFrom2 -> BlockTo;
 }
 
 builtin blocktype TestFileExtractor {


### PR DESCRIPTION
- Changed logic to iterate over pipeline structure.
- Adapted some tests to be more precise

Validation output should have stayed roughly the same (except some minor edge cases)
