### PR TITLE
Add roadmap section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Explore a glimpse of our upcoming features in the following list. This overview 
 - &#9989; Simple valuetypes and constraints
 - &#9989; Natively support table-based data
 - &#9989; Column-based transformations
-- &#9989; Describe blocks via blocktypes in Jayvee
+- &#9989; Describe blocks via builtin blocktypes in Jayvee
+- &#9989; Compose logic of multiple blocks via composite blocktypes
 - &#8987; Multi-file Jayvee to distribute programs over multiple files (see [RFC 0015](./rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md))
 - &#8987; Improve the syntax of valuetypes (see [RFC 0014](https://github.com/jvalue/jayvee/pull/409))
 - &#8987; Jayvee formatter

--- a/README.md
+++ b/README.md
@@ -12,6 +12,34 @@ Data engineers can use Jayvee and its interpreter to clean and preprocess data f
 
 [![Official Docs](assets/docs-banner.png)](https://jvalue.github.io/jayvee)
 
+## Roadmap
+
+Explore a glimpse of our upcoming features in the following list. This overview is broad and subject to evolution. We're excited to share our vision of the exciting journey ahead, and we invite you to accompany us on this adventure!
+
+- &#9989; Blocks and pipes 
+- &#9989; Simple valuetypes and constraints
+- &#9989; Natively support table-based data
+- &#9989; Column-based transformations
+- &#9989; Describe blocks via blocktypes in Jayvee
+- &#8987; Multi-file Jayvee to distribute programs over multiple files (see [RFC 0015](./rfc/0015-multi-file-jayvee/0015-multi-file-jayvee.md))
+- &#8987; Improve the syntax of valuetypes (see [RFC 0014](https://github.com/jvalue/jayvee/pull/409))
+- &#8987; Jayvee formatter
+- &#8987; Further extractors and sinks
+- &#129300; Reusable libraries (with a package manager)
+- &#129300; Composite valuetypes (with multiple fields)
+- &#129300; Natively support tree data (XML, JSON)
+- &#129300; Valuetypes parsers (to read and write different formats)
+- &#129300; Customizable invalid value handling (default value, average, median, interpolation, ...)
+- &#129300; VSCode Debugger
+- &#129300; Blocktypes with multiple ports (e.g., for merging different data)
+
+
+Anything missing, or you have ideas how some of the items on the list could be approached?
+Feel free to create and issue and share your thoughts with us!
+
+You like the project and our vision? Then we'd appreciate your star! &#11088;
+
+
 ## Contribute
 
 In case you would like to contribute to Jayvee, please have a look at our [contribution guide](CONTRIBUTING.md).


### PR DESCRIPTION
We should share our roadmap and vision of Jayvee with the world.

See the rendered README [here](https://github.com/jvalue/jayvee/tree/document-roadmap)

## Screenshot

![image](https://github.com/jvalue/jayvee/assets/28054628/eda73f13-7927-4b37-9894-c0091fd381ee)
