### PR TITLE
Upgrade to Langium 1.3

### DIFF
--- a/libs/language-server/src/lib/completion/jayvee-completion-provider.ts
+++ b/libs/language-server/src/lib/completion/jayvee-completion-provider.ts
@@ -59,13 +59,13 @@ export class JayveeCompletionProvider extends DefaultCompletionProvider {
       const isBlockTypeCompletion =
         isBlockDefinition(astNode) && next.property === 'type';
       if (isBlockTypeCompletion) {
-        return this.completionForBlockType(acceptor);
+        return this.completionForBlockType(context, acceptor);
       }
 
       const isConstraintTypeCompletion =
         isConstraintDefinition(astNode) && next.property === 'type';
       if (isConstraintTypeCompletion) {
-        return this.completionForConstraintType(acceptor);
+        return this.completionForConstraintType(context, acceptor);
       }
 
       const isValuetypeDefinitionCompletion = next.type === ValuetypeReference;
@@ -78,20 +78,21 @@ export class JayveeCompletionProvider extends DefaultCompletionProvider {
       const isOtherPropertyCompletion =
         isPropertyAssignment(astNode) && next.type === PropertyAssignment;
       if (isFirstPropertyCompletion || isOtherPropertyCompletion) {
-        return this.completionForPropertyName(astNode, acceptor);
+        return this.completionForPropertyName(astNode, context, acceptor);
       }
     }
     return super.completionFor(context, next, acceptor);
   }
 
   private completionForBlockType(
+    context: CompletionContext,
     acceptor: CompletionAcceptor,
   ): MaybePromise<void> {
     const blockTypes = getAllBuiltinBlocktypes(this.langiumDocumentService);
     blockTypes.forEach((blockType) => {
       const lspDocBuilder = new LspDocGenerator();
       const markdownDoc = lspDocBuilder.generateBlockTypeDoc(blockType);
-      acceptor({
+      acceptor(context, {
         label: blockType.type,
         labelDetails: {
           detail: ` ${blockType.inputType} ${RIGHT_ARROW_SYMBOL} ${blockType.outputType}`,
@@ -107,6 +108,7 @@ export class JayveeCompletionProvider extends DefaultCompletionProvider {
   }
 
   private completionForConstraintType(
+    context: CompletionContext,
     acceptor: CompletionAcceptor,
   ): MaybePromise<void> {
     const constraintTypes = getAllBuiltinConstraintTypes(
@@ -116,7 +118,7 @@ export class JayveeCompletionProvider extends DefaultCompletionProvider {
       const lspDocBuilder = new LspDocGenerator();
       const markdownDoc =
         lspDocBuilder.generateConstraintTypeDoc(constraintType);
-      acceptor({
+      acceptor(context, {
         label: constraintType.type,
         labelDetails: {
           detail: ` on ${constraintType.on.getName()}`,
@@ -144,7 +146,7 @@ export class JayveeCompletionProvider extends DefaultCompletionProvider {
         parsedDocument.valuetypes.forEach((valuetypeDefinition) => {
           const valuetype = createValuetype(valuetypeDefinition);
           if (valuetype !== undefined && valuetype.isReferenceableByUser()) {
-            acceptor({
+            acceptor(context, {
               label: valuetypeDefinition.name,
               kind: CompletionItemKind.Class,
               detail: `(valuetype)`,
@@ -156,6 +158,7 @@ export class JayveeCompletionProvider extends DefaultCompletionProvider {
 
   private completionForPropertyName(
     astNode: PropertyBody | PropertyAssignment,
+    context: CompletionContext,
     acceptor: CompletionAcceptor,
   ) {
     let container: BlockDefinition | ConstraintDefinition;
@@ -187,7 +190,7 @@ export class JayveeCompletionProvider extends DefaultCompletionProvider {
         wrapper,
         propertyNames,
         propertyKind,
-      ).forEach(acceptor);
+      ).forEach((item) => acceptor(context, item));
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "fp-ts": "^2.13.1",
         "gtfs-realtime-bindings": "^1.1.1",
         "jszip": "^3.10.1",
-        "langium": "^1.2.0",
+        "langium": "^1.3.0",
         "mime-types": "^2.1.35",
         "monaco-editor": "^0.34.1",
         "monaco-languageclient": "^4.0.3",
@@ -75,13 +75,13 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "28.1.1",
         "jest-environment-jsdom": "28.1.1",
-        "langium-cli": "^1.2.0",
+        "langium-cli": "^1.3.0",
         "nock": "13.3.1",
         "nx": "15.3.0",
         "prettier": "^2.8.7",
         "ts-jest": "28.0.5",
         "ts-node": "10.9.1",
-        "typescript": "^4.7.4"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -2175,11 +2175,6 @@
         "lodash": "4.17.21"
       }
     },
-    "node_modules/@chevrotain/cst-dts-gen/node_modules/@chevrotain/types": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
-      "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
-    },
     "node_modules/@chevrotain/gast": {
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.4.2.tgz",
@@ -2189,10 +2184,15 @@
         "lodash": "4.17.21"
       }
     },
-    "node_modules/@chevrotain/gast/node_modules/@chevrotain/types": {
+    "node_modules/@chevrotain/types": {
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
       "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.4.2.tgz",
+      "integrity": "sha512-V34dacxWLwKcvcy32dx96ADJVdB7kOJLm7LyBkBQw5u5HC9WdEFw2G17zml+U3ivavGTrGPJHl8o9/UJm0PlUw=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -8772,26 +8772,7 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/chevrotain-allstar": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.1.4.tgz",
-      "integrity": "sha512-gr5PNT8keiOTt19r+XkRY19unZw7rUE/erXgfFMEJnk1ZTuiVGWREfzVPSlz9u6DxbR0zJ9NQzdQS0a/3SVKFw==",
-      "dependencies": {
-        "chevrotain": "^10.4.1",
-        "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/chevrotain-allstar/node_modules/@chevrotain/types": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
-      "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
-    },
-    "node_modules/chevrotain-allstar/node_modules/@chevrotain/utils": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.4.2.tgz",
-      "integrity": "sha512-V34dacxWLwKcvcy32dx96ADJVdB7kOJLm7LyBkBQw5u5HC9WdEFw2G17zml+U3ivavGTrGPJHl8o9/UJm0PlUw=="
-    },
-    "node_modules/chevrotain-allstar/node_modules/chevrotain": {
+    "node_modules/chevrotain": {
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.4.2.tgz",
       "integrity": "sha512-gzF5GxE0Ckti5kZVuKEZycLntB5X2aj9RVY0r4/220GwQjdnljU+/t3kP74/FMWC7IzCDDEjQ9wsFUf0WCdSHg==",
@@ -8802,6 +8783,15 @@
         "@chevrotain/utils": "10.4.2",
         "lodash": "4.17.21",
         "regexp-to-ast": "0.5.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.1.4.tgz",
+      "integrity": "sha512-gr5PNT8keiOTt19r+XkRY19unZw7rUE/erXgfFMEJnk1ZTuiVGWREfzVPSlz9u6DxbR0zJ9NQzdQS0a/3SVKFw==",
+      "dependencies": {
+        "chevrotain": "^10.4.1",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/chokidar": {
@@ -16198,9 +16188,9 @@
       }
     },
     "node_modules/langium": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-1.2.0.tgz",
-      "integrity": "sha512-jFSptpFljYo9ZTHrq/GZflMUXiKo5KBNtsaIJtnIzDm9zC2FxsxejEFAtNL09262RVQt+zFeF/2iLAShFTGitw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-1.3.1.tgz",
+      "integrity": "sha512-xC+DnAunl6cZIgYjRpgm3s1kYAB5/Wycsj24iYaXG9uai7SgvMaFZSrRvdA5rUK/lSta/CRvgF+ZFoEKEOFJ5w==",
       "dependencies": {
         "chevrotain": "~10.4.2",
         "chevrotain-allstar": "~0.1.4",
@@ -16213,16 +16203,17 @@
       }
     },
     "node_modules/langium-cli": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-1.2.0.tgz",
-      "integrity": "sha512-DPyJUd4Hj8+OBNEcAQyJtW6e38+UPd758gTI7Ep0r/sDogrwJ/GJHx5nGA+r0ygpNcDPG+mS9Hw8Y05uCNNcoQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-1.3.1.tgz",
+      "integrity": "sha512-9faKpioKCjBD0Z4y165+wQlDFiDHOXYBlhPVgbV+neSnSB70belZLNfykAVa564360h7Br/5PogR5jW2n/tOKw==",
       "dev": true,
       "dependencies": {
         "chalk": "~4.1.2",
         "commander": "~10.0.0",
         "fs-extra": "~11.1.0",
         "jsonschema": "~1.4.1",
-        "langium": "~1.2.0",
+        "langium": "~1.3.0",
+        "langium-railroad": "~1.3.0",
         "lodash": "~4.17.21"
       },
       "bin": {
@@ -16255,27 +16246,14 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/langium/node_modules/@chevrotain/types": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
-      "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
-    },
-    "node_modules/langium/node_modules/@chevrotain/utils": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.4.2.tgz",
-      "integrity": "sha512-V34dacxWLwKcvcy32dx96ADJVdB7kOJLm7LyBkBQw5u5HC9WdEFw2G17zml+U3ivavGTrGPJHl8o9/UJm0PlUw=="
-    },
-    "node_modules/langium/node_modules/chevrotain": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.4.2.tgz",
-      "integrity": "sha512-gzF5GxE0Ckti5kZVuKEZycLntB5X2aj9RVY0r4/220GwQjdnljU+/t3kP74/FMWC7IzCDDEjQ9wsFUf0WCdSHg==",
+    "node_modules/langium-railroad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-1.3.0.tgz",
+      "integrity": "sha512-I3gx79iF+Qpn2UjzfHLf2GENAD9mPdSZHL3juAZLBsxznw4se7MBrJX32oPr/35DTjU9q99wFCQoCXu7mcf+Bg==",
+      "dev": true,
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "10.4.2",
-        "@chevrotain/gast": "10.4.2",
-        "@chevrotain/types": "10.4.2",
-        "@chevrotain/utils": "10.4.2",
-        "lodash": "4.17.21",
-        "regexp-to-ast": "0.5.0"
+        "langium": "~1.3.0",
+        "railroad-diagrams": "^1.0.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -19923,6 +19901,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -23229,9 +23213,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -26453,13 +26437,6 @@
         "@chevrotain/gast": "10.4.2",
         "@chevrotain/types": "10.4.2",
         "lodash": "4.17.21"
-      },
-      "dependencies": {
-        "@chevrotain/types": {
-          "version": "10.4.2",
-          "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
-          "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
-        }
       }
     },
     "@chevrotain/gast": {
@@ -26469,14 +26446,17 @@
       "requires": {
         "@chevrotain/types": "10.4.2",
         "lodash": "4.17.21"
-      },
-      "dependencies": {
-        "@chevrotain/types": {
-          "version": "10.4.2",
-          "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
-          "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
-        }
       }
+    },
+    "@chevrotain/types": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
+      "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
+    },
+    "@chevrotain/utils": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.4.2.tgz",
+      "integrity": "sha512-V34dacxWLwKcvcy32dx96ADJVdB7kOJLm7LyBkBQw5u5HC9WdEFw2G17zml+U3ivavGTrGPJHl8o9/UJm0PlUw=="
     },
     "@colors/colors": {
       "version": "1.5.0",
@@ -31475,6 +31455,19 @@
         }
       }
     },
+    "chevrotain": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.4.2.tgz",
+      "integrity": "sha512-gzF5GxE0Ckti5kZVuKEZycLntB5X2aj9RVY0r4/220GwQjdnljU+/t3kP74/FMWC7IzCDDEjQ9wsFUf0WCdSHg==",
+      "requires": {
+        "@chevrotain/cst-dts-gen": "10.4.2",
+        "@chevrotain/gast": "10.4.2",
+        "@chevrotain/types": "10.4.2",
+        "@chevrotain/utils": "10.4.2",
+        "lodash": "4.17.21",
+        "regexp-to-ast": "0.5.0"
+      }
+    },
     "chevrotain-allstar": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.1.4.tgz",
@@ -31482,31 +31475,6 @@
       "requires": {
         "chevrotain": "^10.4.1",
         "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "@chevrotain/types": {
-          "version": "10.4.2",
-          "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
-          "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
-        },
-        "@chevrotain/utils": {
-          "version": "10.4.2",
-          "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.4.2.tgz",
-          "integrity": "sha512-V34dacxWLwKcvcy32dx96ADJVdB7kOJLm7LyBkBQw5u5HC9WdEFw2G17zml+U3ivavGTrGPJHl8o9/UJm0PlUw=="
-        },
-        "chevrotain": {
-          "version": "10.4.2",
-          "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.4.2.tgz",
-          "integrity": "sha512-gzF5GxE0Ckti5kZVuKEZycLntB5X2aj9RVY0r4/220GwQjdnljU+/t3kP74/FMWC7IzCDDEjQ9wsFUf0WCdSHg==",
-          "requires": {
-            "@chevrotain/cst-dts-gen": "10.4.2",
-            "@chevrotain/gast": "10.4.2",
-            "@chevrotain/types": "10.4.2",
-            "@chevrotain/utils": "10.4.2",
-            "lodash": "4.17.21",
-            "regexp-to-ast": "0.5.0"
-          }
-        }
       }
     },
     "chokidar": {
@@ -36956,53 +36924,29 @@
       "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="
     },
     "langium": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-1.2.0.tgz",
-      "integrity": "sha512-jFSptpFljYo9ZTHrq/GZflMUXiKo5KBNtsaIJtnIzDm9zC2FxsxejEFAtNL09262RVQt+zFeF/2iLAShFTGitw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-1.3.1.tgz",
+      "integrity": "sha512-xC+DnAunl6cZIgYjRpgm3s1kYAB5/Wycsj24iYaXG9uai7SgvMaFZSrRvdA5rUK/lSta/CRvgF+ZFoEKEOFJ5w==",
       "requires": {
         "chevrotain": "~10.4.2",
         "chevrotain-allstar": "~0.1.4",
         "vscode-languageserver": "~8.0.2",
         "vscode-languageserver-textdocument": "~1.0.8",
         "vscode-uri": "~3.0.7"
-      },
-      "dependencies": {
-        "@chevrotain/types": {
-          "version": "10.4.2",
-          "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
-          "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
-        },
-        "@chevrotain/utils": {
-          "version": "10.4.2",
-          "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.4.2.tgz",
-          "integrity": "sha512-V34dacxWLwKcvcy32dx96ADJVdB7kOJLm7LyBkBQw5u5HC9WdEFw2G17zml+U3ivavGTrGPJHl8o9/UJm0PlUw=="
-        },
-        "chevrotain": {
-          "version": "10.4.2",
-          "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.4.2.tgz",
-          "integrity": "sha512-gzF5GxE0Ckti5kZVuKEZycLntB5X2aj9RVY0r4/220GwQjdnljU+/t3kP74/FMWC7IzCDDEjQ9wsFUf0WCdSHg==",
-          "requires": {
-            "@chevrotain/cst-dts-gen": "10.4.2",
-            "@chevrotain/gast": "10.4.2",
-            "@chevrotain/types": "10.4.2",
-            "@chevrotain/utils": "10.4.2",
-            "lodash": "4.17.21",
-            "regexp-to-ast": "0.5.0"
-          }
-        }
       }
     },
     "langium-cli": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-1.2.0.tgz",
-      "integrity": "sha512-DPyJUd4Hj8+OBNEcAQyJtW6e38+UPd758gTI7Ep0r/sDogrwJ/GJHx5nGA+r0ygpNcDPG+mS9Hw8Y05uCNNcoQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-1.3.1.tgz",
+      "integrity": "sha512-9faKpioKCjBD0Z4y165+wQlDFiDHOXYBlhPVgbV+neSnSB70belZLNfykAVa564360h7Br/5PogR5jW2n/tOKw==",
       "dev": true,
       "requires": {
         "chalk": "~4.1.2",
         "commander": "~10.0.0",
         "fs-extra": "~11.1.0",
         "jsonschema": "~1.4.1",
-        "langium": "~1.2.0",
+        "langium": "~1.3.0",
+        "langium-railroad": "~1.3.0",
         "lodash": "~4.17.21"
       },
       "dependencies": {
@@ -37023,6 +36967,16 @@
             "universalify": "^2.0.0"
           }
         }
+      }
+    },
+    "langium-railroad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-1.3.0.tgz",
+      "integrity": "sha512-I3gx79iF+Qpn2UjzfHLf2GENAD9mPdSZHL3juAZLBsxznw4se7MBrJX32oPr/35DTjU9q99wFCQoCXu7mcf+Bg==",
+      "dev": true,
+      "requires": {
+        "langium": "~1.3.0",
+        "railroad-diagrams": "^1.0.0"
       }
     },
     "language-subtag-registry": {
@@ -39690,6 +39644,12 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -42133,9 +42093,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "prettier": "^2.8.7",
         "ts-jest": "28.0.5",
         "ts-node": "10.9.1",
-        "typescript": "^4.9.5"
+        "typescript": "^5.0.4"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -23213,16 +23213,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {
@@ -42093,9 +42093,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prettier": "^2.8.7",
     "ts-jest": "28.0.5",
     "ts-node": "10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.4"
   },
   "overrides": {
     "remark-parse@8.0.3": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "fp-ts": "^2.13.1",
     "gtfs-realtime-bindings": "^1.1.1",
     "jszip": "^3.10.1",
-    "langium": "^1.2.0",
+    "langium": "^1.3.0",
     "mime-types": "^2.1.35",
     "monaco-editor": "^0.34.1",
     "monaco-languageclient": "^4.0.3",
@@ -84,13 +84,13 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "28.1.1",
     "jest-environment-jsdom": "28.1.1",
-    "langium-cli": "^1.2.0",
+    "langium-cli": "^1.3.0",
     "nock": "13.3.1",
     "nx": "15.3.0",
     "prettier": "^2.8.7",
     "ts-jest": "28.0.5",
     "ts-node": "10.9.1",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.5"
   },
   "overrides": {
     "remark-parse@8.0.3": {


### PR DESCRIPTION
Closes #426.

## Changes

- Upgrade Langium to version `1.3`
- Upgrade TypeScript to version `4.9.5` as the new langium version introduces the usage of the `satisfies` keyword that comes with TypeScript version `4.9.0`.
- Fix the `JayveeCompletionProvider` that needs to be handed through the `CompletionContext` (change in the new Langium version)
- Further, upgrade TypeScript to `5.0.4` - the version Langium version `1.3` used for development; in expectation the future versions require upgrading TypeScript anyway