### PR TITLE
Add a tertiary operator 'replace'

### DIFF
--- a/libs/language-server/src/grammar/expression.langium
+++ b/libs/language-server/src/grammar/expression.langium
@@ -10,9 +10,12 @@ import './terminal'
 import './transform'
 
 Expression:
-  OrExpression;
+  ReplaceExpression;
 
 // The nesting of the following rules implies the precedence of the operators:
+
+ReplaceExpression infers Expression:
+  OrExpression ({infer TernaryExpression.first=current} operator='replace' second=OrExpression 'with' third=OrExpression)*;
 
 OrExpression infers Expression:
   AndExpression ({infer BinaryExpression.left=current} operator='or' right=AndExpression)*;

--- a/libs/language-server/src/lib/ast/expressions/evaluation.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluation.ts
@@ -26,6 +26,7 @@ import {
   isReferenceLiteral,
   isRegexLiteral,
   isRuntimeParameterLiteral,
+  isTernaryExpression,
   isTransformDefinition,
   isTransformPortDefinition,
   isUnaryExpression,
@@ -41,6 +42,7 @@ import { type InternalValueRepresentation } from './internal-value-representatio
 // eslint-disable-next-line import/no-cycle
 import {
   binaryOperatorRegistry,
+  ternaryOperatorRegistry,
   unaryOperatorRegistry,
 } from './operator-registry';
 import { isEveryValueDefined } from './typeguards';
@@ -221,6 +223,11 @@ export function evaluateExpression(
   if (isBinaryExpression(expression)) {
     const operator = expression.operator;
     const evaluator = binaryOperatorRegistry[operator].evaluation;
+    return evaluator.evaluate(expression, evaluationContext, strategy, context);
+  }
+  if (isTernaryExpression(expression)) {
+    const operator = expression.operator;
+    const evaluator = ternaryOperatorRegistry[operator].evaluation;
     return evaluator.evaluate(expression, evaluationContext, strategy, context);
   }
   assertUnreachable(expression);

--- a/libs/language-server/src/lib/ast/expressions/evaluators/replace-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/replace-operator-evaluator.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// eslint-disable-next-line import/no-cycle
+import { DefaultTernaryOperatorEvaluator } from '../operator-evaluator';
+import { REGEXP_TYPEGUARD, STRING_TYPEGUARD } from '../typeguards';
+
+export class ReplaceOperatorEvaluator extends DefaultTernaryOperatorEvaluator<
+  string,
+  RegExp,
+  string,
+  string
+> {
+  constructor() {
+    super('replace', STRING_TYPEGUARD, REGEXP_TYPEGUARD, STRING_TYPEGUARD);
+  }
+  override doEvaluate(
+    firstValue: string,
+    secondValue: RegExp,
+    thirdValue: string,
+  ): string {
+    return firstValue.replace(secondValue, thirdValue);
+  }
+}

--- a/libs/language-server/src/lib/ast/expressions/operator-registry.ts
+++ b/libs/language-server/src/lib/ast/expressions/operator-registry.ts
@@ -4,9 +4,14 @@
 
 /* eslint-disable import/no-cycle */
 
-import { BinaryExpression, UnaryExpression } from '../generated/ast';
+import {
+  BinaryExpression,
+  TernaryExpression,
+  UnaryExpression,
+} from '../generated/ast';
 import {
   BinaryExpressionOperator,
+  TernaryExpressionOperator,
   UnaryExpressionOperator,
 } from '../model-util';
 
@@ -30,6 +35,7 @@ import { NotOperatorEvaluator } from './evaluators/not-operator-evaluator';
 import { OrOperatorEvaluator } from './evaluators/or-operator-evaluator';
 import { PlusOperatorEvaluator } from './evaluators/plus-operator-evaluator';
 import { PowOperatorEvaluator } from './evaluators/pow-operator-evaluator';
+import { ReplaceOperatorEvaluator } from './evaluators/replace-operator-evaluator';
 import { RootOperatorEvaluator } from './evaluators/root-operator-evaluator';
 import { RoundOperatorEvaluator } from './evaluators/round-operator-evaluator';
 import { SqrtOperatorEvaluator } from './evaluators/sqrt-operator-evaluator';
@@ -38,6 +44,7 @@ import { XorOperatorEvaluator } from './evaluators/xor-operator-evaluator';
 import { OperatorEvaluator } from './operator-evaluator';
 import {
   BinaryOperatorTypeComputer,
+  TernaryOperatorTypeComputer,
   UnaryOperatorTypeComputer,
 } from './operator-type-computer';
 import { BasicArithmeticOperatorTypeComputer } from './type-computers/basic-arithmetic-operator-type-computer';
@@ -50,6 +57,7 @@ import { LogicalOperatorTypeComputer } from './type-computers/logical-operator-t
 import { MatchesOperatorTypeComputer } from './type-computers/matches-operator-type-computer';
 import { NotOperatorTypeComputer } from './type-computers/not-operator-type-computer';
 import { RelationalOperatorTypeComputer } from './type-computers/relational-operator-type-computer';
+import { ReplaceOperatorTypeComputer } from './type-computers/replace-operator-type-computer';
 import { SignOperatorTypeComputer } from './type-computers/sign-operator-type-computer';
 import { SqrtOperatorTypeComputer } from './type-computers/sqrt-operator-type-computer';
 
@@ -172,5 +180,20 @@ export const binaryOperatorRegistry: Record<
   or: {
     typeInference: new LogicalOperatorTypeComputer(),
     evaluation: new OrOperatorEvaluator(),
+  },
+};
+
+export interface TernaryOperatorEntry {
+  typeInference: TernaryOperatorTypeComputer;
+  evaluation: OperatorEvaluator<TernaryExpression>;
+}
+
+export const ternaryOperatorRegistry: Record<
+  TernaryExpressionOperator,
+  TernaryOperatorEntry
+> = {
+  replace: {
+    typeInference: new ReplaceOperatorTypeComputer(),
+    evaluation: new ReplaceOperatorEvaluator(),
   },
 };

--- a/libs/language-server/src/lib/ast/expressions/type-computers/replace-operator-type-computer.ts
+++ b/libs/language-server/src/lib/ast/expressions/type-computers/replace-operator-type-computer.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { type Valuetype } from '../../wrappers/value-type';
+// eslint-disable-next-line import/no-cycle
+import { PrimitiveValuetypes } from '../../wrappers/value-type/primitive/primitive-valuetypes';
+import { DefaultTernaryOperatorTypeComputer } from '../operator-type-computer';
+
+export class ReplaceOperatorTypeComputer extends DefaultTernaryOperatorTypeComputer {
+  constructor() {
+    super(
+      PrimitiveValuetypes.Text,
+      PrimitiveValuetypes.Regex,
+      PrimitiveValuetypes.Text,
+    );
+  }
+
+  override doComputeType(): Valuetype {
+    return PrimitiveValuetypes.Text;
+  }
+}

--- a/libs/language-server/src/lib/ast/expressions/type-inference.ts
+++ b/libs/language-server/src/lib/ast/expressions/type-inference.ts
@@ -26,6 +26,7 @@ import {
   isNumericLiteral,
   isReferenceLiteral,
   isRegexLiteral,
+  isTernaryExpression,
   isTextLiteral,
   isTransformDefinition,
   isTransformPortDefinition,
@@ -50,6 +51,7 @@ import { createValuetype } from '../wrappers/value-type/valuetype-util';
 
 import {
   binaryOperatorRegistry,
+  ternaryOperatorRegistry,
   unaryOperatorRegistry,
 } from './operator-registry';
 import { isEveryValueDefined } from './typeguards';
@@ -84,6 +86,28 @@ export function inferExpressionType(
     const operator = expression.operator;
     const typeComputer = binaryOperatorRegistry[operator].typeInference;
     return typeComputer.computeType(leftType, rightType, expression, context);
+  }
+  if (isTernaryExpression(expression)) {
+    const firstType = inferExpressionType(expression.first, context);
+    const secondType = inferExpressionType(expression.second, context);
+    const thirdType = inferExpressionType(expression.third, context);
+    if (
+      firstType === undefined ||
+      secondType === undefined ||
+      thirdType === undefined
+    ) {
+      return undefined;
+    }
+
+    const operator = expression.operator;
+    const typeComputer = ternaryOperatorRegistry[operator].typeInference;
+    return typeComputer.computeType(
+      firstType,
+      secondType,
+      thirdType,
+      expression,
+      context,
+    );
   }
   assertUnreachable(expression);
 }

--- a/libs/language-server/src/lib/ast/model-util.ts
+++ b/libs/language-server/src/lib/ast/model-util.ts
@@ -8,6 +8,7 @@ import {
   BinaryExpression,
   BuiltinBlocktypeDefinition,
   BuiltinConstrainttypeDefinition,
+  TernaryExpression,
   UnaryExpression,
   isBuiltinBlocktypeDefinition,
   isJayveeModel,
@@ -17,6 +18,7 @@ import { BlockTypeWrapper, ConstraintTypeWrapper } from './wrappers';
 
 export type UnaryExpressionOperator = UnaryExpression['operator'];
 export type BinaryExpressionOperator = BinaryExpression['operator'];
+export type TernaryExpressionOperator = TernaryExpression['operator'];
 
 export type AstTypeGuard<T extends AstNode = AstNode> = (
   obj: unknown,

--- a/libs/language-server/src/lib/validation/checks/transform-output-assigment.ts
+++ b/libs/language-server/src/lib/validation/checks/transform-output-assigment.ts
@@ -18,6 +18,7 @@ import {
   isBinaryExpression,
   isExpressionLiteral,
   isReferenceLiteral,
+  isTernaryExpression,
   isTransformPortDefinition,
   isUnaryExpression,
 } from '../../ast/generated/ast';
@@ -121,6 +122,12 @@ export function extractReferenceLiterals(
       return [expression];
     }
     return [];
+  } else if (isTernaryExpression(expression)) {
+    return [
+      ...extractReferenceLiterals(expression.first),
+      ...extractReferenceLiterals(expression.second),
+      ...extractReferenceLiterals(expression.third),
+    ];
   } else if (isBinaryExpression(expression)) {
     return [
       ...extractReferenceLiterals(expression.left),

--- a/libs/language-server/src/lib/validation/validation-util.ts
+++ b/libs/language-server/src/lib/validation/validation-util.ts
@@ -15,6 +15,7 @@ import {
   isBinaryExpression,
   isExpressionLiteral,
   isFreeVariableLiteral,
+  isTernaryExpression,
   isUnaryExpression,
   isValueLiteral,
 } from '../ast';
@@ -135,6 +136,39 @@ function collectSubExpressionsWithoutFreeVariables(
       return [expression];
     }
     return [...leftSubExpressions, ...rightSubExpressions];
+  } else if (isTernaryExpression(expression)) {
+    const firstExpression = expression.first;
+    const secondExpression = expression.second;
+    const thirdExpression = expression.third;
+    const firstSubExpressions =
+      collectSubExpressionsWithoutFreeVariables(firstExpression);
+    const secondSubExpressions =
+      collectSubExpressionsWithoutFreeVariables(secondExpression);
+    const thirdSubExpressions =
+      collectSubExpressionsWithoutFreeVariables(thirdExpression);
+
+    const firstExpressionHasNoFreeVariables =
+      firstSubExpressions.length === 1 &&
+      firstSubExpressions[0] === firstExpression;
+    const secondExpressionHasNoFreeVariables =
+      secondSubExpressions.length === 1 &&
+      secondSubExpressions[0] === secondExpression;
+    const thirdExpressionHasNoFreeVariables =
+      thirdSubExpressions.length === 1 &&
+      thirdSubExpressions[0] === thirdExpression;
+
+    if (
+      firstExpressionHasNoFreeVariables &&
+      secondExpressionHasNoFreeVariables &&
+      thirdExpressionHasNoFreeVariables
+    ) {
+      return [expression];
+    }
+    return [
+      ...firstSubExpressions,
+      ...secondSubExpressions,
+      ...thirdSubExpressions,
+    ];
   }
   assertUnreachable(expression);
 }


### PR DESCRIPTION
Adds the `replace` operator.

This is:
- the first tertiary operator in Jayvee
- the first operator with a string return type

Closes #482.