### PR TITLE
Fixed build failing if no peer dependencies exist

### DIFF
--- a/tools/scripts/relax-peer-dependency-versions.mjs
+++ b/tools/scripts/relax-peer-dependency-versions.mjs
@@ -31,19 +31,20 @@ const [, , projectName] = process.argv;
 process.chdir(getOutputPath(projectName));
 
 const packageJson = parsePackageJson();
-invariant(packageJson.peerDependencies, 'Found no peer dependencies in package.json');
 
-for (const [packageName, packageVersion] of Object.entries(
-    packageJson.peerDependencies,
-)) {
-    const parsedVersion = parsePackageVersion(packageVersion);
-    let newVersion;
-    if (parsedVersion.major < 1) {
-        newVersion = `^0.${parsedVersion.minor}.0`;
-    } else {
-        newVersion = `^${parsedVersion.major}.0.0`;
+if (packageJson.peerDependencies) {
+    for (const [packageName, packageVersion] of Object.entries(
+        packageJson.peerDependencies,
+    )) {
+        const parsedVersion = parsePackageVersion(packageVersion);
+        let newVersion;
+        if (parsedVersion.major < 1) {
+            newVersion = `^0.${parsedVersion.minor}.0`;
+        } else {
+            newVersion = `^${parsedVersion.major}.0.0`;
+        }
+        packageJson.peerDependencies[packageName] = newVersion;
     }
-    packageJson.peerDependencies[packageName] = newVersion;
 }
 
 writePackageJson(packageJson);


### PR DESCRIPTION
Publishing jayvee fails with

```
Found no peer dependencies in package.json
Warning: run-commands command "node tools/scripts/relax-peer-dependency-versions.mjs interpreter-lib" exited with non-zero status code
```

And I don't think there are peer dependencies in the package.json indeed, could this be related to the upgrades (langium/nx)?

This change allows all steps including `pack` to run successfully at least.