### PR TITLE
Operator tests

### DIFF
--- a/libs/language-server/src/lib/ast/expressions/evaluators/replace-operator-evaluator.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/replace-operator-evaluator.spec.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import { executeExpressionTestHelper } from '../test-utils';
+
+describe('The replace operator', () => {
+  it('should replace text successfully', async () => {
+    const result = await executeExpressionTestHelper(
+      "inputValue replace /test/ with 'works'",
+      'inputValue',
+      'test',
+    );
+
+    expect(result).toEqual('test');
+  });
+});

--- a/libs/language-server/src/lib/ast/expressions/evaluators/replace-operator-evaluator.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/replace-operator-evaluator.spec.ts
@@ -1,16 +1,24 @@
 // SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
 //
 // SPDX-License-Identifier: AGPL-3.0-only
-import { executeExpressionTestHelper } from '../test-utils';
+import { executeDefaultTextToTextExpression } from '../test-utils';
 
 describe('The replace operator', () => {
   it('should replace text successfully', async () => {
-    const result = await executeExpressionTestHelper(
-      "inputValue replace /test/ with 'works'",
-      'inputValue',
-      'test',
+    const result = await executeDefaultTextToTextExpression(
+      "inputValue replace /Test/ with 'World'",
+      'Hello Test',
     );
 
-    expect(result).toEqual('test');
+    expect(result).toEqual('Hello World');
+  });
+
+  it('should be able to replace text with nothing', async () => {
+    const result = await executeDefaultTextToTextExpression(
+      "inputValue replace / Test/ with ''",
+      'Hello Test',
+    );
+
+    expect(result).toEqual('Hello');
   });
 });

--- a/libs/language-server/src/lib/ast/expressions/test-utils.ts
+++ b/libs/language-server/src/lib/ast/expressions/test-utils.ts
@@ -12,10 +12,25 @@ import { TransformDefinition } from '../generated/ast';
 import { EvaluationContext, evaluateExpression } from './evaluation';
 import { InternalValueRepresentation } from './internal-value-representation';
 
+export async function executeDefaultTextToTextExpression(
+  expression: string,
+  input: InternalValueRepresentation,
+) {
+  return executeExpressionTestHelper(
+    expression,
+    'inputValue',
+    'text',
+    input,
+    'text',
+  );
+}
+
 export async function executeExpressionTestHelper(
   expression: string,
   inputValueName: string,
+  inputValueType: 'text',
   inputValueValue: InternalValueRepresentation,
+  outputValueType: 'text',
 ): Promise<InternalValueRepresentation | undefined> {
   const services = createJayveeServices(NodeFileSystem).Jayvee;
   const parse = parseHelper(services);
@@ -23,8 +38,8 @@ export async function executeExpressionTestHelper(
 
   const document = await parse(`
         transform TestTransform {
-            from ${inputValueName} oftype text;
-            to outputValue oftype text;
+            from ${inputValueName} oftype ${inputValueType};
+            to outputValue oftype ${outputValueType};
         
             outputValue: ${expression};
         }

--- a/libs/language-server/src/lib/ast/expressions/test-utils.ts
+++ b/libs/language-server/src/lib/ast/expressions/test-utils.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { NodeFileSystem } from 'langium/node';
+
+import { parseHelper } from '../../../test/langium-utils';
+import { createJayveeServices } from '../../jayvee-module';
+import { RuntimeParameterProvider } from '../../services';
+import { TransformDefinition } from '../generated/ast';
+
+import { EvaluationContext, evaluateExpression } from './evaluation';
+import { InternalValueRepresentation } from './internal-value-representation';
+
+export async function executeExpressionTestHelper(
+  expression: string,
+  inputValueName: string,
+  inputValueValue: InternalValueRepresentation,
+): Promise<InternalValueRepresentation | undefined> {
+  const services = createJayveeServices(NodeFileSystem).Jayvee;
+  const parse = parseHelper(services);
+  const locator = services.workspace.AstNodeLocator;
+
+  const document = await parse(`
+        transform TestTransform {
+            from ${inputValueName} oftype text;
+            to outputValue oftype text;
+        
+            outputValue: ${expression};
+        }
+    `);
+
+  const transform = locator.getAstNode<TransformDefinition>(
+    document.parseResult.value,
+    'transforms@0',
+  ) as TransformDefinition;
+
+  const runTimeParameterProvider = new RuntimeParameterProvider();
+  const evaluationContext = new EvaluationContext(runTimeParameterProvider);
+
+  evaluationContext.setValueForReference(inputValueName, inputValueValue);
+
+  return evaluateExpression(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    transform.body.outputAssignments[0]!.expression,
+    evaluationContext,
+  );
+}


### PR DESCRIPTION
Adds basic test utilities (reusing transforms) and uses those to implement a few example operator tests for expressions.

reference https://github.com/jvalue/jayvee/issues/522