### PR TITLE
Fixed publishing to npm failing because of peerDependencies

### DIFF
--- a/.github/workflows/check-paths-for-windows.yaml
+++ b/.github/workflows/check-paths-for-windows.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-name: CI
+name: Check paths for windows
 
 on:
   push:

--- a/tools/scripts/monaco-editor/delete-vscode-peer-dependency.mjs
+++ b/tools/scripts/monaco-editor/delete-vscode-peer-dependency.mjs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import {getOutputPath, parsePackageJson, writePackageJson} from "../shared-util.mjs";
+import { getOutputPath, parsePackageJson, writePackageJson } from "../shared-util.mjs";
 
 // Executing this script: node path/to/delete-vscode-peer-dependency.mjs {projectName}
 const [, , projectName] = process.argv;
@@ -22,6 +22,8 @@ const packageJson = parsePackageJson();
 
   Since this package is a peer dependency of `monaco-languageclient` anyways, we can simply remove the entry for `vscode` to fix the problem.
 */
-delete packageJson.peerDependencies.vscode;
+if (packageJson.peerDependencies) {
+  delete packageJson.peerDependencies.vscode;
+}
 
 writePackageJson(packageJson);

--- a/tools/scripts/monaco-editor/relax-react-version.mjs
+++ b/tools/scripts/monaco-editor/relax-react-version.mjs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import {getOutputPath, parsePackageJson, writePackageJson} from "../shared-util.mjs";
+import { getOutputPath, parsePackageJson, writePackageJson } from "../shared-util.mjs";
 
 // Executing this script: node path/to/relax-react-version.mjs {projectName}
 const [, , projectName] = process.argv;
@@ -11,6 +11,8 @@ process.chdir(getOutputPath(projectName));
 const packageJson = parsePackageJson();
 
 // By default, this value is set to the exact React version we are using. This makes it hard to use the package in environments where a different React version is present.
-packageJson.peerDependencies.react = '>= 17';
+if (packageJson.peerDependencies) {
+    packageJson.peerDependencies.react = '>= 17';
+}
 
 writePackageJson(packageJson);


### PR DESCRIPTION
I am not sure why this did not fail earlier for me but this allows pack to run for all projects, using `npx nx run-many --target pack`. As this only changes the monaco editor used in the hub the impact should be small.