### PR TITLE
CI Publish Safeguard

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,3 +44,11 @@ jobs:
 
       - name: Test
         run: npx nx affected --target=test --parallel=3 --base=remotes/origin/main --head=HEAD --ci
+
+      # Ensure this works for future release publishing
+      - name: Publish Dry-Run
+        run: npx nx affected --target=pre-publish --parallel=3 --base=remotes/origin/main --head=HEAD --ci
+
+      # Ensure this works for future release publishing
+      - name: Pack VSCode Extension
+        run: npx nx run vs-code-extension:pack:prod

--- a/apps/interpreter/project.json
+++ b/apps/interpreter/project.json
@@ -48,7 +48,8 @@
         "commands": [
           "node tools/scripts/interpreter/prepend-shebang.mjs interpreter main.js",
           "node tools/scripts/add-package-json-version.mjs interpreter",
-          "node tools/scripts/interpreter/rewrite-version-mainjs.mjs interpreter"
+          "node tools/scripts/interpreter/rewrite-version-mainjs.mjs interpreter",
+          "node tools/scripts/publish.mjs interpreter false" // dry-run
         ],
         "parallel": false
       }
@@ -57,7 +58,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["pre-publish"],
       "options": {
-        "commands": ["node tools/scripts/publish.mjs interpreter"],
+        "commands": ["node tools/scripts/publish.mjs interpreter true"],
         "parallel": false
       }
     },

--- a/apps/language-server-web-worker/project.json
+++ b/apps/language-server-web-worker/project.json
@@ -46,7 +46,7 @@
         "jestConfig": "apps/language-server-web-worker/jest.config.ts"
       }
     },
-    "publish": {
+    "pre-publish": {
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
       "options": {
@@ -54,7 +54,17 @@
           // Manually delete all dependencies in package.json because the "externalDependencies": "none" setting in "build" above seems to have no effect on the generated package.json
           "node tools/scripts/delete-dependencies.mjs language-server-web-worker",
           "node tools/scripts/add-package-json-version.mjs language-server-web-worker",
-          "node tools/scripts/publish.mjs language-server-web-worker"
+          "node tools/scripts/publish.mjs language-server-web-worker false" // dry-run
+        ],
+        "parallel": false
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["pre-publish"],
+      "options": {
+        "commands": [
+          "node tools/scripts/publish.mjs language-server-web-worker true"
         ],
         "parallel": false
       }

--- a/libs/interpreter-lib/project.json
+++ b/libs/interpreter-lib/project.json
@@ -32,7 +32,8 @@
       "options": {
         "commands": [
           "node tools/scripts/relax-peer-dependency-versions.mjs interpreter-lib",
-          "node tools/scripts/add-package-json-version.mjs interpreter-lib"
+          "node tools/scripts/add-package-json-version.mjs interpreter-lib",
+          "node tools/scripts/publish.mjs interpreter-lib false" // dry-run
         ],
         "parallel": false
       }
@@ -41,7 +42,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["pre-publish"],
       "options": {
-        "commands": ["node tools/scripts/publish.mjs interpreter-lib"],
+        "commands": ["node tools/scripts/publish.mjs interpreter-lib true"],
         "parallel": false
       }
     },

--- a/libs/language-server/project.json
+++ b/libs/language-server/project.json
@@ -49,7 +49,8 @@
       "options": {
         "commands": [
           "node tools/scripts/relax-peer-dependency-versions.mjs language-server",
-          "node tools/scripts/add-package-json-version.mjs language-server"
+          "node tools/scripts/add-package-json-version.mjs language-server",
+          "node tools/scripts/publish.mjs language-server false"
         ],
         "parallel": false
       }
@@ -58,7 +59,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["pre-publish"],
       "options": {
-        "commands": ["node tools/scripts/publish.mjs language-server"],
+        "commands": ["node tools/scripts/publish.mjs language-server true"],
         "parallel": false
       }
     },

--- a/libs/monaco-editor/project.json
+++ b/libs/monaco-editor/project.json
@@ -51,7 +51,8 @@
           "node tools/scripts/relax-peer-dependency-versions.mjs monaco-editor",
           "node tools/scripts/monaco-editor/delete-vscode-peer-dependency.mjs monaco-editor",
           "node tools/scripts/monaco-editor/relax-react-version.mjs monaco-editor",
-          "node tools/scripts/add-package-json-version.mjs monaco-editor"
+          "node tools/scripts/add-package-json-version.mjs monaco-editor",
+          "node tools/scripts/publish.mjs monaco-editor false" // dry-run
         ],
         "parallel": false
       }
@@ -60,7 +61,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["pre-publish"],
       "options": {
-        "commands": ["node tools/scripts/publish.mjs monaco-editor"],
+        "commands": ["node tools/scripts/publish.mjs monaco-editor true"],
         "parallel": false
       }
     },

--- a/tools/scripts/publish.mjs
+++ b/tools/scripts/publish.mjs
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import {execSync} from 'child_process';
-import {getOutputPath} from "./shared-util.mjs";
+import { execSync } from 'child_process';
+import { getOutputPath } from './shared-util.mjs';
 
-// Executing this script: node path/to/publish.mjs {projectName}
-const [, , projectName] = process.argv;
+// Executing this script: node path/to/publish.mjs {projectName} {no-dry-run}
+const [, , projectName, isNoDryRun] = process.argv;
+
+const isDryRun = isNoDryRun !== 'true';
 
 const outputPath = getOutputPath(projectName);
 
-execSync(`npm publish ${outputPath}`);
+execSync(`npm publish ${outputPath} ${!isDryRun ? '' : '--dry-run'}`);


### PR DESCRIPTION
Adds a "package publish dry-run" to every CI run to ensure releases don't fail due to build errors. 

I used the `pre-publish` build command instead of introducing another command. 