### PR TITLE
add unary operators 'lowercase' and 'uppercase'

### DIFF
--- a/apps/docs/docs/user/expressions.md
+++ b/apps/docs/docs/user/expressions.md
@@ -58,6 +58,10 @@ The following expression is evaluated to the `text` `I love Datypus`: `"I love p
 - `matches` for a regex match, e.g., `"A07" matches /^[A-Z0-9]*$/` evaluates to `true`
 - `in` for inclusion in an array, e.g., `"a" in ["a", "b", "c"]` evaluates to `true`
 
+#### Text manipulation (unary operators)
+- `lowercase` converts all alphabetic characters in a text to lowercase
+- `uppercase` converts all alphabetic characters in a text to uppercase
+
 #### Text manipulation (ternary operators)
 - `replace [...] with [...]` replaces regex matches in a text with a string
 

--- a/libs/language-server/src/grammar/expression.langium
+++ b/libs/language-server/src/grammar/expression.langium
@@ -53,7 +53,7 @@ PrimaryExpression infers Expression:
   | ExpressionLiteral;
 
 UnaryExpression:
-  operator=('not' | '+' | '-' | 'sqrt' | 'floor' | 'ceil' | 'round') expression=PrimaryExpression;
+  operator=('not' | '+' | '-' | 'sqrt' | 'floor' | 'ceil' | 'round' | 'lowercase' | 'uppercase') expression=PrimaryExpression;
 
 ExpressionLiteral:
   ValueLiteral | FreeVariableLiteral;

--- a/libs/language-server/src/lib/ast/expressions/evaluators/lowercase-operator-evaluator.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/lowercase-operator-evaluator.spec.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import { executeDefaultTextToTextExpression } from '../test-utils';
+
+describe('The lowercase operator', () => {
+  it('should lowercase alphabetic characters successfully', async () => {
+    const result = await executeDefaultTextToTextExpression(
+      'lowercase inputValue',
+      'Hello, World!',
+    );
+
+    expect(result).toEqual('hello, world!');
+  });
+});

--- a/libs/language-server/src/lib/ast/expressions/evaluators/lowercase-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/lowercase-operator-evaluator.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// eslint-disable-next-line import/no-cycle
+import { DefaultUnaryOperatorEvaluator } from '../operator-evaluator';
+import { STRING_TYPEGUARD } from '../typeguards';
+
+export class LowercaseOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
+  string,
+  string
+> {
+  constructor() {
+    super('lowercase', STRING_TYPEGUARD);
+  }
+  override doEvaluate(operandValue: string): string {
+    return operandValue.toLowerCase();
+  }
+}

--- a/libs/language-server/src/lib/ast/expressions/evaluators/uppercase-operator-evaluator.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/uppercase-operator-evaluator.spec.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import { executeDefaultTextToTextExpression } from '../test-utils';
+
+describe('The uppercase operator', () => {
+  it('should uppercase alphabetic characters successfully', async () => {
+    const result = await executeDefaultTextToTextExpression(
+      'uppercase inputValue',
+      'Hello, World!',
+    );
+
+    expect(result).toEqual('HELLO, WORLD!');
+  });
+});

--- a/libs/language-server/src/lib/ast/expressions/evaluators/uppercase-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/uppercase-operator-evaluator.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// eslint-disable-next-line import/no-cycle
+import { DefaultUnaryOperatorEvaluator } from '../operator-evaluator';
+import { STRING_TYPEGUARD } from '../typeguards';
+
+export class UppercaseOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
+  string,
+  string
+> {
+  constructor() {
+    super('uppercase', STRING_TYPEGUARD);
+  }
+  override doEvaluate(operandValue: string): string {
+    return operandValue.toUpperCase();
+  }
+}

--- a/libs/language-server/src/lib/ast/expressions/operator-registry.ts
+++ b/libs/language-server/src/lib/ast/expressions/operator-registry.ts
@@ -22,6 +22,7 @@ import { InOperatorEvaluator } from './evaluators/in-operator-evaluator';
 import { InequalityOperatorEvaluator } from './evaluators/inequality-operator-evaluator';
 import { LessEqualOperatorEvaluator } from './evaluators/less-equal-operator-evaluator';
 import { LessThanOperatorEvaluator } from './evaluators/less-than-operator-evaluator';
+import { LowercaseOperatorEvaluator } from './evaluators/lowercase-operator-evaluator';
 import { MatchesOperatorEvaluator } from './evaluators/matches-operator-evaluator';
 import { MinusOperatorEvaluator } from './evaluators/minus-operator-evaluator';
 import { ModuloOperatorEvaluator } from './evaluators/modulo-operator-evaluator';
@@ -35,6 +36,7 @@ import { RootOperatorEvaluator } from './evaluators/root-operator-evaluator';
 import { RoundOperatorEvaluator } from './evaluators/round-operator-evaluator';
 import { SqrtOperatorEvaluator } from './evaluators/sqrt-operator-evaluator';
 import { SubtractionOperatorEvaluator } from './evaluators/subtraction-operator-evaluator';
+import { UppercaseOperatorEvaluator } from './evaluators/uppercase-operator-evaluator';
 import { XorOperatorEvaluator } from './evaluators/xor-operator-evaluator';
 import { type OperatorEvaluator } from './operator-evaluator';
 import {
@@ -60,6 +62,7 @@ import { RelationalOperatorTypeComputer } from './type-computers/relational-oper
 import { ReplaceOperatorTypeComputer } from './type-computers/replace-operator-type-computer';
 import { SignOperatorTypeComputer } from './type-computers/sign-operator-type-computer';
 import { SqrtOperatorTypeComputer } from './type-computers/sqrt-operator-type-computer';
+import { StringTransformTypeComputer } from './type-computers/string-transform-type-computer';
 
 export interface OperatorEvaluatorRegistry {
   unary: Record<UnaryExpressionOperator, OperatorEvaluator<UnaryExpression>>;
@@ -87,6 +90,8 @@ export class DefaultOperatorEvaluatorRegistry
     floor: new FloorOperatorEvaluator(),
     ceil: new CeilOperatorEvaluator(),
     round: new RoundOperatorEvaluator(),
+    lowercase: new LowercaseOperatorEvaluator(),
+    uppercase: new UppercaseOperatorEvaluator(),
   };
   binary = {
     pow: new PowOperatorEvaluator(),
@@ -124,6 +129,8 @@ export class DefaultOperatorTypeComputerRegistry
     floor: new IntegerConversionOperatorTypeComputer(),
     ceil: new IntegerConversionOperatorTypeComputer(),
     round: new IntegerConversionOperatorTypeComputer(),
+    lowercase: new StringTransformTypeComputer(),
+    uppercase: new StringTransformTypeComputer(),
   };
   binary = {
     pow: new ExponentialOperatorTypeComputer(),

--- a/libs/language-server/src/lib/ast/expressions/type-computers/string-transform-type-computer.ts
+++ b/libs/language-server/src/lib/ast/expressions/type-computers/string-transform-type-computer.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { type ValueType } from '../../wrappers/value-type';
+// eslint-disable-next-line import/no-cycle
+import { PrimitiveValuetypes } from '../../wrappers/value-type/primitive/primitive-value-types';
+import { DefaultUnaryOperatorTypeComputer } from '../operator-type-computer';
+
+export class StringTransformTypeComputer extends DefaultUnaryOperatorTypeComputer {
+  constructor() {
+    super(PrimitiveValuetypes.Text);
+  }
+
+  override doComputeType(): ValueType {
+    return PrimitiveValuetypes.Text;
+  }
+}


### PR DESCRIPTION
adds the `lowercase` and  `lowercase` operators.

I adapted `cars.jv* to demonstrate them. This file adds 2 new columns, one for the lowercase and one for the uppercase name.

```
pipeline CarsPipeline {

	CarsExtractor
        -> CarsTextFileInterpreter
		-> CarsCSVInterpreter
		-> NameHeaderWriter
	   	-> CarsTableInterpreter
        -> NameToLowerCase
        -> NameToUpperCase
		-> CarsLoader;

    block CarsExtractor oftype HttpExtractor {
	url: "https://gist.githubusercontent.com/noamross/e5d3e859aa0c794be10b/raw/b999fb4425b54c63cab088c0ce2c0d6ce961a563/cars.csv";
	}

	block CarsTextFileInterpreter oftype TextFileInterpreter { }

	block CarsCSVInterpreter oftype CSVInterpreter {
		enclosing: '"';
	}

	block NameHeaderWriter oftype CellWriter {
		at: cell A1;
		write: ["name"];
	}

	block CarsTableInterpreter oftype TableInterpreter {
		header: true;
		columns: [
			"name" oftype text,
			"mpg" oftype decimal,
			"cyl" oftype integer,
			"disp" oftype decimal,
			"hp" oftype integer,
			"drat" oftype decimal,
			"wt" oftype decimal,
			"qsec" oftype decimal,
			"vs" oftype integer,
			"am" oftype integer,
			"gear" oftype integer,
			"carb" oftype integer
		];
	}


	transform LowerCaseText {
		from inputValue oftype text;
		to outputValue oftype text;

		outputValue: lowercase inputValue;
	}

    transform UpperCaseText {
		from inputValue oftype text;
		to outputValue oftype text;

		outputValue: uppercase inputValue;
	}

    block NameToLowerCase oftype TableTransformer {
        inputColumns: ["name"];
        outputColumn: "name_lowercase";

        use: LowerCaseText;
    }

    block NameToUpperCase oftype TableTransformer {
        inputColumns: ["name"];
        outputColumn: "NAME_UPPERCASE";

        use: UpperCaseText;
    }

	block CarsLoader oftype SQLiteLoader {
		table: "Cars";
		file: "./cars.sqlite";
	}
}
```

closes #540 
@rhazn 