### PR TITLE
fix(FilePicker): path can now start with a dot

### DIFF
--- a/libs/execution/src/lib/types/io-types/filesystem-inmemory.ts
+++ b/libs/execution/src/lib/types/io-types/filesystem-inmemory.ts
@@ -57,12 +57,12 @@ export class InMemoryFileSystem implements FileSystem {
   }
 
   private processPath(path: string): string[] | null {
-    if (!path.startsWith(InMemoryFileSystem.getPathSeparator())) {
+    const [head, ...tail] = path.split(InMemoryFileSystem.getPathSeparator());
+    if (!(head === '' || head === InMemoryFileSystem.CURRENT_DIR)) {
       return null;
     }
-    const parts = path
-      .split(InMemoryFileSystem.getPathSeparator())
-      .filter((p) => p !== ''); // Process paths like "folder1//folder1" to "folder1/folder2"
+
+    const parts = tail.filter((p) => p !== ''); // Process paths like "folder1//folder1" to "folder1/folder2"
     const processedParts: string[] = [];
     for (const part of parts) {
       if (part === InMemoryFileSystem.CURRENT_DIR) {

--- a/libs/extensions/std/exec/src/file-picker-executor.spec.ts
+++ b/libs/extensions/std/exec/src/file-picker-executor.spec.ts
@@ -118,4 +118,23 @@ describe('Validation of FilePickerExecutor', () => {
       expect(result.left.message).toEqual(`File '/test.txt' not found`);
     }
   });
+
+  it('should work if the filename starts with a dot', async () => {
+    const text = readJvTestAsset('dot-valid-file-picker.jv');
+    uploadTestFile('test.txt');
+
+    const result = await parseAndExecuteArchiveInterpreter(text, fileSystem);
+
+    expect(R.isErr(result)).toEqual(false);
+    if (R.isOk(result)) {
+      expect(result.right).toEqual(
+        expect.objectContaining({
+          name: 'test.txt',
+          extension: 'txt',
+          ioType: IOType.FILE,
+          mimeType: R.MimeType.TEXT_PLAIN,
+        }),
+      );
+    }
+  });
 });

--- a/libs/extensions/std/exec/test/assets/file-picker-executor/dot-valid-file-picker.jv
+++ b/libs/extensions/std/exec/test/assets/file-picker-executor/dot-valid-file-picker.jv
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestFileExtractor {
+  }
+
+  block TestBlock oftype FilePicker {
+    path: './test.txt';
+  }
+
+  block TestLoader oftype TestFileLoader {
+  }
+
+  TestExtractor -> TestBlock -> TestLoader;
+}


### PR DESCRIPTION
paths inside `FilePicker` can now start with a dot

```
block DataPicker oftype FilePicker {
	path: "./data.csv";
}
```

closes #381 