### PR TITLE
Remove dependency cycle caused be CellRangeWrapper being an internal value representation

### DIFF
--- a/libs/execution/src/lib/blocks/block-executor.ts
+++ b/libs/execution/src/lib/blocks/block-executor.ts
@@ -70,6 +70,7 @@ export abstract class AbstractBlockExecutor<I extends IOType, O extends IOType>
         context.runOptions.debugGranularity,
         'Output',
         context.logger,
+        context.wrapperFactories,
       ),
     );
   }

--- a/libs/execution/src/lib/debugging/debug-log-visitor.ts
+++ b/libs/execution/src/lib/debugging/debug-log-visitor.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { internalValueToString } from '@jvalue/jayvee-language-server';
+import {
+  type WrapperFactoryProvider,
+  internalValueToString,
+} from '@jvalue/jayvee-language-server';
 
 import { type Logger } from '../logging/logger';
 import { type Workbook } from '../types';
@@ -25,6 +28,7 @@ export class DebugLogVisitor implements IoTypeVisitor<void> {
     private debugGranularity: DebugGranularity,
     private logPrefix: string,
     private logger: Logger,
+    private wrapperFactories: WrapperFactoryProvider,
   ) {}
 
   visitTable(table: Table): void {
@@ -51,7 +55,7 @@ export class DebugLogVisitor implements IoTypeVisitor<void> {
 
       const row = table.getRow(i);
       const rowData = [...row.values()]
-        .map((cell) => internalValueToString(cell))
+        .map((cell) => internalValueToString(cell, this.wrapperFactories))
         .join(' | ');
       this.log(`[Row ${i}] ${rowData}`);
     }

--- a/libs/extensions/tabular/exec/src/lib/cell-range-selector-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/cell-range-selector-executor.ts
@@ -32,8 +32,11 @@ export class CellRangeSelectorExecutor extends AbstractBlockExecutor<
       'select',
       PrimitiveValuetypes.CellRange,
     );
+    const relativeRangeWrapper =
+      context.wrapperFactories.CellRange.wrap(relativeRange);
 
-    const absoluteRange = inputSheet.resolveRelativeIndexes(relativeRange);
+    const absoluteRange =
+      inputSheet.resolveRelativeIndexes(relativeRangeWrapper);
 
     if (!inputSheet.isInBounds(absoluteRange)) {
       return R.err({

--- a/libs/extensions/tabular/exec/src/lib/cell-writer-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/cell-writer-executor.ts
@@ -43,10 +43,14 @@ export class CellWriterExecutor extends AbstractBlockExecutor<
       new CollectionValuetype(PrimitiveValuetypes.Text),
     );
 
-    assert(relativeCellRange.isOneDimensional());
+    const relativeCellRangeWrapper =
+      context.wrapperFactories.CellRange.wrap(relativeCellRange);
 
-    const absoluteCellRange =
-      inputSheet.resolveRelativeIndexes(relativeCellRange);
+    assert(relativeCellRangeWrapper.isOneDimensional());
+
+    const absoluteCellRange = inputSheet.resolveRelativeIndexes(
+      relativeCellRangeWrapper,
+    );
     if (!inputSheet.isInBounds(absoluteCellRange)) {
       return R.err({
         message: 'Some specified cells do not exist in the sheet',
@@ -54,13 +58,14 @@ export class CellWriterExecutor extends AbstractBlockExecutor<
       });
     }
 
-    const cellIndexesToWrite =
-      inputSheet.enumerateCellIndexes(relativeCellRange);
+    const cellIndexesToWrite = inputSheet.enumerateCellIndexes(
+      relativeCellRangeWrapper,
+    );
 
     if (writeValues.length !== cellIndexesToWrite.length) {
       context.logger.logWarnDiagnostic(
         `The number of values to write (${writeValues.length}) does not match the number of cells (${cellIndexesToWrite.length})`,
-        { node: relativeCellRange.astNode },
+        { node: relativeCellRangeWrapper.astNode },
       );
     }
 

--- a/libs/extensions/tabular/exec/src/lib/column-deleter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/column-deleter-executor.ts
@@ -38,10 +38,12 @@ export class ColumnDeleterExecutor extends AbstractBlockExecutor<
     inputSheet: Sheet,
     context: ExecutionContext,
   ): Promise<R.Result<Sheet>> {
-    const relativeColumns = context.getPropertyValue(
-      'delete',
-      new CollectionValuetype(PrimitiveValuetypes.CellRange),
-    );
+    const relativeColumns = context
+      .getPropertyValue(
+        'delete',
+        new CollectionValuetype(PrimitiveValuetypes.CellRange),
+      )
+      .map((astNode) => context.wrapperFactories.CellRange.wrap(astNode));
     assert(relativeColumns.every(isColumnWrapper));
 
     let absoluteColumns = relativeColumns.map((column) =>

--- a/libs/extensions/tabular/exec/src/lib/row-deleter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/row-deleter-executor.ts
@@ -38,10 +38,12 @@ export class RowDeleterExecutor extends AbstractBlockExecutor<
     inputSheet: Sheet,
     context: ExecutionContext,
   ): Promise<R.Result<Sheet>> {
-    const relativeRows = context.getPropertyValue(
-      'delete',
-      new CollectionValuetype(PrimitiveValuetypes.CellRange),
-    );
+    const relativeRows = context
+      .getPropertyValue(
+        'delete',
+        new CollectionValuetype(PrimitiveValuetypes.CellRange),
+      )
+      .map((astNode) => context.wrapperFactories.CellRange.wrap(astNode));
     assert(relativeRows.every(isRowWrapper));
 
     let absoluteRows = relativeRows.map((row) =>

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -278,7 +278,9 @@ export function logPipelineOverview(
   if (runtimeParameters.size > 0) {
     linesBuffer.push(`\tRuntime Parameters (${runtimeParameters.size}):`);
     for (const [key, value] of runtimeParameters.entries()) {
-      linesBuffer.push(`\t\t${key}: ${internalValueToString(value)}`);
+      linesBuffer.push(
+        `\t\t${key}: ${internalValueToString(value, wrapperFactories)}`,
+      );
     }
   }
   linesBuffer.push(

--- a/libs/language-server/src/lib/ast/expressions/evaluate-expression.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluate-expression.ts
@@ -166,7 +166,7 @@ function evaluateValueLiteral(
     if (!wrapperFactories.CellRange.canWrap(expression)) {
       return undefined;
     }
-    return wrapperFactories.CellRange.wrap(expression);
+    return expression;
   }
   if (isRegexLiteral(expression)) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/libs/language-server/src/lib/ast/expressions/index.ts
+++ b/libs/language-server/src/lib/ast/expressions/index.ts
@@ -5,9 +5,9 @@
 export * from './evaluation-strategy';
 
 export * from './evaluation-context';
-// eslint-disable-next-line import/no-cycle
 export * from './internal-value-representation';
 export * from './operator-registry';
+// eslint-disable-next-line import/no-cycle
 export * from './type-inference';
 export * from './typeguards';
 export * from './evaluate-expression';

--- a/libs/language-server/src/lib/ast/expressions/internal-value-representation.ts
+++ b/libs/language-server/src/lib/ast/expressions/internal-value-representation.ts
@@ -4,16 +4,17 @@
 
 import {
   type BlockTypeProperty,
+  type CellRangeLiteral,
   type ConstraintDefinition,
   type TransformDefinition,
   type ValuetypeAssignment,
   isBlockTypeProperty,
+  isCellRangeLiteral,
   isConstraintDefinition,
   isTransformDefinition,
   isValuetypeAssignment,
 } from '../generated/ast';
-// eslint-disable-next-line import/no-cycle
-import { type CellRangeWrapper, isCellRangeWrapper } from '../wrappers';
+import type { WrapperFactoryProvider } from '../wrappers';
 
 export type InternalValueRepresentation =
   | AtomicInternalValueRepresentation
@@ -25,7 +26,7 @@ export type AtomicInternalValueRepresentation =
   | number
   | string
   | RegExp
-  | CellRangeWrapper
+  | CellRangeLiteral
   | ConstraintDefinition
   | ValuetypeAssignment
   | BlockTypeProperty
@@ -37,12 +38,13 @@ export type InternalValueRepresentationTypeguard<
 
 export function internalValueToString(
   valueRepresentation: InternalValueRepresentation,
+  wrapperFactories: WrapperFactoryProvider,
 ): string {
   if (Array.isArray(valueRepresentation)) {
     return (
       '[ ' +
       valueRepresentation
-        .map((item) => internalValueToString(item))
+        .map((item) => internalValueToString(item, wrapperFactories))
         .join(', ') +
       ' ]'
     );
@@ -70,8 +72,8 @@ export function internalValueToString(
   if (valueRepresentation instanceof RegExp) {
     return valueRepresentation.source;
   }
-  if (isCellRangeWrapper(valueRepresentation)) {
-    return valueRepresentation.toString();
+  if (isCellRangeLiteral(valueRepresentation)) {
+    return wrapperFactories.CellRange.wrap(valueRepresentation).toString();
   }
   if (isConstraintDefinition(valueRepresentation)) {
     return valueRepresentation.name;

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/cell-range-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/cell-range-value-type.ts
@@ -3,13 +3,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
-import { type CellRangeWrapper } from '../../cell-range-wrapper';
-import { isCellRangeWrapper } from '../../util/cell-range-util';
+import {
+  type CellRangeLiteral,
+  isCellRangeLiteral,
+} from '../../../generated/ast';
 import { type ValueTypeVisitor } from '../value-type';
 
 import { PrimitiveValueType } from './primitive-value-type';
 
-class CellRangeValuetypeImpl extends PrimitiveValueType<CellRangeWrapper> {
+class CellRangeValuetypeImpl extends PrimitiveValueType<CellRangeLiteral> {
   acceptVisitor<R>(visitor: ValueTypeVisitor<R>): R {
     return visitor.visitCellRange(this);
   }
@@ -24,8 +26,8 @@ class CellRangeValuetypeImpl extends PrimitiveValueType<CellRangeWrapper> {
 
   override isInternalValueRepresentation(
     operandValue: InternalValueRepresentation | undefined,
-  ): operandValue is CellRangeWrapper {
-    return isCellRangeWrapper(operandValue);
+  ): operandValue is CellRangeLiteral {
+    return isCellRangeLiteral(operandValue);
   }
 }
 

--- a/libs/language-server/src/lib/validation/checks/block-type-specific/property-assignment.ts
+++ b/libs/language-server/src/lib/validation/checks/block-type-specific/property-assignment.ts
@@ -118,12 +118,17 @@ function checkCellWriterProperty(
       return;
     }
 
-    if (!cellRange.isOneDimensional()) {
+    if (!props.wrapperFactories.CellRange.canWrap(cellRange)) {
+      return;
+    }
+    const cellRangeWrapper = props.wrapperFactories.CellRange.wrap(cellRange);
+
+    if (!cellRangeWrapper.isOneDimensional()) {
       props.validationContext.accept(
         'error',
         'The cell range needs to be one-dimensional',
         {
-          node: cellRange.astNode,
+          node: cellRangeWrapper.astNode,
         },
       );
     }
@@ -144,12 +149,17 @@ function checkColumnDeleterProperty(
     );
 
     cellRanges?.forEach((cellRange) => {
-      if (!isColumnWrapper(cellRange)) {
+      if (!props.wrapperFactories.CellRange.canWrap(cellRange)) {
+        return;
+      }
+      const cellRangeWrapper = props.wrapperFactories.CellRange.wrap(cellRange);
+
+      if (!isColumnWrapper(cellRangeWrapper)) {
         props.validationContext.accept(
           'error',
           'An entire column needs to be selected',
           {
-            node: cellRange.astNode,
+            node: cellRangeWrapper.astNode,
           },
         );
       }
@@ -234,7 +244,7 @@ function checkLocalFileExtractorProperty(
 ) {
   if (
     propName === 'filePath' &&
-    internalValueToString(propValue).includes('..')
+    internalValueToString(propValue, props.wrapperFactories).includes('..')
   ) {
     props.validationContext.accept(
       'error',
@@ -261,12 +271,17 @@ function checkRowDeleterProperty(
     );
 
     cellRanges?.forEach((cellRange) => {
-      if (!isRowWrapper(cellRange)) {
+      if (!props.wrapperFactories.CellRange.canWrap(cellRange)) {
+        return;
+      }
+      const cellRangeWrapper = props.wrapperFactories.CellRange.wrap(cellRange);
+
+      if (!isRowWrapper(cellRangeWrapper)) {
         props.validationContext.accept(
           'error',
           'An entire row needs to be selected',
           {
-            node: cellRange.astNode,
+            node: cellRangeWrapper.astNode,
           },
         );
       }
@@ -387,7 +402,7 @@ function checkPropertyValueOneOf(
     props.validationContext.accept(
       'error',
       `The value of property "${propName}" must be one of the following values: ${allowedValues
-        .map((v) => `${internalValueToString(v)}`)
+        .map((v) => `${internalValueToString(v, props.wrapperFactories)}`)
         .join(', ')}`,
       {
         node: property,

--- a/libs/language-server/src/lib/validation/checks/block-type-specific/property-body.ts
+++ b/libs/language-server/src/lib/validation/checks/block-type-specific/property-body.ts
@@ -96,8 +96,13 @@ function checkCellWriterPropertyBody(
     return;
   }
 
+  if (!props.wrapperFactories.CellRange.canWrap(atValue)) {
+    return;
+  }
+  const atValueWrapper = props.wrapperFactories.CellRange.wrap(atValue);
+
   const numberOfValuesToWrite = writeValues.length;
-  const numberOfCells = atValue.numberOfCells();
+  const numberOfCells = atValueWrapper.numberOfCells();
 
   if (numberOfCells !== numberOfValuesToWrite) {
     [writeProperty, atProperty].forEach((propertyNode) => {

--- a/libs/language-server/src/lib/validation/validation-util.ts
+++ b/libs/language-server/src/lib/validation/validation-util.ts
@@ -86,6 +86,7 @@ export function checkExpressionSimplification(
       'info',
       `The expression can be simplified to ${internalValueToString(
         evaluatedExpression,
+        props.wrapperFactories,
       )}`,
       { node: expression },
     );


### PR DESCRIPTION
Removes a dependency cycle from our code base by using the `WrapperFactoryProvider` construct introduced in #536.

The remaining dependency cycles revolve around our design of the `ValueType` and `wrapper` constructs.