### PR TITLE
fix: range-constraint and lenght-constraint work with only one bound

### DIFF
--- a/libs/execution/src/lib/constraints/executors/length-constraint-executor.spec.ts
+++ b/libs/execution/src/lib/constraints/executors/length-constraint-executor.spec.ts
@@ -93,4 +93,24 @@ describe('Validation of LengthConstraintExecutor', () => {
 
     expect(valid).toBe(false);
   });
+
+  it('should work with only a lower bound specified', async () => {
+    const text = readJvTestAsset(
+      'length-constraint-executor/only-lower-bound.jv',
+    );
+
+    const valid = await parseAndValidateConstraint(text, 'morethan2chars');
+
+    expect(valid).toBe(true);
+  });
+
+  it('should work with only an uppper bound specified', async () => {
+    const text = readJvTestAsset(
+      'length-constraint-executor/only-upper-bound.jv',
+    );
+
+    const valid = await parseAndValidateConstraint(text, '');
+
+    expect(valid).toBe(true);
+  });
 });

--- a/libs/execution/src/lib/constraints/executors/range-constraint-executor.spec.ts
+++ b/libs/execution/src/lib/constraints/executors/range-constraint-executor.spec.ts
@@ -96,4 +96,24 @@ describe('Validation of RangeConstraintExecutor', () => {
 
     expect(valid).toBe(false);
   });
+
+  it('should work with only an upper bound specified', async () => {
+    const text = readJvTestAsset(
+      'range-constraint-executor/only-upper-bound.jv',
+    );
+
+    const valid = await parseAndValidateConstraint(text, 0);
+
+    expect(valid).toBe(true);
+  });
+
+  it('should work with only a lower bound specified', async () => {
+    const text = readJvTestAsset(
+      'range-constraint-executor/only-lower-bound.jv',
+    );
+
+    const valid = await parseAndValidateConstraint(text, 999999999);
+
+    expect(valid).toBe(true);
+  });
 });

--- a/libs/execution/test/assets/length-constraint-executor/only-lower-bound.jv
+++ b/libs/execution/test/assets/length-constraint-executor/only-lower-bound.jv
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+constraint TestConstraint oftype LengthConstraint {
+  minLength: 2;
+}
+
+valuetype TestValueType oftype text {
+	constraints: [
+		TestConstraint,
+	];
+}
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestFileExtractor {
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  block TestProperty oftype TestProperty {
+		valuetypeAssignmentProperty: "test" oftype TestValueType;
+	}
+
+  TestExtractor -> TestProperty -> TestLoader;
+}

--- a/libs/execution/test/assets/length-constraint-executor/only-upper-bound.jv
+++ b/libs/execution/test/assets/length-constraint-executor/only-upper-bound.jv
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+constraint TestConstraint oftype LengthConstraint {
+  maxLength: 3;
+}
+
+valuetype TestValueType oftype text {
+	constraints: [
+		TestConstraint,
+	];
+}
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestFileExtractor {
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  block TestProperty oftype TestProperty {
+		valuetypeAssignmentProperty: "test" oftype TestValueType;
+	}
+
+  TestExtractor -> TestProperty -> TestLoader;
+}

--- a/libs/execution/test/assets/range-constraint-executor/only-lower-bound.jv
+++ b/libs/execution/test/assets/range-constraint-executor/only-lower-bound.jv
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+constraint TestConstraint oftype RangeConstraint {
+  lowerBound: 1;
+}
+
+valuetype TestValueType oftype integer {
+	constraints: [
+		TestConstraint,
+	];
+}
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestFileExtractor {
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  block TestProperty oftype TestProperty {
+		valuetypeAssignmentProperty: "test" oftype TestValueType;
+	}
+
+  TestExtractor -> TestProperty -> TestLoader;
+}

--- a/libs/execution/test/assets/range-constraint-executor/only-upper-bound.jv
+++ b/libs/execution/test/assets/range-constraint-executor/only-upper-bound.jv
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+constraint TestConstraint oftype RangeConstraint {
+  upperBound: 10;
+}
+
+valuetype TestValueType oftype integer {
+	constraints: [
+		TestConstraint,
+	];
+}
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestFileExtractor {
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  block TestProperty oftype TestProperty {
+		valuetypeAssignmentProperty: "test" oftype TestValueType;
+	}
+
+  TestExtractor -> TestProperty -> TestLoader;
+}

--- a/libs/language-server/src/lib/validation/checks/constrainttype-specific/property-body.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/constrainttype-specific/property-body.spec.ts
@@ -90,6 +90,21 @@ describe('Validation of constraint type specific property bodies', () => {
         expect.any(Object),
       );
     });
+
+    it('should hint if no bounds were specified', async () => {
+      const text = readJvTestAsset(
+        'property-body/constrainttype-specific/length-constraint/no-bound.jv',
+      );
+
+      await parseAndValidatePropertyAssignment(text);
+
+      expect(validationAcceptorMock).toHaveBeenCalledTimes(1);
+      expect(validationAcceptorMock).toHaveBeenCalledWith(
+        'hint',
+        'This constraint should either specify an upper or lower bound, otherwise it has no effect.',
+        expect.any(Object),
+      );
+    });
   });
 
   describe('RangeConstraint constraint type', () => {
@@ -119,6 +134,21 @@ describe('Validation of constraint type specific property bodies', () => {
       expect(validationAcceptorMock).toHaveBeenCalledWith(
         'error',
         `Lower and upper bounds need to be inclusive if they are identical`,
+        expect.any(Object),
+      );
+    });
+
+    it('should hint if no bounds were specified', async () => {
+      const text = readJvTestAsset(
+        'property-body/constrainttype-specific/range-constraint/no-bound.jv',
+      );
+
+      await parseAndValidatePropertyAssignment(text);
+
+      expect(validationAcceptorMock).toHaveBeenCalledTimes(1);
+      expect(validationAcceptorMock).toHaveBeenCalledWith(
+        'hint',
+        'This constraint should either specify an upper or lower bound, otherwise it has no effect.',
         expect.any(Object),
       );
     });

--- a/libs/language-server/src/lib/validation/checks/constrainttype-specific/property-body.ts
+++ b/libs/language-server/src/lib/validation/checks/constrainttype-specific/property-body.ts
@@ -32,9 +32,13 @@ function checkLengthConstraintPropertyBody(
   if (minLengthProperty === undefined && maxLengthProperty === undefined) {
     props.validationContext.accept(
       'hint',
-      'This constraint should either specify an upper bound or lower bound, otherwise it has no effect',
+      'This constraint should either specify an upper or lower bound, otherwise it has no effect.',
       { node: propertyBody },
     );
+  }
+
+  if (minLengthProperty === undefined || maxLengthProperty === undefined) {
+    return;
   }
 
   const minLength = evaluatePropertyValue(
@@ -78,9 +82,13 @@ function checkRangeConstraintPropertyBody(
   if (lowerBoundProperty === undefined && upperBoundProperty === undefined) {
     props.validationContext.accept(
       'hint',
-      'This constraint should either specify an upper bound or lower bound, otherwise it has no effect',
+      'This constraint should either specify an upper or lower bound, otherwise it has no effect.',
       { node: propertyBody },
     );
+  }
+
+  if (lowerBoundProperty === undefined || upperBoundProperty === undefined) {
+    return;
   }
 
   const lowerBound = evaluatePropertyValue(

--- a/libs/language-server/src/lib/validation/checks/constrainttype-specific/property-body.ts
+++ b/libs/language-server/src/lib/validation/checks/constrainttype-specific/property-body.ts
@@ -29,8 +29,12 @@ function checkLengthConstraintPropertyBody(
     (p) => p.name === 'maxLength',
   );
 
-  if (minLengthProperty === undefined || maxLengthProperty === undefined) {
-    return;
+  if (minLengthProperty === undefined && maxLengthProperty === undefined) {
+    props.validationContext.accept(
+      'hint',
+      'This constraint should either specify an upper bound or lower bound, otherwise it has no effect',
+      { node: propertyBody },
+    );
   }
 
   const minLength = evaluatePropertyValue(
@@ -71,8 +75,12 @@ function checkRangeConstraintPropertyBody(
     (p) => p.name === 'upperBound',
   );
 
-  if (lowerBoundProperty === undefined || upperBoundProperty === undefined) {
-    return;
+  if (lowerBoundProperty === undefined && upperBoundProperty === undefined) {
+    props.validationContext.accept(
+      'hint',
+      'This constraint should either specify an upper bound or lower bound, otherwise it has no effect',
+      { node: propertyBody },
+    );
   }
 
   const lowerBound = evaluatePropertyValue(

--- a/libs/language-server/src/test/assets/property-body/constrainttype-specific/length-constraint/no-bound.jv
+++ b/libs/language-server/src/test/assets/property-body/constrainttype-specific/length-constraint/no-bound.jv
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+constraint Test oftype LengthConstraint {
+}

--- a/libs/language-server/src/test/assets/property-body/constrainttype-specific/range-constraint/no-bound.jv
+++ b/libs/language-server/src/test/assets/property-body/constrainttype-specific/range-constraint/no-bound.jv
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+constraint Test oftype RangeConstraint {
+}


### PR DESCRIPTION
It is now possible to only specify one bound when using `lenght-constraint`. However one bound minimum is still required
closes #533

I went ahead and took the liberty to also implement this fix for `range-constraint`.