### PR TITLE
Clean-up remaining ESM migration effects

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,7 @@
             "paths": [
               {
                 "name": "node:assert",
-                "message": "Please use the library `assert` instead to keep browser compatibility. You might need to disable rule `unicorn/prefer-node-protocol` to do so."
+                "message": "Please use the library `assert` instead to keep browser compatibility. Import `from \"assert/\"` to do so (note the trailing \"/\")."
               }
             ]
           }

--- a/apps/docs-generator/project.json
+++ b/apps/docs-generator/project.json
@@ -13,6 +13,7 @@
     },
     "start": {
       "executor": "@nx/js:node",
+      "dependsOn": ["generate-language-server"],
       "options": {
         "watch": false,
         "buildTarget": "docs-generator:build"

--- a/apps/docs-generator/src/user-doc-generator.ts
+++ b/apps/docs-generator/src/user-doc-generator.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type BlockTypeWrapper,
   type ConstraintTypeWrapper,
@@ -18,6 +15,7 @@ import {
   type PrimitiveValueType,
   type PropertySpecification,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 export class UserDocGenerator
   implements

--- a/apps/docs/docs/dev/04-guides/02-working-with-the-ast.md
+++ b/apps/docs/docs/dev/04-guides/02-working-with-the-ast.md
@@ -127,7 +127,7 @@ Here is an example of how to use it in practice:
 // We use the `assert` function from the `assert` library, not `node:assert` (to preserve browser compatibility)
 
 // eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import { A, B, isB } from './ast';
 

--- a/libs/execution/src/lib/blocks/block-executor.ts
+++ b/libs/execution/src/lib/blocks/block-executor.ts
@@ -2,10 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import { type IOType, isBlockDefinition } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 import { isBlockTargetedForDebugLogging } from '../debugging/debug-configuration';
 import { DebugLogVisitor } from '../debugging/debug-log-visitor';

--- a/libs/execution/src/lib/blocks/composite-block-executor.ts
+++ b/libs/execution/src/lib/blocks/composite-block-executor.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type BlockDefinition,
   type BlockTypePipeline,
@@ -20,6 +17,7 @@ import {
   getIOType,
   isCompositeBlockTypeDefinition,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 import { type ExecutionContext } from '../execution-context';
 import { type IOTypeImplementation } from '../types';

--- a/libs/execution/src/lib/constraints/constraint-executor-extension.ts
+++ b/libs/execution/src/lib/constraints/constraint-executor-extension.ts
@@ -2,15 +2,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type ConstraintDefinition,
   Registry,
   isExpressionConstraintDefinition,
   isTypedConstraintDefinition,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 import { assertUnreachable } from 'langium';
 
 import { type ConstraintExecutor } from './constraint-executor';

--- a/libs/execution/src/lib/constraints/executors/expression-constraint-executor.ts
+++ b/libs/execution/src/lib/constraints/executors/expression-constraint-executor.ts
@@ -2,15 +2,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type AstNodeWrapper,
   type ExpressionConstraintDefinition,
   type InternalValueRepresentation,
   evaluateExpression,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 import { type ExecutionContext } from '../../execution-context';
 import { type ConstraintExecutor } from '../constraint-executor';

--- a/libs/execution/src/lib/execution-context.ts
+++ b/libs/execution/src/lib/execution-context.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type BlockDefinition,
   type ConstraintDefinition,
@@ -24,6 +21,7 @@ import {
   isTransformDefinition,
   isTypedConstraintDefinition,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 import { assertUnreachable, isReference } from 'langium';
 
 import { type JayveeConstraintExtension } from './constraints';

--- a/libs/execution/src/lib/extension.ts
+++ b/libs/execution/src/lib/extension.ts
@@ -2,13 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type BlockDefinition,
   isCompositeBlockTypeDefinition,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 import { type BlockExecutor } from './blocks';
 import { type BlockExecutorClass } from './blocks/block-executor-class';

--- a/libs/execution/src/lib/logging/logger.ts
+++ b/libs/execution/src/lib/logging/logger.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import {
   type AstNode,
   type DiagnosticInfo,

--- a/libs/execution/src/lib/transforms/transform-executor.spec.ts
+++ b/libs/execution/src/lib/transforms/transform-executor.spec.ts
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import assert from 'assert';
 import path from 'node:path';
 
 import {
@@ -19,6 +17,7 @@ import {
   parseHelper,
   readJvTestAssetHelper,
 } from '@jvalue/jayvee-language-server/test';
+import assert from 'assert/';
 import {
   type AstNode,
   type AstNodeLocator,

--- a/libs/execution/src/lib/transforms/transform-executor.ts
+++ b/libs/execution/src/lib/transforms/transform-executor.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type InternalValueRepresentation,
   type TransformDefinition,
@@ -13,6 +10,7 @@ import {
   type ValueType,
   evaluateExpression,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 import { type ExecutionContext } from '../execution-context';
 import { isValidValueRepresentation } from '../types';

--- a/libs/execution/src/lib/types/io-types/sheet.ts
+++ b/libs/execution/src/lib/types/io-types/sheet.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   CellIndex,
   type CellIndexBounds,
@@ -16,6 +13,7 @@ import {
   getColumnIndex,
   getRowIndex,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 import {
   type IOTypeImplementation,

--- a/libs/execution/src/lib/types/io-types/table.ts
+++ b/libs/execution/src/lib/types/io-types/table.ts
@@ -2,14 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   IOType,
   type InternalValueRepresentation,
   type ValueType,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 import { SQLColumnTypeVisitor } from '../value-types/visitors/sql-column-type-visitor';
 import { SQLValueRepresentationVisitor } from '../value-types/visitors/sql-value-representation-visitor';

--- a/libs/execution/src/lib/types/value-types/internal-representation-parsing.ts
+++ b/libs/execution/src/lib/types/value-types/internal-representation-parsing.ts
@@ -2,15 +2,13 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type AtomicValueType,
   type InternalValueRepresentation,
   type ValueType,
   ValueTypeVisitor,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 const NUMBER_REGEX = /^[+-]?([0-9]*[,.])?[0-9]+([eE][+-]?\d+)?$/;
 

--- a/libs/execution/src/lib/types/value-types/value-representation-validity.ts
+++ b/libs/execution/src/lib/types/value-types/value-representation-validity.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type AtomicValueType,
   type BooleanValuetype,
@@ -22,6 +19,7 @@ import {
   ValueTypeVisitor,
   type ValuetypeAssignmentValuetype,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 import { type ExecutionContext } from '../../execution-context';
 

--- a/libs/execution/src/lib/types/value-types/visitors/sql-column-type-visitor.ts
+++ b/libs/execution/src/lib/types/value-types/visitors/sql-column-type-visitor.ts
@@ -2,13 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type AtomicValueType,
   ValueTypeVisitor,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 export class SQLColumnTypeVisitor extends ValueTypeVisitor<string> {
   override visitBoolean(): string {

--- a/libs/execution/src/lib/types/value-types/visitors/sql-value-representation-visitor.ts
+++ b/libs/execution/src/lib/types/value-types/visitors/sql-value-representation-visitor.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import {
   type AtomicValueType,
   type BooleanValuetype,
@@ -14,6 +11,7 @@ import {
   type TextValuetype,
   ValueTypeVisitor,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 export class SQLValueRepresentationVisitor extends ValueTypeVisitor<
   (value: InternalValueRepresentation) => string

--- a/libs/extensions/rdbms/exec/test/mocks/postgres-loader-executor-mock.ts
+++ b/libs/extensions/rdbms/exec/test/mocks/postgres-loader-executor-mock.ts
@@ -2,10 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import assert from 'assert';
-
 import { type BlockExecutorMock } from '@jvalue/jayvee-execution/test';
+import assert from 'assert/';
 import pg from 'pg';
 import { type Mock, type Mocked, vi } from 'vitest';
 

--- a/libs/extensions/rdbms/exec/test/mocks/sqlite-loader-executor-mock.ts
+++ b/libs/extensions/rdbms/exec/test/mocks/sqlite-loader-executor-mock.ts
@@ -2,10 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import assert from 'assert';
-
 import { type BlockExecutorMock } from '@jvalue/jayvee-execution/test';
+import assert from 'assert/';
 import sqlite3 from 'sqlite3';
 import { type Mock, type Mocked, vi } from 'vitest';
 

--- a/libs/extensions/std/exec/src/archive-interpreter-executor.ts
+++ b/libs/extensions/std/exec/src/archive-interpreter-executor.ts
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
 import path from 'node:path';
 import * as zlib from 'node:zlib';
 
@@ -23,6 +21,7 @@ import {
   inferMimeTypeFromFileExtensionString,
 } from '@jvalue/jayvee-execution';
 import { IOType } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 import JSZip from 'jszip';
 
 @implementsStatic<BlockExecutorClass>()

--- a/libs/extensions/std/exec/src/file-picker-executor.ts
+++ b/libs/extensions/std/exec/src/file-picker-executor.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import * as R from '@jvalue/jayvee-execution';
 import {
   AbstractBlockExecutor,
@@ -15,6 +12,7 @@ import {
   implementsStatic,
 } from '@jvalue/jayvee-execution';
 import { IOType } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 @implementsStatic<BlockExecutorClass>()
 export class FilePickerExecutor extends AbstractBlockExecutor<

--- a/libs/extensions/std/exec/src/http-extractor-executor.ts
+++ b/libs/extensions/std/exec/src/http-extractor-executor.ts
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
 import path from 'node:path';
 
 import * as R from '@jvalue/jayvee-execution';
@@ -22,6 +20,7 @@ import {
   inferMimeTypeFromFileExtensionString,
 } from '@jvalue/jayvee-execution';
 import { IOType } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 import followRedirects from 'follow-redirects';
 import { type AstNode } from 'langium';
 

--- a/libs/extensions/tabular/exec/src/lib/cell-writer-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/cell-writer-executor.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import * as R from '@jvalue/jayvee-execution';
 import {
   AbstractBlockExecutor,
@@ -14,6 +11,7 @@ import {
   implementsStatic,
 } from '@jvalue/jayvee-execution';
 import { IOType } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 @implementsStatic<BlockExecutorClass>()
 export class CellWriterExecutor extends AbstractBlockExecutor<

--- a/libs/extensions/tabular/exec/src/lib/column-deleter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/column-deleter-executor.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import * as R from '@jvalue/jayvee-execution';
 import {
   AbstractBlockExecutor,
@@ -20,6 +17,7 @@ import {
   getColumnIndex,
   isColumnWrapper,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 @implementsStatic<BlockExecutorClass>()
 export class ColumnDeleterExecutor extends AbstractBlockExecutor<

--- a/libs/extensions/tabular/exec/src/lib/row-deleter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/row-deleter-executor.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import * as R from '@jvalue/jayvee-execution';
 import {
   AbstractBlockExecutor,
@@ -20,6 +17,7 @@ import {
   isRowWrapper,
   rowIndexToString,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 @implementsStatic<BlockExecutorClass>()
 export class RowDeleterExecutor extends AbstractBlockExecutor<

--- a/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import * as R from '@jvalue/jayvee-execution';
 import {
   AbstractBlockExecutor,
@@ -24,6 +21,7 @@ import {
   type ValuetypeAssignment,
   rowIndexToString,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 export interface ColumnDefinitionEntry {
   sheetColumnIndex: number;

--- a/libs/extensions/tabular/exec/src/lib/table-transformer-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-transformer-executor.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import * as R from '@jvalue/jayvee-execution';
 import {
   AbstractBlockExecutor,
@@ -19,6 +16,7 @@ import {
   IOType,
   type InternalValueRepresentation,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 
 @implementsStatic<BlockExecutorClass>()
 export class TableTransformerExecutor extends AbstractBlockExecutor<

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import * as R from '@jvalue/jayvee-execution';
 import {
   type DebugGranularity,
@@ -31,6 +28,7 @@ import {
   initializeWorkspace,
   internalValueToString,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 import chalk from 'chalk';
 import { NodeFileSystem } from 'langium/node';
 

--- a/libs/interpreter-lib/src/std-extension.spec.ts
+++ b/libs/interpreter-lib/src/std-extension.spec.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import { StdExecExtension } from '@jvalue/jayvee-extensions/std/exec';
 import {
   type BlockTypeWrapper,
@@ -12,6 +9,7 @@ import {
   getAllBuiltinBlockTypes,
   initializeWorkspace,
 } from '@jvalue/jayvee-language-server';
+import { strict as assert } from 'assert/';
 import { NodeFileSystem } from 'langium/node';
 
 async function loadAllBuiltinBlockTypes(): Promise<BlockTypeWrapper[]> {

--- a/libs/language-server/src/lib/ast/expressions/evaluate-expression.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluate-expression.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import { assertUnreachable } from 'langium';
 
 import { type ValidationContext } from '../../validation';

--- a/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import { assertUnreachable } from 'langium';
 
 import { type RuntimeParameterProvider } from '../../services';

--- a/libs/language-server/src/lib/ast/expressions/evaluators/division-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/division-operator-evaluator.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type BinaryExpression } from '../../generated/ast';

--- a/libs/language-server/src/lib/ast/expressions/evaluators/sqrt-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/sqrt-operator-evaluator.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type UnaryExpression } from '../../generated/ast';

--- a/libs/language-server/src/lib/ast/expressions/operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/operator-evaluator.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import { type ValidationContext } from '../../validation/validation-context';
 import {

--- a/libs/language-server/src/lib/ast/expressions/type-computers/in-operator-type-computer.ts
+++ b/libs/language-server/src/lib/ast/expressions/type-computers/in-operator-type-computer.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type BinaryExpression } from '../../generated/ast';

--- a/libs/language-server/src/lib/ast/io-type.ts
+++ b/libs/language-server/src/lib/ast/io-type.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import { type BlockTypeInput, type BlockTypeOutput } from './generated/ast';
 

--- a/libs/language-server/src/lib/ast/wrappers/cell-range-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/cell-range-wrapper.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import { assertUnreachable } from 'langium';
 
 import {

--- a/libs/language-server/src/lib/ast/wrappers/pipe-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/pipe-wrapper.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import { type DiagnosticInfo } from 'langium';
 
 import {

--- a/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/pipeline-wrapper.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import {
   type BlockDefinition,

--- a/libs/language-server/src/lib/ast/wrappers/typed-object/block-type-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/typed-object/block-type-wrapper.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import { type Reference, isReference } from 'langium';
 
 import { RuntimeParameterProvider } from '../../../services';

--- a/libs/language-server/src/lib/ast/wrappers/typed-object/constrainttype-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/typed-object/constrainttype-wrapper.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import { type Reference, isReference } from 'langium';
 
 import { RuntimeParameterProvider } from '../../../services';

--- a/libs/language-server/src/lib/ast/wrappers/util/cell-range-util.ts
+++ b/libs/language-server/src/lib/ast/wrappers/util/cell-range-util.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import {
   isCellLiteral,

--- a/libs/language-server/src/lib/ast/wrappers/util/value-type-util.ts
+++ b/libs/language-server/src/lib/ast/wrappers/util/value-type-util.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import {
   type AtomicValueType,

--- a/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import { evaluateExpression } from '../../expressions/evaluate-expression';
 import { type EvaluationContext } from '../../expressions/evaluation-context';

--- a/libs/language-server/src/lib/ast/wrappers/wrapper-factory-provider.ts
+++ b/libs/language-server/src/lib/ast/wrappers/wrapper-factory-provider.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import {
   type AstNode,
   type Reference,

--- a/libs/language-server/src/lib/completion/jayvee-completion-provider.ts
+++ b/libs/language-server/src/lib/completion/jayvee-completion-provider.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import { type LangiumDocuments, type MaybePromise } from 'langium';
 import {
   type CompletionAcceptor,

--- a/libs/language-server/src/lib/util/registry.ts
+++ b/libs/language-server/src/lib/util/registry.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 export class Registry<C> {
   protected readonly registry = new Map<string, C>();

--- a/libs/language-server/src/lib/validation/checks/block-type-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/block-type-definition.ts
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
+import { strict as assert } from 'assert/';
 
 import {
   type BlockTypeProperty,

--- a/libs/language-server/src/lib/validation/checks/value-type-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/value-type-definition.ts
@@ -7,9 +7,7 @@
  */
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import { assertUnreachable } from 'langium';
 
 import {

--- a/libs/language-server/src/lib/validation/checks/value-type-reference.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/value-type-reference.spec.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import {
   type AstNode,
   type AstNodeLocator,

--- a/libs/language-server/src/lib/validation/validation-util.ts
+++ b/libs/language-server/src/lib/validation/validation-util.ts
@@ -2,9 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
+import { strict as assert } from 'assert/';
 import { type AstNode, MultiMap, assertUnreachable } from 'langium';
 
 import {

--- a/libs/language-server/src/test/utils.ts
+++ b/libs/language-server/src/test/utils.ts
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
+import { strict as assert } from 'assert/';
 import {
   type AstNode,
   type LangiumDocument,

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@swc-node/register": "~1.8.0",
         "@swc/core": "~1.3.85",
         "@swc/helpers": "~0.5.2",
+        "@types/assert": "^1.5.10",
         "@types/follow-redirects": "^1.14.1",
         "@types/mime-types": "^2.1.1",
         "@types/node": "18.19.11",
@@ -8823,6 +8824,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "node_modules/@types/assert": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.10.tgz",
+      "integrity": "sha512-qEO+AUgYab7GVbeDDgUNCU3o0aZUoIMpNAe+w5LDbRxfxQX7vQAdDgwj1AroX+i8KaV56FWg0srXlSZROnsrIQ==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -35885,6 +35892,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "@types/assert": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/@types/assert/-/assert-1.5.10.tgz",
+      "integrity": "sha512-qEO+AUgYab7GVbeDDgUNCU3o0aZUoIMpNAe+w5LDbRxfxQX7vQAdDgwj1AroX+i8KaV56FWg0srXlSZROnsrIQ==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@swc-node/register": "~1.8.0",
     "@swc/core": "~1.3.85",
     "@swc/helpers": "~0.5.2",
+    "@types/assert": "^1.5.10",
     "@types/follow-redirects": "^1.14.1",
     "@types/mime-types": "^2.1.1",
     "@types/node": "18.19.11",


### PR DESCRIPTION
- Import from "assert/" instead of "assert" ti disambiguate whether we mean the node core module or the assert library.
Based on the input from this issue: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2326
- Explicitly require language-server build task before generating docs