### PR TITLE
Publish via alias

### DIFF
--- a/libs/language-server/src/grammar/main.langium
+++ b/libs/language-server/src/grammar/main.langium
@@ -33,7 +33,7 @@ ExportableElement:
     | IotypeDefinition;
 
 ExportDefinition:
-  'publish' element=[ExportableElement] ';';
+  'publish' element=[ExportableElement] ('as' alias=ID)? ';';
 
 ImportDefinition:
   'use' '*' 'from' path=STRING ';';

--- a/libs/language-server/src/lib/validation/checks/export-definition.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/export-definition.spec.ts
@@ -2,11 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type AstNode, AstUtils, type LangiumDocument } from 'langium';
+import { type AstNode, type LangiumDocument } from 'langium';
 import { NodeFileSystem } from 'langium/node';
 import { vi } from 'vitest';
 
 import {
+  type ExportDefinition,
   type JayveeServices,
   createJayveeServices,
   isExportDefinition,
@@ -15,6 +16,7 @@ import {
   type ParseHelperOptions,
   createJayveeValidationProps,
   expectNoParserAndLexerErrors,
+  extractTestElements,
   parseHelper,
   readJvTestAssetHelper,
   validationAcceptorMockImpl,
@@ -41,11 +43,9 @@ describe('Validation of ExportDefinition', () => {
     const document = await parse(input);
     expectNoParserAndLexerErrors(document);
 
-    const allElements = AstUtils.streamAllContents(document.parseResult.value);
-    const allExportDefinitions = [...allElements.filter(isExportDefinition)];
-    expect(
-      allExportDefinitions.length > 0,
-      'No export definition found in test file',
+    const allExportDefinitions = extractTestElements(
+      document,
+      (x): x is ExportDefinition => isExportDefinition(x),
     );
 
     for (const exportDefinition of allExportDefinitions) {

--- a/libs/language-server/src/lib/validation/checks/export-definition.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/export-definition.spec.ts
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { type AstNode, AstUtils, type LangiumDocument } from 'langium';
+import { NodeFileSystem } from 'langium/node';
+import { vi } from 'vitest';
+
+import {
+  type JayveeServices,
+  createJayveeServices,
+  isExportDefinition,
+} from '../../../lib';
+import {
+  type ParseHelperOptions,
+  createJayveeValidationProps,
+  expectNoParserAndLexerErrors,
+  parseHelper,
+  readJvTestAssetHelper,
+  validationAcceptorMockImpl,
+} from '../../../test';
+
+import { validateExportDefinition } from './export-definition';
+
+describe('Validation of ExportDefinition', () => {
+  let parse: (
+    input: string,
+    options?: ParseHelperOptions,
+  ) => Promise<LangiumDocument<AstNode>>;
+
+  const validationAcceptorMock = vi.fn(validationAcceptorMockImpl);
+
+  let services: JayveeServices;
+
+  const readJvTestAsset = readJvTestAssetHelper(
+    __dirname,
+    '../../../test/assets/',
+  );
+
+  async function parseAndValidateExportDefinition(input: string) {
+    const document = await parse(input);
+    expectNoParserAndLexerErrors(document);
+
+    const allElements = AstUtils.streamAllContents(document.parseResult.value);
+    const allExportDefinitions = [...allElements.filter(isExportDefinition)];
+    expect(
+      allExportDefinitions.length > 0,
+      'No export definition found in test file',
+    );
+
+    for (const exportDefinition of allExportDefinitions) {
+      validateExportDefinition(
+        exportDefinition,
+        createJayveeValidationProps(validationAcceptorMock, services),
+      );
+    }
+  }
+
+  beforeAll(() => {
+    // Create language services
+    services = createJayveeServices(NodeFileSystem).Jayvee;
+    // Parse function for Jayvee (without validation)
+    parse = parseHelper(services);
+  });
+
+  afterEach(() => {
+    // Reset mock
+    validationAcceptorMock.mockReset();
+  });
+
+  it('should have no error if export has no alias', async () => {
+    const text = readJvTestAsset(
+      'export-definition/valid-export-definition-no-alias.jv',
+    );
+
+    await parseAndValidateExportDefinition(text);
+
+    expect(validationAcceptorMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should have no error if export has viable alias', async () => {
+    const text = readJvTestAsset(
+      'export-definition/valid-export-definition-with-alias.jv',
+    );
+
+    await parseAndValidateExportDefinition(text);
+
+    expect(validationAcceptorMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should have error if original element definition already exports element', async () => {
+    const text = readJvTestAsset(
+      'export-definition/invalid-export-definition-on-exported-element.jv',
+    );
+
+    await parseAndValidateExportDefinition(text);
+
+    expect(validationAcceptorMock).toHaveBeenCalledTimes(1);
+    expect(validationAcceptorMock).toHaveBeenNthCalledWith(
+      1,
+      'error',
+      'Element X is already published at its definition.',
+      expect.any(Object),
+    );
+  });
+
+  it('should have error if two elements are exported under the same name', async () => {
+    const text = readJvTestAsset(
+      'export-definition/invalid-export-definition-same-name-exported-definition.jv',
+    );
+
+    await parseAndValidateExportDefinition(text);
+
+    expect(validationAcceptorMock).toHaveBeenCalledTimes(2);
+    expect(validationAcceptorMock).toHaveBeenNthCalledWith(
+      1,
+      'error',
+      'This alias is ambiguous. There is another element published element with the same name "Z".',
+      expect.any(Object),
+    );
+    expect(validationAcceptorMock).toHaveBeenNthCalledWith(
+      2,
+      'error',
+      'This alias is ambiguous. There is another element published element with the same name "Z".',
+      expect.any(Object),
+    );
+  });
+
+  it('should have error if there is already an element exported in element definition with the same name', async () => {
+    const text = readJvTestAsset(
+      'export-definition/invalid-export-definition-same-name-multiple-alias.jv',
+    );
+
+    await parseAndValidateExportDefinition(text);
+
+    expect(validationAcceptorMock).toHaveBeenCalledTimes(1);
+    expect(validationAcceptorMock).toHaveBeenNthCalledWith(
+      1,
+      'error',
+      'This alias is ambiguous. There is another element published element with the same name "X".',
+      expect.any(Object),
+    );
+  });
+});

--- a/libs/language-server/src/lib/validation/checks/export-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/export-definition.ts
@@ -1,0 +1,134 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-condition */
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import { strict as assert } from 'assert';
+
+import { AstUtils } from 'langium';
+
+import {
+  type ExportDefinition,
+  type ExportableElement,
+  type JayveeModel,
+  isExportableElement,
+  isExportableElementDefinition,
+  isJayveeModel,
+} from '../../ast/generated/ast';
+import { type JayveeValidationProps } from '../validation-registry';
+
+export function validateExportDefinition(
+  exportDefinition: ExportDefinition,
+  props: JayveeValidationProps,
+): void {
+  checkIsAlreadyPublished(exportDefinition, props);
+  checkUniqueAlias(exportDefinition, props);
+}
+
+function checkIsAlreadyPublished(
+  exportDefinition: ExportDefinition,
+  props: JayveeValidationProps,
+): void {
+  const originalDefinition = exportDefinition.element?.ref;
+  if (originalDefinition === undefined) {
+    return;
+  }
+
+  const exportableElementDefinition = AstUtils.getContainerOfType(
+    originalDefinition,
+    isExportableElementDefinition,
+  );
+  if (exportableElementDefinition === undefined) {
+    return;
+  }
+
+  const isAlreadyPublished = exportableElementDefinition.isPublished;
+  if (isAlreadyPublished) {
+    props.validationContext.accept(
+      'error',
+      `Element ${originalDefinition.name} is already published at its definition.`,
+      {
+        node: exportDefinition,
+      },
+    );
+  }
+}
+
+function checkUniqueAlias(
+  exportDefinition: ExportDefinition,
+  props: JayveeValidationProps,
+): void {
+  if (exportDefinition.alias === undefined) {
+    return;
+  }
+
+  const model = AstUtils.getContainerOfType(exportDefinition, isJayveeModel);
+  assert(model !== undefined);
+  const allExports = collectAllExportsWithinSameFile(model);
+
+  const elementsWithSameName = allExports.filter(
+    (e) => e.alias === exportDefinition.alias,
+  );
+  assert(
+    elementsWithSameName.length > 0,
+    'Could not the export definition itself in exports',
+  );
+
+  const isAliasUnique = elementsWithSameName.length === 1;
+  if (!isAliasUnique) {
+    props.validationContext.accept(
+      'error',
+      `This alias is ambiguous. There is another element published element with the same name "${exportDefinition.alias}".`,
+      {
+        node: exportDefinition,
+        property: 'alias',
+      },
+    );
+  }
+}
+
+function collectAllExportsWithinSameFile(model: JayveeModel): {
+  alias: string;
+  element: ExportDefinition | ExportableElement;
+}[] {
+  const exportedElementNames: {
+    alias: string;
+    element: ExportDefinition | ExportableElement;
+  }[] = [];
+
+  for (const node of model.exportableElements) {
+    if (node.isPublished) {
+      assert(
+        isExportableElement(node),
+        'Exported node is not an ExportableElement',
+      );
+      exportedElementNames.push({
+        alias: node.name,
+        element: node,
+      });
+    }
+  }
+
+  for (const node of model.exports) {
+    if (node.alias !== undefined) {
+      exportedElementNames.push({
+        alias: node.alias,
+        element: node,
+      });
+      continue;
+    }
+
+    const originalDefinition = node.element?.ref;
+    if (
+      originalDefinition !== undefined &&
+      originalDefinition.name !== undefined
+    ) {
+      exportedElementNames.push({
+        alias: originalDefinition.name,
+        element: originalDefinition,
+      });
+    }
+  }
+  return exportedElementNames;
+}

--- a/libs/language-server/src/lib/validation/checks/export-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/export-definition.ts
@@ -72,7 +72,7 @@ function checkUniqueAlias(
   );
   assert(
     elementsWithSameName.length > 0,
-    'Could not the export definition itself in exports',
+    'Could not find the export definition itself in exports',
   );
 
   const isAliasUnique = elementsWithSameName.length === 1;

--- a/libs/language-server/src/lib/validation/validation-registry.ts
+++ b/libs/language-server/src/lib/validation/validation-registry.ts
@@ -26,6 +26,7 @@ import { validateBlockDefinition } from './checks/block-definition';
 import { validateBlockTypeDefinition } from './checks/block-type-definition';
 import { validateColumnId } from './checks/column-id';
 import { validateCompositeBlockTypeDefinition } from './checks/composite-block-type-definition';
+import { validateExportDefinition } from './checks/export-definition';
 import { validateExpressionConstraintDefinition } from './checks/expression-constraint-definition';
 import { validateImportDefinition } from './checks/import-definition';
 import { validateJayveeModel } from './checks/jayvee-model';
@@ -78,6 +79,7 @@ export class JayveeValidationRegistry extends ValidationRegistry {
       ValuetypeDefinition: validateValueTypeDefinition,
       ValueTypeReference: validateValueTypeReference,
       TransformBody: validateTransformBody,
+      ExportDefinition: validateExportDefinition,
     });
   }
 

--- a/libs/language-server/src/test/assets/export-definition/invalid-export-definition-on-exported-element.jv
+++ b/libs/language-server/src/test/assets/export-definition/invalid-export-definition-on-exported-element.jv
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+publish constraint X on integer: value > 0;
+
+publish X; // invalid: is already published

--- a/libs/language-server/src/test/assets/export-definition/invalid-export-definition-same-name-exported-definition.jv
+++ b/libs/language-server/src/test/assets/export-definition/invalid-export-definition-same-name-exported-definition.jv
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+constraint X on integer: value > 0;
+constraint Y on integer: value > 1;
+
+publish X as Z; 
+publish Y as Z; // invalid: multiple exports with same name

--- a/libs/language-server/src/test/assets/export-definition/invalid-export-definition-same-name-multiple-alias.jv
+++ b/libs/language-server/src/test/assets/export-definition/invalid-export-definition-same-name-multiple-alias.jv
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+publish constraint X on integer: value > 0;
+
+constraint Y on integer: value > 1;
+publish Y as X; // invalid: multiple exports with same name

--- a/libs/language-server/src/test/assets/export-definition/valid-export-definition-no-alias.jv
+++ b/libs/language-server/src/test/assets/export-definition/valid-export-definition-no-alias.jv
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+constraint X on integer: value > 0;
+
+publish X; // valid

--- a/libs/language-server/src/test/assets/export-definition/valid-export-definition-with-alias.jv
+++ b/libs/language-server/src/test/assets/export-definition/valid-export-definition-with-alias.jv
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+constraint X on integer: value > 0;
+
+publish X as Y; // valid


### PR DESCRIPTION
Builds on #571. Introduces `export Element as Alias;` syntax.
