### PR TITLE
Add generate task as build dependency

### DIFF
--- a/libs/language-server/project.json
+++ b/libs/language-server/project.json
@@ -16,7 +16,9 @@
         "parallel": false
       }
     },
-    "build": {},
+    "build": {
+      "dependsOn": ["^build", "generate"]
+    },
     "lint": {
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"]


### PR DESCRIPTION
The language service does not generate code from the langium definitions automatically. This bug was introduced during the changes to the build system in #558 / 05f47bfc55ec213193685cb4dd8754a37c6445cd. 