### PR TITLE
Add sourcemaps to development build

### DIFF
--- a/apps/interpreter/project.json
+++ b/apps/interpreter/project.json
@@ -15,9 +15,14 @@
     },
     "run": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build"],
       "options": {
-        "commands": ["node --enable-source-maps dist/apps/interpreter/main.js"],
+        "commands": [
+          {
+            "command": "nx run interpreter:build:development",
+            "forwardAllArgs": false
+          },
+          "node --enable-source-maps dist/apps/interpreter/main.js"
+        ],
         "parallel": false
       }
     },

--- a/nx.json
+++ b/nx.json
@@ -23,7 +23,11 @@
         "generatePackageJson": true
       },
       "configurations": {
-        "development": {},
+        "development": {
+          "esbuildOptions": {
+            "sourcemap": true
+          }
+        },
         "production": {}
       }
     },


### PR DESCRIPTION
Sourcemaps help debugging, especially when editing the interpreter. The sourcemaps are only emitted when building explicitly with the configuration `development`. This is enabled by default when running the examples. 

Before (References compiled and bundled JS code):

```
file:///path/to/jayvee/dist/apps/interpreter/main.js:14606
throw new Error("TEST");
      ^

Error: TEST
    at file:///path/to/jayvee/dist/apps/interpreter/main.js:14606:7
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)
```

After (References TypeScript source):

```
/path/to/jayvee/libs/interpreter-lib/src/index.ts:10
throw new Error('TEST');
      ^


Error: TEST
    at <anonymous> (/path/to/jayvee/libs/interpreter-lib/src/index.ts:10:7)
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12)
```