### PR TITLE
Refactor Interpreter (to an Interface + Implementation Class)

### DIFF
--- a/apps/interpreter/src/examples-smoke-test.spec.ts
+++ b/apps/interpreter/src/examples-smoke-test.spec.ts
@@ -18,7 +18,8 @@ import { NodeFileSystem } from 'langium/node';
 import nock from 'nock';
 import { type MockInstance, vi } from 'vitest';
 
-import { type RunOptions, runAction } from './run-action';
+import { runAction } from './run-action';
+import { type RunOptions } from './run-options';
 
 // Mock global imports
 vi.mock('pg', () => {

--- a/apps/interpreter/src/examples-smoke-test.spec.ts
+++ b/apps/interpreter/src/examples-smoke-test.spec.ts
@@ -18,7 +18,7 @@ import { NodeFileSystem } from 'langium/node';
 import nock from 'nock';
 import { type MockInstance, vi } from 'vitest';
 
-import { runAction } from './run-action';
+import { type RunOptions, runAction } from './run-action';
 
 // Mock global imports
 vi.mock('pg', () => {
@@ -46,11 +46,12 @@ vi.mock('sqlite3', () => {
 describe('jv example smoke tests', () => {
   const baseDir = path.resolve(__dirname, '../../../example/');
 
-  const defaultOptions = {
+  const defaultOptions: RunOptions = {
     env: new Map<string, string>(),
     debug: false,
     debugGranularity: 'minimal',
-    debugTarget: undefined,
+    debugTarget: 'all',
+    parseOnly: false,
   };
 
   let exitSpy: MockInstance;

--- a/apps/interpreter/src/index.ts
+++ b/apps/interpreter/src/index.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { DebugGranularityValues } from '@jvalue/jayvee-execution';
+import {
+  DebugGranularityValues,
+  DefaultDebugTargetsValue,
+} from '@jvalue/jayvee-execution';
 import { Command } from 'commander';
 
 import { version as packageJsonVersion } from '../package.json';
@@ -55,7 +58,7 @@ program
   .option(
     '-dt, --debug-target <block name>',
     `Sets the target blocks of the of block debug logging, separated by comma. If not given, all blocks are targeted.`,
-    undefined,
+    DefaultDebugTargetsValue,
   )
   .option(
     '-po, --parse-only',

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -12,6 +12,7 @@ import { type RunOptions, runAction } from './run-action';
 
 const interpreterMock: JayveeInterpreter = {
   interpretModel: vi.fn(),
+  interpretFile: vi.fn(),
   interpretString: vi.fn(),
   parseModel: vi.fn(),
 };

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -30,7 +30,8 @@ describe('Parse Only', () => {
     env: new Map<string, string>(),
     debug: false,
     debugGranularity: 'minimal',
-    debugTarget: undefined,
+    debugTarget: 'all',
+    parseOnly: false,
   };
 
   afterEach(() => {

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -8,7 +8,8 @@ import process from 'node:process';
 
 import { type JayveeInterpreter } from '@jvalue/jayvee-interpreter-lib';
 
-import { type RunOptions, runAction } from './run-action';
+import { runAction } from './run-action';
+import { type RunOptions } from './run-options';
 
 const interpreterMock: JayveeInterpreter = {
   interpretModel: vi.fn(),

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -6,25 +6,17 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-import {
-  type RunOptions,
-  interpretModel,
-  interpretString,
-} from '@jvalue/jayvee-interpreter-lib';
-import { vi } from 'vitest';
+import { type JayveeInterpreter } from '@jvalue/jayvee-interpreter-lib';
 
-import { runAction } from './run-action';
+import { type RunOptions, runAction } from './run-action';
 
-vi.mock('@jvalue/jayvee-interpreter-lib', async () => {
-  const original: object = await vi.importActual(
-    '@jvalue/jayvee-interpreter-lib',
-  );
-  return {
-    ...original,
-    interpretModel: vi.fn(),
-    interpretString: vi.fn(),
-  };
-});
+const interpreterMock: JayveeInterpreter = {
+  interpretModel: vi.fn(),
+  interpretString: vi.fn(),
+  parseModel: vi.fn(),
+};
+
+vi.stubGlobal('DefaultJayveeInterpreter', interpreterMock);
 
 describe('Parse Only', () => {
   const pathToValidModel = path.resolve(__dirname, '../../../example/cars.jv');
@@ -42,8 +34,8 @@ describe('Parse Only', () => {
 
   afterEach(() => {
     // Assert that model is not executed
-    expect(interpretString).not.toBeCalled();
-    expect(interpretModel).not.toBeCalled();
+    expect(interpreterMock.interpretString).not.toBeCalled();
+    expect(interpreterMock.interpretModel).not.toBeCalled();
   });
 
   beforeEach(() => {

--- a/apps/interpreter/src/run-action.ts
+++ b/apps/interpreter/src/run-action.ts
@@ -4,7 +4,6 @@
 
 import process from 'node:process';
 
-import { type Logger } from '@jvalue/jayvee-execution';
 import {
   DefaultJayveeInterpreter,
   ExitCode,
@@ -17,7 +16,7 @@ import {
   type JayveeServices,
 } from '@jvalue/jayvee-language-server';
 
-import { parseRunOptions } from './run-options';
+import { parsePipelineMatcherRegExp, parseRunOptions } from './run-options';
 
 export async function runAction(
   filePath: string,
@@ -65,19 +64,4 @@ async function runParseOnly(
   );
   const exitCode = model === undefined ? ExitCode.FAILURE : ExitCode.SUCCESS;
   process.exit(exitCode);
-}
-
-function parsePipelineMatcherRegExp(
-  matcher: string,
-  logger: Logger,
-): RegExp | undefined {
-  try {
-    return new RegExp(matcher);
-  } catch (e: unknown) {
-    logger.logErr(
-      `Invalid value "${matcher}" for pipeline selection option: -p --pipeline.\n` +
-        'Must be a valid regular expression.',
-    );
-    return undefined;
-  }
 }

--- a/apps/interpreter/src/run-action.ts
+++ b/apps/interpreter/src/run-action.ts
@@ -2,13 +2,23 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import { strict as assert } from 'assert';
 import process from 'node:process';
 
+import {
+  type DebugGranularity,
+  DebugGranularityValues,
+  type DebugTargets,
+  DefaultDebugTargetsValue,
+  type Logger,
+  isDebugGranularity,
+} from '@jvalue/jayvee-execution';
 import {
   DefaultJayveeInterpreter,
   ExitCode,
   type JayveeInterpreter,
-  type LoggerFactory,
+  LoggerFactory,
   extractAstNodeFromFile,
 } from '@jvalue/jayvee-interpreter-lib';
 import {
@@ -19,15 +29,23 @@ import {
 export interface RunOptions {
   env: Map<string, string>;
   debug: boolean;
-  debugGranularity: string;
-  debugTarget: string | undefined;
-  parseOnly?: boolean;
+  debugGranularity: DebugGranularity;
+  debugTarget: DebugTargets;
+  parseOnly: boolean;
 }
 
 export async function runAction(
   filePath: string,
-  options: RunOptions,
+  optionsRaw: unknown,
 ): Promise<void> {
+  const options = parseRunOptions(
+    optionsRaw,
+    new LoggerFactory(true).createLogger(),
+  );
+  if (options === undefined) {
+    return process.exit(ExitCode.FAILURE);
+  }
+
   const interpreter = new DefaultJayveeInterpreter({
     env: options.env,
     debug: options.debug,
@@ -57,4 +75,127 @@ async function runParseOnly(
   );
   const exitCode = model === undefined ? ExitCode.FAILURE : ExitCode.SUCCESS;
   process.exit(exitCode);
+}
+
+function parseRunOptions(
+  optionsRaw: unknown,
+  logger: Logger,
+): RunOptions | undefined {
+  if (typeof optionsRaw !== 'object' || optionsRaw == null) {
+    logger.logErr(
+      "Error in the interpreter: didn't receive a valid RunOptions object.",
+    );
+    return undefined;
+  }
+
+  const requiredFields = [
+    'env',
+    'debug',
+    'debugGranularity',
+    'debugTarget',
+    'parseOnly',
+  ];
+  if (requiredFields.some((f) => !(f in optionsRaw))) {
+    logger.logErr(
+      `Error in the interpreter: didn't receive a valid RunOptions object. Must have the fields ${requiredFields
+        .map((f) => `"${f}"`)
+        .join(', ')} but got object ${JSON.stringify(optionsRaw, null, 2)}`,
+    );
+    return undefined;
+  }
+
+  const options = optionsRaw as {
+    env: unknown;
+    debug: unknown;
+    debugGranularity: unknown;
+    debugTarget: unknown;
+    parseOnly: unknown;
+  };
+  assert(
+    options.env instanceof Map,
+    'Error in parsing env variable (see commander setup)',
+  );
+
+  if (!isDebugGranularity(options.debugGranularity)) {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.debugGranularity,
+      )}" for debug granularity option: -dg --debug-granularity.\n` +
+        `Must be one of the following values: ${DebugGranularityValues.join(
+          ', ',
+        )}.`,
+    );
+    return undefined;
+  }
+
+  if (typeof options.debugTarget !== 'string') {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.debugTarget,
+      )}" for debug target option: -dt --debug-target.\n` +
+        'Must be a string value.',
+    );
+    return undefined;
+  }
+
+  if (
+    typeof options.debug !== 'boolean' &&
+    options.debug !== 'true' &&
+    options.debug !== 'false'
+  ) {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.debug,
+      )}" for debug option: -d --debug.\n` + 'Must be true or false.',
+    );
+    return undefined;
+  }
+
+  if (
+    typeof options.parseOnly !== 'boolean' &&
+    options.parseOnly !== 'true' &&
+    options.parseOnly !== 'false'
+  ) {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.parseOnly,
+      )}" for parse-only option: -po --parse-only.\n` +
+        'Must be true or false.',
+    );
+    return undefined;
+  }
+
+  if (
+    !(
+      options.env instanceof Map &&
+      [...options.env.entries()].every(
+        ([key, value]) => typeof key === 'string' && typeof value === 'string',
+      )
+    )
+  ) {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.env,
+      )}" for env option: -e --env.\n` +
+        'Must be map from string keys to string values.',
+    );
+    return undefined;
+  }
+
+  return {
+    env: options.env as Map<string, string>,
+    debug: options.debug === true || options.debug === 'true',
+    debugGranularity: options.debugGranularity,
+    debugTarget: getDebugTargets(options.debugTarget),
+    parseOnly: options.parseOnly === true || options.parseOnly === 'true',
+  };
+}
+
+function getDebugTargets(debugTargetsString: string): DebugTargets {
+  const areAllBlocksTargeted = debugTargetsString === DefaultDebugTargetsValue;
+  if (areAllBlocksTargeted) {
+    return DefaultDebugTargetsValue;
+  }
+
+  return debugTargetsString.split(',').map((target) => target.trim());
 }

--- a/apps/interpreter/src/run-action.ts
+++ b/apps/interpreter/src/run-action.ts
@@ -5,14 +5,6 @@
 import process from 'node:process';
 
 import {
-  type DebugGranularity,
-  DebugGranularityValues,
-  type DebugTargets,
-  DefaultDebugTargetsValue,
-  type Logger,
-  isDebugGranularity,
-} from '@jvalue/jayvee-execution';
-import {
   DefaultJayveeInterpreter,
   ExitCode,
   type JayveeInterpreter,
@@ -24,14 +16,7 @@ import {
   type JayveeServices,
 } from '@jvalue/jayvee-language-server';
 
-export interface RunOptions {
-  pipeline: string;
-  env: Map<string, string>;
-  debug: boolean;
-  debugGranularity: DebugGranularity;
-  debugTarget: DebugTargets;
-  parseOnly: boolean;
-}
+import { parseRunOptions } from './run-options';
 
 export async function runAction(
   filePath: string,
@@ -85,142 +70,4 @@ async function runParseOnly(
   );
   const exitCode = model === undefined ? ExitCode.FAILURE : ExitCode.SUCCESS;
   process.exit(exitCode);
-}
-
-function parseRunOptions(
-  optionsRaw: unknown,
-  logger: Logger,
-): RunOptions | undefined {
-  if (typeof optionsRaw !== 'object' || optionsRaw == null) {
-    logger.logErr(
-      "Error in the interpreter: didn't receive a valid RunOptions object.",
-    );
-    return undefined;
-  }
-
-  const requiredFields = [
-    'env',
-    'debug',
-    'debugGranularity',
-    'debugTarget',
-    'parseOnly',
-    'pipeline',
-  ];
-  if (requiredFields.some((f) => !(f in optionsRaw))) {
-    logger.logErr(
-      `Error in the interpreter: didn't receive a valid RunOptions object. Must have the fields ${requiredFields
-        .map((f) => `"${f}"`)
-        .join(', ')} but got object ${JSON.stringify(optionsRaw, null, 2)}`,
-    );
-    return undefined;
-  }
-
-  const options = optionsRaw as {
-    pipeline: unknown;
-    env: unknown;
-    debug: unknown;
-    debugGranularity: unknown;
-    debugTarget: unknown;
-    parseOnly: unknown;
-  };
-
-  // options.pipeline
-  if (typeof options.pipeline !== 'string') {
-    logger.logErr(
-      `Invalid value "${JSON.stringify(
-        options.pipeline,
-      )}" for pipeline selection option: -p --pipeline.\n` +
-        'Must be a string value.',
-    );
-    return undefined;
-  }
-
-  // options.debugGranularity
-  if (!isDebugGranularity(options.debugGranularity)) {
-    logger.logErr(
-      `Invalid value "${JSON.stringify(
-        options.debugGranularity,
-      )}" for debug granularity option: -dg --debug-granularity.\n` +
-        `Must be one of the following values: ${DebugGranularityValues.join(
-          ', ',
-        )}.`,
-    );
-    return undefined;
-  }
-
-  // options.debugTarget
-  if (typeof options.debugTarget !== 'string') {
-    logger.logErr(
-      `Invalid value "${JSON.stringify(
-        options.debugTarget,
-      )}" for debug target option: -dt --debug-target.\n` +
-        'Must be a string value.',
-    );
-    return undefined;
-  }
-
-  // options.debug
-  if (
-    typeof options.debug !== 'boolean' &&
-    options.debug !== 'true' &&
-    options.debug !== 'false'
-  ) {
-    logger.logErr(
-      `Invalid value "${JSON.stringify(
-        options.debug,
-      )}" for debug option: -d --debug.\n` + 'Must be true or false.',
-    );
-    return undefined;
-  }
-
-  // options.parseOnly
-  if (
-    typeof options.parseOnly !== 'boolean' &&
-    options.parseOnly !== 'true' &&
-    options.parseOnly !== 'false'
-  ) {
-    logger.logErr(
-      `Invalid value "${JSON.stringify(
-        options.parseOnly,
-      )}" for parse-only option: -po --parse-only.\n` +
-        'Must be true or false.',
-    );
-    return undefined;
-  }
-
-  // options.env
-  if (
-    !(
-      options.env instanceof Map &&
-      [...options.env.entries()].every(
-        ([key, value]) => typeof key === 'string' && typeof value === 'string',
-      )
-    )
-  ) {
-    logger.logErr(
-      `Invalid value "${JSON.stringify(
-        options.env,
-      )}" for env option: -e --env.\n` +
-        'Must be map from string keys to string values.',
-    );
-    return undefined;
-  }
-
-  return {
-    pipeline: options.pipeline,
-    env: options.env as Map<string, string>,
-    debug: options.debug === true || options.debug === 'true',
-    debugGranularity: options.debugGranularity,
-    debugTarget: getDebugTargets(options.debugTarget),
-    parseOnly: options.parseOnly === true || options.parseOnly === 'true',
-  };
-}
-
-function getDebugTargets(debugTargetsString: string): DebugTargets {
-  const areAllBlocksTargeted = debugTargetsString === DefaultDebugTargetsValue;
-  if (areAllBlocksTargeted) {
-    return DefaultDebugTargetsValue;
-  }
-
-  return debugTargetsString.split(',').map((target) => target.trim());
 }

--- a/apps/interpreter/src/run-action.ts
+++ b/apps/interpreter/src/run-action.ts
@@ -4,6 +4,7 @@
 
 import process from 'node:process';
 
+import { type Logger } from '@jvalue/jayvee-execution';
 import {
   DefaultJayveeInterpreter,
   ExitCode,
@@ -28,15 +29,9 @@ export async function runAction(
     return process.exit(ExitCode.FAILURE);
   }
 
-  let pipelineRegExp: RegExp | undefined;
-  try {
-    pipelineRegExp = new RegExp(options.pipeline);
-  } catch (e: unknown) {
-    logger.logErr(
-      `Invalid value "${options.pipeline}" for pipeline selection option: -p --pipeline.\n` +
-        'Must be a valid regular expression.',
-    );
-    return undefined;
+  const pipelineRegExp = parsePipelineMatcherRegExp(options.pipeline, logger);
+  if (pipelineRegExp === undefined) {
+    return process.exit(ExitCode.FAILURE);
   }
 
   const interpreter = new DefaultJayveeInterpreter({
@@ -70,4 +65,19 @@ async function runParseOnly(
   );
   const exitCode = model === undefined ? ExitCode.FAILURE : ExitCode.SUCCESS;
   process.exit(exitCode);
+}
+
+function parsePipelineMatcherRegExp(
+  matcher: string,
+  logger: Logger,
+): RegExp | undefined {
+  try {
+    return new RegExp(matcher);
+  } catch (e: unknown) {
+    logger.logErr(
+      `Invalid value "${matcher}" for pipeline selection option: -p --pipeline.\n` +
+        'Must be a valid regular expression.',
+    );
+    return undefined;
+  }
 }

--- a/apps/interpreter/src/run-options.ts
+++ b/apps/interpreter/src/run-options.ts
@@ -179,3 +179,18 @@ function isEnvArgument(
   }
   return true;
 }
+
+export function parsePipelineMatcherRegExp(
+  matcher: string,
+  logger: Logger,
+): RegExp | undefined {
+  try {
+    return new RegExp(matcher);
+  } catch (e: unknown) {
+    logger.logErr(
+      `Invalid value "${matcher}" for pipeline selection option: -p --pipeline.\n` +
+        'Must be a valid regular expression.',
+    );
+    return undefined;
+  }
+}

--- a/apps/interpreter/src/run-options.ts
+++ b/apps/interpreter/src/run-options.ts
@@ -1,0 +1,155 @@
+import {
+  type DebugGranularity,
+  DebugGranularityValues,
+  type DebugTargets,
+  DefaultDebugTargetsValue,
+  type Logger,
+  isDebugGranularity,
+} from '@jvalue/jayvee-execution';
+
+export interface RunOptions {
+  pipeline: string;
+  env: Map<string, string>;
+  debug: boolean;
+  debugGranularity: DebugGranularity;
+  debugTarget: DebugTargets;
+  parseOnly: boolean;
+}
+
+export function parseRunOptions(
+  optionsRaw: unknown,
+  logger: Logger,
+): RunOptions | undefined {
+  if (typeof optionsRaw !== 'object' || optionsRaw == null) {
+    logger.logErr(
+      "Error in the interpreter: didn't receive a valid RunOptions object.",
+    );
+    return undefined;
+  }
+
+  const requiredFields = [
+    'env',
+    'debug',
+    'debugGranularity',
+    'debugTarget',
+    'parseOnly',
+    'pipeline',
+  ];
+  if (requiredFields.some((f) => !(f in optionsRaw))) {
+    logger.logErr(
+      `Error in the interpreter: didn't receive a valid RunOptions object. Must have the fields ${requiredFields
+        .map((f) => `"${f}"`)
+        .join(', ')} but got object ${JSON.stringify(optionsRaw, null, 2)}`,
+    );
+    return undefined;
+  }
+
+  const options = optionsRaw as {
+    pipeline: unknown;
+    env: unknown;
+    debug: unknown;
+    debugGranularity: unknown;
+    debugTarget: unknown;
+    parseOnly: unknown;
+  };
+
+  // options.pipeline
+  if (typeof options.pipeline !== 'string') {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.pipeline,
+      )}" for pipeline selection option: -p --pipeline.\n` +
+        'Must be a string value.',
+    );
+    return undefined;
+  }
+
+  // options.debugGranularity
+  if (!isDebugGranularity(options.debugGranularity)) {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.debugGranularity,
+      )}" for debug granularity option: -dg --debug-granularity.\n` +
+        `Must be one of the following values: ${DebugGranularityValues.join(
+          ', ',
+        )}.`,
+    );
+    return undefined;
+  }
+
+  // options.debugTarget
+  if (typeof options.debugTarget !== 'string') {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.debugTarget,
+      )}" for debug target option: -dt --debug-target.\n` +
+        'Must be a string value.',
+    );
+    return undefined;
+  }
+
+  // options.debug
+  if (
+    typeof options.debug !== 'boolean' &&
+    options.debug !== 'true' &&
+    options.debug !== 'false'
+  ) {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.debug,
+      )}" for debug option: -d --debug.\n` + 'Must be true or false.',
+    );
+    return undefined;
+  }
+
+  // options.parseOnly
+  if (
+    typeof options.parseOnly !== 'boolean' &&
+    options.parseOnly !== 'true' &&
+    options.parseOnly !== 'false'
+  ) {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.parseOnly,
+      )}" for parse-only option: -po --parse-only.\n` +
+        'Must be true or false.',
+    );
+    return undefined;
+  }
+
+  // options.env
+  if (
+    !(
+      options.env instanceof Map &&
+      [...options.env.entries()].every(
+        ([key, value]) => typeof key === 'string' && typeof value === 'string',
+      )
+    )
+  ) {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(
+        options.env,
+      )}" for env option: -e --env.\n` +
+        'Must be map from string keys to string values.',
+    );
+    return undefined;
+  }
+
+  return {
+    pipeline: options.pipeline,
+    env: options.env as Map<string, string>,
+    debug: options.debug === true || options.debug === 'true',
+    debugGranularity: options.debugGranularity,
+    debugTarget: getDebugTargets(options.debugTarget),
+    parseOnly: options.parseOnly === true || options.parseOnly === 'true',
+  };
+}
+
+function getDebugTargets(debugTargetsString: string): DebugTargets {
+  const areAllBlocksTargeted = debugTargetsString === DefaultDebugTargetsValue;
+  if (areAllBlocksTargeted) {
+    return DefaultDebugTargetsValue;
+  }
+
+  return debugTargetsString.split(',').map((target) => target.trim());
+}

--- a/apps/interpreter/src/run-options.ts
+++ b/apps/interpreter/src/run-options.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 import {
   type DebugGranularity,
   DebugGranularityValues,

--- a/apps/interpreter/src/run-options.ts
+++ b/apps/interpreter/src/run-options.ts
@@ -48,14 +48,7 @@ export function parseRunOptions(
     return undefined;
   }
 
-  const options = optionsRaw as {
-    pipeline: unknown;
-    env: unknown;
-    debug: unknown;
-    debugGranularity: unknown;
-    debugTarget: unknown;
-    parseOnly: unknown;
-  };
+  const options = optionsRaw as Record<keyof RunOptions, unknown>;
 
   isPipelineArgument(options.pipeline, logger);
   isEnvArgument(options.env, logger);

--- a/apps/interpreter/src/run-options.ts
+++ b/apps/interpreter/src/run-options.ts
@@ -61,7 +61,6 @@ export function parseRunOptions(
     return undefined;
   }
 
-  // TypeScript does not infer type from type guards, probably fixed in TS 5.5
   return {
     pipeline: options.pipeline,
     env: options.env,

--- a/apps/interpreter/src/run-options.ts
+++ b/apps/interpreter/src/run-options.ts
@@ -50,20 +50,24 @@ export function parseRunOptions(
 
   const options = optionsRaw as Record<keyof RunOptions, unknown>;
 
-  isPipelineArgument(options.pipeline, logger);
-  isEnvArgument(options.env, logger);
-  isDebugArgument(options.debug, logger);
-  isDebugGranularityArgument(options.debugGranularity, logger);
-  isDebugTargetArgument(options.debugTarget, logger);
-  isParseOnlyArgument(options.parseOnly, logger);
+  if (
+    !isPipelineArgument(options.pipeline, logger) ||
+    !isEnvArgument(options.env, logger) ||
+    !isDebugArgument(options.debug, logger) ||
+    !isDebugGranularityArgument(options.debugGranularity, logger) ||
+    !isDebugTargetArgument(options.debugTarget, logger) ||
+    !isParseOnlyArgument(options.parseOnly, logger)
+  ) {
+    return undefined;
+  }
 
   // TypeScript does not infer type from type guards, probably fixed in TS 5.5
   return {
-    pipeline: options.pipeline as string,
-    env: options.env as Map<string, string>,
+    pipeline: options.pipeline,
+    env: options.env,
     debug: options.debug === true || options.debug === 'true',
     debugGranularity: options.debugGranularity as DebugGranularity,
-    debugTarget: getDebugTargets(options.debugTarget as string),
+    debugTarget: getDebugTargets(options.debugTarget),
     parseOnly: options.parseOnly === true || options.parseOnly === 'true',
   };
 }

--- a/libs/interpreter-lib/src/interpreter.spec.ts
+++ b/libs/interpreter-lib/src/interpreter.spec.ts
@@ -18,7 +18,7 @@ describe('Interpreter', () => {
       const interpreter = new DefaultJayveeInterpreter({
         debug: true,
         debugGranularity: 'peek',
-        debugTarget: undefined,
+        debugTarget: 'all',
         env: new Map(),
       });
       const exitCode = await interpreter.interpretString(model);

--- a/libs/interpreter-lib/src/interpreter.spec.ts
+++ b/libs/interpreter-lib/src/interpreter.spec.ts
@@ -4,7 +4,7 @@
 
 import { readJvTestAssetHelper } from '@jvalue/jayvee-language-server/test';
 
-import { interpretString } from './interpreter';
+import { DefaultJayveeInterpreter } from './interpreter';
 import { ExitCode } from './parsing-util';
 
 describe('Interpreter', () => {
@@ -15,12 +15,13 @@ describe('Interpreter', () => {
       const exampleFilePath = 'example/cars.jv';
       const model = readJvTestAsset(exampleFilePath);
 
-      const exitCode = await interpretString(model, {
+      const interpreter = new DefaultJayveeInterpreter({
         debug: true,
         debugGranularity: 'peek',
         debugTarget: undefined,
         env: new Map(),
       });
+      const exitCode = await interpreter.interpretString(model);
       expect(exitCode).toEqual(ExitCode.SUCCESS);
     });
   });

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line no-restricted-imports
-import { strict as assert } from 'node:assert';
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import { strict as assert } from 'assert';
 
 import {
   type DebugGranularity,

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // eslint-disable-next-line no-restricted-imports
 import { strict as assert } from 'node:assert';
 

--- a/libs/interpreter-lib/src/parsing-util.ts
+++ b/libs/interpreter-lib/src/parsing-util.ts
@@ -22,12 +22,12 @@ export enum ExitCode {
  * Does load the directory of this document as the working directory.
  */
 export async function extractDocumentFromFile(
-  fileName: string,
+  filePath: string,
   services: LangiumServices,
   logger: Logger,
 ): Promise<LangiumDocument> {
   const extensions = services.LanguageMetaData.fileExtensions;
-  if (!extensions.includes(path.extname(fileName))) {
+  if (!extensions.includes(path.extname(filePath))) {
     const errorMessage = `Please choose a file with ${
       extensions.length === 1 ? 'this extension' : 'one of these extensions'
     }: ${extensions.map((extension) => `"${extension}"`).join(',')}`;
@@ -36,12 +36,12 @@ export async function extractDocumentFromFile(
     return Promise.reject(ExitCode.FAILURE);
   }
 
-  if (!fs.existsSync(fileName)) {
-    logger.logErr(`File ${fileName} does not exist.`);
+  if (!fs.existsSync(filePath)) {
+    logger.logErr(`File ${filePath} does not exist.`);
     return Promise.reject(ExitCode.FAILURE);
   }
 
-  const workingDirPath = path.dirname(fileName);
+  const workingDirPath = path.dirname(filePath);
 
   await initializeWorkspace(services, [
     {
@@ -51,10 +51,10 @@ export async function extractDocumentFromFile(
   ]);
 
   const document = services.shared.workspace.LangiumDocuments.getDocument(
-    URI.file(path.resolve(fileName)),
+    URI.file(path.resolve(filePath)),
   );
   if (document === undefined) {
-    logger.logErr(`Did not load file ${fileName} correctly.`);
+    logger.logErr(`Did not load file ${filePath} correctly.`);
     return Promise.reject(ExitCode.FAILURE);
   }
 
@@ -112,11 +112,11 @@ export async function validateDocument(
 }
 
 export async function extractAstNodeFromFile<T extends AstNode>(
-  fileName: string,
+  filePath: string,
   services: LangiumServices,
   logger: Logger,
 ): Promise<T> {
-  return (await extractDocumentFromFile(fileName, services, logger)).parseResult
+  return (await extractDocumentFromFile(filePath, services, logger)).parseResult
     .value as T;
 }
 


### PR DESCRIPTION
- reduces amounts of parameters in the interpretation model by using object construction
- defines a nicer interpreter interface that is easier to use
- pulls out CLI runtime argument validation (should not be located in interpreter-lib)
- introduces a default value for the `--debug-target` parameter to align with other params: use a default value over undefined