### PR TITLE
Add link to SWC example to docs

### DIFF
--- a/apps/docs/docs/user/examples/README.mdx
+++ b/apps/docs/docs/user/examples/README.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # Jayvee Examples

--- a/apps/docs/docs/user/use-cases/README.mdx
+++ b/apps/docs/docs/user/use-cases/README.mdx
@@ -4,7 +4,7 @@ sidebar_position: 12
 
 # Jayvee Use Cases
 
-Here you can find a selection of more complex projects that use (some form of) Jayvee to accomplish a real world task.
+Here you can find a selection of more complex projects that use (some form of) Jayvee to accomplish a real world task. If you have used or spotted Jayvee in the wild, we welcome additions to this list by PR or email to jvalue@group.riehle.org.
 
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';

--- a/apps/docs/docs/user/use-cases/README.mdx
+++ b/apps/docs/docs/user/use-cases/README.mdx
@@ -1,0 +1,13 @@
+---
+sidebar_position: 12
+---
+
+# Jayvee Use Cases
+
+Here you can find a selection of more complex projects that use (some form of) Jayvee to accomplish a real world task.
+
+```mdx-code-block
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />
+```

--- a/apps/docs/docs/user/use-cases/README.mdx.license
+++ b/apps/docs/docs/user/use-cases/README.mdx.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/docs/docs/user/use-cases/SWC-JValue-OCDE-Case1.md
+++ b/apps/docs/docs/user/use-cases/SWC-JValue-OCDE-Case1.md
@@ -1,0 +1,3 @@
+# Exploring material science data using Jayvee
+
+[Exploring material science data using Jayvee on GitHub](https://github.com/jvalue/Exploring-Materials-Science-Data-Using-Jayvee)

--- a/apps/docs/docs/user/use-cases/SWC-JValue-OCDE-Case1.md
+++ b/apps/docs/docs/user/use-cases/SWC-JValue-OCDE-Case1.md
@@ -1,3 +1,8 @@
 # Exploring material science data using Jayvee
 
+During the [Software Campus](https://softwarecampus.de/) project JValue-OCDE-Case1, managed by [Philip Heltweg](https://heltweg.org), Jayvee was applied to develop data pipelines for open data from the materials science domain, provided by the industry partner [Springer Materials](https://materials.springer.com/).
+
+## Project Link
+You can find the source code here:
+
 [Exploring material science data using Jayvee on GitHub](https://github.com/jvalue/Exploring-Materials-Science-Data-Using-Jayvee)

--- a/apps/docs/docs/user/use-cases/SWC-JValue-OCDE-Case1.md.license
+++ b/apps/docs/docs/user/use-cases/SWC-JValue-OCDE-Case1.md.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION
Adds a reference to use cases to the docs, currently only with the SWC project. I'd keep the actual description of the use case on the shorter side and directly link to the GitHub repo as I think it is pretty well explained there.

I will of course not merge this PR before making the SWC examples repo public.