### PR TITLE
Fix README output

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -15,9 +15,9 @@
         "tsConfig": "{projectRoot}/tsconfig.lib.json",
         "assets": [
           {
-            "glob": "{projectRoot}/README.md",
-            "input": ".",
-            "output": "."
+            "glob": "README.md",
+            "input": "{projectRoot}",
+            "output": "/"
           }
         ],
         "generatePackageJson": true


### PR DESCRIPTION
The `README.md`s were in the wrong directory in the build output. This PR fixes which also makes the NPM page proper again (https://www.npmjs.com/package/@jvalue/jayvee-interpreter-lib).

Before:
```
interpreter-lib/
├── libs
│   └── interpreter-lib
│       └── README.md
├── main.js
├── package.json
└── package-lock.json
```

With these changes:
```
interpreter-lib/
├── main.js
├── package.json
├── package-lock.json
└── README.md
```