### PR TITLE
Remove explicit main attribute

### DIFF
--- a/libs/language-server/package.json
+++ b/libs/language-server/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@jvalue/jayvee-language-server",
-  "main": "./src/index.js",
   "bugs": {
     "url": "https://github.com/jvalue/jayvee/issues"
   },


### PR DESCRIPTION
The entry point to the `language-server` lib is wrong. Removing the attribute allows `esbuild` to set it automatically to the correct value `./main.js`