### PR TITLE
fix(LocalFileExtractor): log correct error message

### DIFF
--- a/libs/extensions/std/exec/src/local-file-extractor-executor.spec.ts
+++ b/libs/extensions/std/exec/src/local-file-extractor-executor.spec.ts
@@ -104,7 +104,7 @@ describe('Validation of LocalFileExtractorExecutor', () => {
     expect(R.isErr(result)).toEqual(true);
     if (R.isErr(result)) {
       expect(result.left.message).toEqual(
-        `File './does-not-exist.csv' not found.`,
+        `ENOENT: no such file or directory, open './does-not-exist.csv'`,
       );
     }
   });


### PR DESCRIPTION
Problem: no matter why `readFile()` fails, the error is reported as 'file not found'
Solution: print the thrown errors message

closes #609