### PR TITLE
Add new builtin blocktype for CSV file to table parsing

### DIFF
--- a/libs/execution/src/lib/types/io-types/table.ts
+++ b/libs/execution/src/lib/types/io-types/table.ts
@@ -43,6 +43,10 @@ export class Table implements IOTypeImplementation<IOType.TABLE> {
     this.numberOfRows = numberOfRows;
   }
 
+  isEmpty(): boolean {
+    return this.numberOfRows === 0;
+  }
+
   addColumn(name: string, column: TableColumn): void {
     assert(column.values.length === this.numberOfRows);
     this.columns.set(name, column);

--- a/libs/extensions/tabular/exec/src/extension.ts
+++ b/libs/extensions/tabular/exec/src/extension.ts
@@ -12,6 +12,7 @@ import { CellWriterExecutor } from './lib/cell-writer-executor';
 import { ColumnDeleterExecutor } from './lib/column-deleter-executor';
 import { CSVFileLoaderExecutor } from './lib/csv-file-loader-executor';
 import { CSVInterpreterExecutor } from './lib/csv-interpreter-executor';
+import { CSVToTableInterpreterExecutor } from './lib/csv-to-table-interpreter-executor';
 import { RowDeleterExecutor } from './lib/row-deleter-executor';
 import { SheetPickerExecutor } from './lib/sheet-picker-executor';
 import { TableInterpreterExecutor } from './lib/table-interpreter-executor';
@@ -31,6 +32,7 @@ export class TabularExecExtension extends JayveeExecExtension {
       TableTransformerExecutor,
       XLSXInterpreterExecutor,
       SheetPickerExecutor,
+      CSVToTableInterpreterExecutor,
     ];
   }
 }

--- a/libs/extensions/tabular/exec/src/lib/csv-to-table-interpreter-executor.spec.ts
+++ b/libs/extensions/tabular/exec/src/lib/csv-to-table-interpreter-executor.spec.ts
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import * as R from '@jvalue/jayvee-execution';
+import { getTestExecutionContext } from '@jvalue/jayvee-execution/test';
+import {
+  type BlockDefinition,
+  IOType,
+  type JayveeServices,
+  createJayveeServices,
+} from '@jvalue/jayvee-language-server';
+import {
+  type ParseHelperOptions,
+  expectNoParserAndLexerErrors,
+  loadTestExtensions,
+  parseHelper,
+  readJvTestAssetHelper,
+} from '@jvalue/jayvee-language-server/test';
+import {
+  type AstNode,
+  type AstNodeLocator,
+  type LangiumDocument,
+} from 'langium';
+import { NodeFileSystem } from 'langium/node';
+
+import { CSVToTableInterpreterExecutor } from './csv-to-table-interpreter-executor';
+
+describe('Validation of CSVToTableInterpreterExecutor', () => {
+  let parse: (
+    input: string,
+    options?: ParseHelperOptions,
+  ) => Promise<LangiumDocument<AstNode>>;
+
+  let locator: AstNodeLocator;
+  let services: JayveeServices;
+
+  const readJvTestAsset = readJvTestAssetHelper(
+    __dirname,
+    '../../test/assets/csv-to-table-interpreter-executor/',
+  );
+
+  async function readTestCSV(fileName: string): Promise<R.BinaryFile> {
+    const absoluteFileName = path.resolve(
+      __dirname,
+      '../../test/assets/csv-to-table-interpreter-executor/',
+      fileName,
+    );
+
+    const content = await readFile(absoluteFileName);
+
+    return new R.BinaryFile(
+      fileName,
+      R.FileExtension.CSV,
+      R.MimeType.TEXT_CSV,
+      content,
+    );
+  }
+
+  async function parseAndExecuteExecutor(
+    input: string,
+    IOInput: R.BinaryFile,
+  ): Promise<R.Result<R.Table>> {
+    const document = await parse(input, { validation: true });
+    expectNoParserAndLexerErrors(document);
+
+    const block = locator.getAstNode<BlockDefinition>(
+      document.parseResult.value,
+      'pipelines@0/blocks@1',
+    ) as BlockDefinition;
+
+    return new CSVToTableInterpreterExecutor().doExecute(
+      IOInput,
+      getTestExecutionContext(locator, document, services, [block]),
+    );
+  }
+
+  beforeAll(async () => {
+    // Create language services
+    services = createJayveeServices(NodeFileSystem).Jayvee;
+    await loadTestExtensions(services, [
+      path.resolve(__dirname, '../../test/test-extension/TestBlockTypes.jv'),
+    ]);
+    locator = services.workspace.AstNodeLocator;
+    // Parse function for Jayvee (without validation)
+    parse = parseHelper(services);
+  });
+
+  describe('validation of sheet with header', () => {
+    it('should diagnose no error on valid sheet', async () => {
+      const text = readJvTestAsset('valid-with-header.jv');
+
+      const testFile = await readTestCSV('test-with-header.csv');
+      const result = await parseAndExecuteExecutor(text, testFile);
+
+      expect(R.isErr(result)).toEqual(false);
+      if (R.isOk(result)) {
+        expect(result.right.ioType).toEqual(IOType.TABLE);
+        expect(result.right.getNumberOfColumns()).toEqual(3);
+        expect(result.right.getNumberOfRows()).toEqual(16);
+        expect(result.right.getColumn('index')).toEqual(
+          expect.objectContaining({
+            values: expect.arrayContaining([0, 1, 2, 15]) as number[],
+          }),
+        );
+        expect(result.right.getColumn('name')).toEqual(
+          expect.objectContaining({
+            values: expect.arrayContaining(['Test']) as string[],
+          }),
+        );
+        expect(result.right.getColumn('flag')).toEqual(
+          expect.objectContaining({
+            values: expect.arrayContaining([true, false]) as boolean[],
+          }),
+        );
+      }
+    });
+
+    it('should diagnose empty table on empty column parameter', async () => {
+      const text = readJvTestAsset('valid-empty-columns-with-header.jv');
+
+      const testFile = await readTestCSV('test-with-header.csv');
+      const result = await parseAndExecuteExecutor(text, testFile);
+
+      expect(R.isErr(result)).toEqual(false);
+      if (R.isOk(result)) {
+        expect(result.right.ioType).toEqual(IOType.TABLE);
+        expect(result.right.getNumberOfColumns()).toEqual(0);
+        expect(result.right.getNumberOfRows()).toEqual(0);
+      }
+    });
+
+    it('should diagnose skipping row on wrong cell value type', async () => {
+      const text = readJvTestAsset('valid-wrong-value-type-with-header.jv');
+
+      const testFile = await readTestCSV('test-with-header.csv');
+      const result = await parseAndExecuteExecutor(text, testFile);
+
+      expect(R.isErr(result)).toEqual(false);
+      if (R.isOk(result)) {
+        expect(result.right.ioType).toEqual(IOType.TABLE);
+        expect(result.right.getNumberOfColumns()).toEqual(3);
+        expect(result.right.getNumberOfRows()).toEqual(0);
+      }
+    });
+  });
+
+  describe('validation of sheet without header', () => {
+    it('should diagnose no error on valid sheet', async () => {
+      const text = readJvTestAsset('valid-without-header.jv');
+
+      const testFile = await readTestCSV('test-without-header.csv');
+      const result = await parseAndExecuteExecutor(text, testFile);
+
+      expect(R.isErr(result)).toEqual(false);
+      if (R.isOk(result)) {
+        expect(result.right.ioType).toEqual(IOType.TABLE);
+        expect(result.right.getNumberOfColumns()).toEqual(3);
+        expect(result.right.getNumberOfRows()).toEqual(16);
+        expect(result.right.getColumn('index')).toEqual(
+          expect.objectContaining({
+            values: expect.arrayContaining([0, 1, 2, 15]) as number[],
+          }),
+        );
+        expect(result.right.getColumn('name')).toEqual(
+          expect.objectContaining({
+            values: expect.arrayContaining(['Test']) as string[],
+          }),
+        );
+        expect(result.right.getColumn('flag')).toEqual(
+          expect.objectContaining({
+            values: expect.arrayContaining([true, false]) as boolean[],
+          }),
+        );
+      }
+    });
+
+    it('should diagnose no error on valid sheet with header', async () => {
+      const text = readJvTestAsset('valid-without-header.jv');
+
+      const testFile = await readTestCSV('test-with-header.csv');
+      const result = await parseAndExecuteExecutor(text, testFile);
+
+      expect(R.isErr(result)).toEqual(false);
+      if (R.isOk(result)) {
+        expect(result.right.ioType).toEqual(IOType.TABLE);
+        expect(result.right.getNumberOfColumns()).toEqual(3);
+        expect(result.right.getNumberOfRows()).toEqual(16);
+        expect(result.right.getColumn('index')).toEqual(
+          expect.objectContaining({
+            values: expect.arrayContaining([0, 1, 2, 15]) as number[],
+          }),
+        );
+        expect(result.right.getColumn('name')).toEqual(
+          expect.objectContaining({
+            values: expect.arrayContaining(['Test']) as string[],
+          }),
+        );
+        expect(result.right.getColumn('flag')).toEqual(
+          expect.objectContaining({
+            values: expect.arrayContaining([true, false]) as boolean[],
+          }),
+        );
+      }
+    });
+
+    it('should diagnose empty table on empty column parameter', async () => {
+      const text = readJvTestAsset('valid-empty-columns-without-header.jv');
+
+      const testFile = await readTestCSV('test-without-header.csv');
+      const result = await parseAndExecuteExecutor(text, testFile);
+
+      expect(R.isErr(result)).toEqual(false);
+      if (R.isOk(result)) {
+        expect(result.right.ioType).toEqual(IOType.TABLE);
+        expect(result.right.getNumberOfColumns()).toEqual(0);
+        expect(result.right.getNumberOfRows()).toEqual(0);
+      }
+    });
+
+    it('should diagnose empty table on empty sheet', async () => {
+      const text = readJvTestAsset('valid-without-header.jv');
+
+      const testFile = await readTestCSV('test-empty.csv');
+      const result = await parseAndExecuteExecutor(text, testFile);
+
+      expect(R.isErr(result)).toEqual(false);
+      if (R.isOk(result)) {
+        expect(result.right.isEmpty()).toEqual(true);
+      }
+    });
+
+    it('should diagnose skipping row on wrong cell value type', async () => {
+      const text = readJvTestAsset('valid-wrong-value-type-without-header.jv');
+
+      const testFile = await readTestCSV('test-without-header.csv');
+      const result = await parseAndExecuteExecutor(text, testFile);
+
+      expect(R.isErr(result)).toEqual(false);
+      if (R.isOk(result)) {
+        expect(result.right.ioType).toEqual(IOType.TABLE);
+        expect(result.right.getNumberOfColumns()).toEqual(3);
+        expect(result.right.getNumberOfRows()).toEqual(0);
+      }
+    });
+  });
+});

--- a/libs/extensions/tabular/exec/src/lib/csv-to-table-interpreter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/csv-to-table-interpreter-executor.ts
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import { strict as assert } from 'assert';
+
+import { HeaderArray, parseString as parseCSVString } from '@fast-csv/parse';
+import { type ParserOptionsArgs } from '@fast-csv/parse/build/src/ParserOptions';
+import * as R from '@jvalue/jayvee-execution';
+import {
+  AbstractBlockExecutor,
+  BinaryFile,
+  type BlockExecutorClass,
+  type ExecutionContext,
+  Table,
+  implementsStatic,
+} from '@jvalue/jayvee-execution';
+import {
+  CellIndex,
+  IOType,
+  type ValuetypeAssignment,
+  rowIndexToString,
+} from '@jvalue/jayvee-language-server';
+
+import {
+  ColumnDefinitionEntry,
+  TableInterpreterExecutor,
+} from './table-interpreter-executor';
+
+@implementsStatic<BlockExecutorClass>()
+export class CSVToTableInterpreterExecutor extends AbstractBlockExecutor<
+  IOType.FILE,
+  IOType.TABLE
+> {
+  public static readonly type = 'CSVToTableInterpreter';
+
+  constructor() {
+    super(IOType.FILE, IOType.TABLE);
+  }
+
+  async doExecute(
+    inputFile: BinaryFile,
+    context: ExecutionContext,
+  ): Promise<R.Result<Table>> {
+    const encoding = context.getPropertyValue(
+      'encoding',
+      context.valueTypeProvider.Primitives.Text,
+    );
+    const delimiter = context.getPropertyValue(
+      'delimiter',
+      context.valueTypeProvider.Primitives.Text,
+    );
+    const enclosing = context.getPropertyValue(
+      'enclosing',
+      context.valueTypeProvider.Primitives.Text,
+    );
+    const enclosingEscape = context.getPropertyValue(
+      'enclosingEscape',
+      context.valueTypeProvider.Primitives.Text,
+    );
+    const header = context.getPropertyValue(
+      'header',
+      context.valueTypeProvider.Primitives.Boolean,
+    );
+    const columnDefinitions = context.getPropertyValue(
+      'columns',
+      context.valueTypeProvider.createCollectionValueTypeOf(
+        context.valueTypeProvider.Primitives.ValuetypeAssignment,
+      ),
+    );
+
+    const parseOptions: ParserOptionsArgs = {
+      delimiter,
+      quote: enclosing,
+      escape: enclosingEscape,
+      encoding,
+    };
+
+    const table = await this.parseCSV(
+      inputFile,
+      encoding,
+      parseOptions,
+      header,
+      columnDefinitions,
+      context,
+    );
+    context.logger.logDebug(
+      `Validation completed, the resulting table has ${table.getNumberOfRows()} row(s) and ${table.getNumberOfColumns()} column(s)`,
+    );
+    return R.ok(table);
+  }
+
+  private async parseCSV(
+    inputFile: BinaryFile,
+    encoding: string,
+    parseOptions: ParserOptionsArgs,
+    header: boolean,
+    columnDefinitions: ValuetypeAssignment[],
+    context: ExecutionContext,
+  ): Promise<Table> {
+    const decoder = new TextDecoder(encoding);
+    const csvText = decoder.decode(inputFile.content);
+
+    return new Promise((resolve, reject) => {
+      const table = new Table();
+      let columnEntries: ColumnDefinitionEntry[] | undefined = undefined;
+      if (header) {
+        parseOptions.headers = true;
+        // NOTE: columns will be added on the parsers `header` event
+      } else {
+        columnEntries =
+          TableInterpreterExecutor.deriveColumnDefinitionEntriesWithoutHeader(
+            columnDefinitions,
+            context,
+          );
+        columnEntries.forEach((columnEntry) => {
+          table.addColumn(columnEntry.columnName, {
+            values: [],
+            valueType: columnEntry.valueType,
+          });
+        });
+      }
+
+      let rowIdx = 0;
+      parseCSVString(csvText, parseOptions)
+        .on('error', (error) => {
+          reject(error);
+        })
+
+        .on('headers', (headers: HeaderArray) => {
+          columnEntries = this.deriveColumnDefinitionEntriesFromHeader(
+            columnDefinitions,
+            headers,
+            context,
+          );
+          columnEntries.forEach((columnEntry) => {
+            table.addColumn(columnEntry.columnName, {
+              values: [],
+              valueType: columnEntry.valueType,
+            });
+          });
+        })
+
+        .on('data', (data: Record<string, string> | string[]) => {
+          assert(
+            columnEntries !== undefined,
+            'Headers have either been parsed in the `header` event, or derived from column definitions',
+          );
+          const parsedRow = this.constructAndValidateTableRow(
+            data,
+            rowIdx++,
+            columnEntries,
+            context,
+          );
+          if (parsedRow === undefined) {
+            context.logger.logDebug(`Omitting row ${rowIndexToString(rowIdx)}`);
+          } else {
+            table.addRow(parsedRow);
+          }
+        })
+
+        .on('end', () => {
+          resolve(table);
+        });
+    });
+  }
+
+  private constructAndValidateTableRow(
+    sheetRow: Record<string, string> | string[],
+    sheetRowIndex: number,
+    columnEntries: ColumnDefinitionEntry[],
+    context: ExecutionContext,
+  ): R.TableRow | undefined {
+    let invalidRow = false;
+    const tableRow: R.TableRow = {};
+    columnEntries.forEach((columnEntry) => {
+      const sheetColumnIndex = columnEntry.sheetColumnIndex;
+
+      const value: string = Array.isArray(sheetRow)
+        ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          sheetRow[sheetColumnIndex]!
+        : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          sheetRow[columnEntry.columnName]!;
+
+      const valueType = columnEntry.valueType;
+
+      const parsedValue = TableInterpreterExecutor.parseAndValidateValue(
+        value,
+        valueType,
+        context,
+      );
+      if (parsedValue === undefined) {
+        const currentCellIndex = new CellIndex(sheetColumnIndex, sheetRowIndex);
+        context.logger.logDebug(
+          `Invalid value at cell ${currentCellIndex.toString()}: "${value}" does not match the type ${columnEntry.valueType.getName()}`,
+        );
+        invalidRow = true;
+        return;
+      }
+
+      tableRow[columnEntry.columnName] = parsedValue;
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (invalidRow) {
+      return undefined;
+    }
+
+    assert(Object.keys(tableRow).length === columnEntries.length);
+    return tableRow;
+  }
+
+  private deriveColumnDefinitionEntriesFromHeader(
+    columnDefinitions: ValuetypeAssignment[],
+    headerRow: (string | null | undefined)[],
+    context: ExecutionContext,
+  ): ColumnDefinitionEntry[] {
+    context.logger.logDebug(`Matching header with provided column names`);
+
+    const columnEntries: ColumnDefinitionEntry[] = [];
+    for (const columnDefinition of columnDefinitions) {
+      const indexOfMatchingHeader = headerRow.findIndex(
+        (headerColumnName) => headerColumnName === columnDefinition.name,
+      );
+      if (indexOfMatchingHeader === -1) {
+        context.logger.logDebug(
+          `Omitting column "${columnDefinition.name}" as the name was not found in the header`,
+        );
+        continue;
+      }
+      const columnValuetype = context.wrapperFactories.ValueType.wrap(
+        columnDefinition.type,
+      );
+      assert(columnValuetype !== undefined);
+
+      columnEntries.push({
+        sheetColumnIndex: indexOfMatchingHeader,
+        columnName: columnDefinition.name,
+        valueType: columnValuetype,
+        astNode: columnDefinition,
+      });
+    }
+
+    return columnEntries;
+  }
+}

--- a/libs/extensions/tabular/exec/src/lib/csv-to-table-interpreter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/csv-to-table-interpreter-executor.ts
@@ -85,6 +85,19 @@ export class CSVToTableInterpreterExecutor extends AbstractBlockExecutor<
       columnDefinitions,
       context,
     );
+
+    if (
+      header &&
+      columnDefinitions.length !== 0 &&
+      table.getNumberOfColumns() === 0
+    ) {
+      return R.err({
+        message: 'The input csv is empty and thus has no header',
+        diagnostic: {
+          node: context.getCurrentNode(),
+        },
+      });
+    }
     context.logger.logDebug(
       `Validation completed, the resulting table has ${table.getNumberOfRows()} row(s) and ${table.getNumberOfColumns()} column(s)`,
     );

--- a/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
@@ -73,11 +73,12 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
 
       const headerRow = inputSheet.getHeaderRow();
 
-      columnEntries = this.deriveColumnDefinitionEntriesFromHeader(
-        columnDefinitions,
-        headerRow,
-        context,
-      );
+      columnEntries =
+        TableInterpreterExecutor.deriveColumnDefinitionEntriesFromHeader(
+          columnDefinitions,
+          headerRow,
+          context,
+        );
     } else {
       if (inputSheet.getNumberOfColumns() < columnDefinitions.length) {
         return R.err({
@@ -90,10 +91,11 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
         });
       }
 
-      columnEntries = this.deriveColumnDefinitionEntriesWithoutHeader(
-        columnDefinitions,
-        context,
-      );
+      columnEntries =
+        TableInterpreterExecutor.deriveColumnDefinitionEntriesWithoutHeader(
+          columnDefinitions,
+          context,
+        );
     }
 
     const numberOfTableRows = header
@@ -103,7 +105,7 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
       `Validating ${numberOfTableRows} row(s) according to the column types`,
     );
 
-    const resultingTable = this.constructAndValidateTable(
+    const resultingTable = TableInterpreterExecutor.constructAndValidateTable(
       inputSheet,
       header,
       columnEntries,
@@ -115,7 +117,7 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
     return R.ok(resultingTable);
   }
 
-  private constructAndValidateTable(
+  private static constructAndValidateTable(
     sheet: Sheet,
     header: boolean,
     columnEntries: ColumnDefinitionEntry[],
@@ -154,7 +156,7 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
     return table;
   }
 
-  private constructAndValidateTableRow(
+  private static constructAndValidateTableRow(
     sheetRow: string[],
     sheetRowIndex: number,
     columnEntries: ColumnDefinitionEntry[],
@@ -189,7 +191,7 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
     return tableRow;
   }
 
-  private parseAndValidateValue(
+  static parseAndValidateValue(
     value: string,
     valueType: ValueType,
     context: ExecutionContext,
@@ -205,7 +207,7 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
     return parsedValue;
   }
 
-  private deriveColumnDefinitionEntriesWithoutHeader(
+  static deriveColumnDefinitionEntriesWithoutHeader(
     columnDefinitions: ValuetypeAssignment[],
     context: ExecutionContext,
   ): ColumnDefinitionEntry[] {
@@ -225,7 +227,7 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
     );
   }
 
-  private deriveColumnDefinitionEntriesFromHeader(
+  private static deriveColumnDefinitionEntriesFromHeader(
     columnDefinitions: ValuetypeAssignment[],
     headerRow: string[],
     context: ExecutionContext,

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/test-empty.csv.license
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/test-empty.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/test-with-header.csv
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/test-with-header.csv
@@ -1,0 +1,17 @@
+index,name,flag
+0,Test,true
+1,Test,false
+2,Test,false
+3,Test,true
+4,Test,true
+5,Test,false
+6,Test,false
+7,Test,false
+8,Test,false
+9,Test,true
+10,Test,false
+11,Test,false
+12,Test,true
+13,Test,true
+14,Test,true
+15,Test,true

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/test-with-header.csv.license
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/test-with-header.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/test-without-header.csv
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/test-without-header.csv
@@ -1,0 +1,16 @@
+0,Test,true
+1,Test,false
+2,Test,false
+3,Test,true
+4,Test,true
+5,Test,false
+6,Test,false
+7,Test,false
+8,Test,false
+9,Test,true
+10,Test,false
+11,Test,false
+12,Test,true
+13,Test,true
+14,Test,true
+15,Test,true

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/test-without-header.csv.license
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/test-without-header.csv.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-empty-columns-with-header.jv
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-empty-columns-with-header.jv
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestSheetExtractor {
+  }
+
+  block TestBlock oftype CSVToTableInterpreter {
+    header: true;
+    columns: [];
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  TestExtractor -> TestBlock -> TestLoader;
+}

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-empty-columns-without-header.jv
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-empty-columns-without-header.jv
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestSheetExtractor {
+  }
+
+  block TestBlock oftype CSVToTableInterpreter {
+    header: false;
+    columns: [];
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  TestExtractor -> TestBlock -> TestLoader;
+}

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-with-capitalized-header.jv
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-with-capitalized-header.jv
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestSheetExtractor {
+  }
+
+  block TestBlock oftype CSVToTableInterpreter {
+    header: true;
+    columns: [
+      "Index" oftype integer,
+      "Name" oftype text,
+      "Flag" oftype boolean
+    ];
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  TestExtractor -> TestBlock -> TestLoader;
+}

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-with-header.jv
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-with-header.jv
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestFileExtractor {
+  }
+
+  block TestBlock oftype CSVToTableInterpreter {
+    header: true;
+    columns: [
+      "index" oftype integer,
+      "name" oftype text,
+      "flag" oftype boolean
+    ];
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  TestExtractor -> TestBlock -> TestLoader;
+}

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-without-header.jv
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-without-header.jv
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestSheetExtractor {
+  }
+
+  block TestBlock oftype CSVToTableInterpreter {
+    header: false;
+    columns: [
+      "index" oftype integer,
+      "name" oftype text,
+      "flag" oftype boolean
+    ];
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  TestExtractor -> TestBlock -> TestLoader;
+}

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-wrong-value-type-with-header.jv
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-wrong-value-type-with-header.jv
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestSheetExtractor {
+  }
+
+  block TestBlock oftype CSVToTableInterpreter {
+    header: true;
+    columns: [
+      "index" oftype integer,
+      "name" oftype text,
+      "flag" oftype integer
+    ];
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  TestExtractor -> TestBlock -> TestLoader;
+}

--- a/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-wrong-value-type-without-header.jv
+++ b/libs/extensions/tabular/exec/test/assets/csv-to-table-interpreter-executor/valid-wrong-value-type-without-header.jv
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline TestPipeline {
+
+  block TestExtractor oftype TestSheetExtractor {
+  }
+
+  block TestBlock oftype CSVToTableInterpreter {
+    header: false;
+    columns: [
+      "index" oftype integer,
+      "name" oftype text,
+      "flag" oftype integer
+    ];
+  }
+
+  block TestLoader oftype TestTableLoader {
+  }
+
+  TestExtractor -> TestBlock -> TestLoader;
+}

--- a/libs/language-server/src/stdlib/builtin-block-types/CsvToTableInterpreter.jv
+++ b/libs/language-server/src/stdlib/builtin-block-types/CsvToTableInterpreter.jv
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+* Interprets a `File` with CSV contents as a `Table`. This combines the functionality of the Blocks `TextFileInterpreter`, `CSVInterpreter` and `TableInterpreter`, leading to increased performance.
+*
+* @example Properties from all the 'subblocks' can be used.
+* block CarsTableInterpreter oftype TableInterpreter {
+*   encoding: 'utf-8';
+*   delimiter: ',';
+*   header: true;
+*   columns: [
+*     "name" oftype text,
+*     "mpg" oftype decimal,
+*     "cyl" oftype integer,
+*   ];
+* }
+*
+*/
+publish builtin blocktype CSVToTableInterpreter {
+	input default oftype File;
+	output default oftype Table;
+
+	/**
+	* The encoding used for decoding the file contents.
+	*/
+	property encoding oftype text: 'utf-8';
+
+	/**
+	* The regex for identifying line breaks.
+	*/
+	property lineBreak oftype Regex: /\r?\n/;
+
+
+	/**
+	* The delimiter for values in the CSV file.
+	*/
+	property delimiter oftype text: ',';
+
+	/**
+	* The enclosing character that may be used for values in the CSV file.
+	*/
+	property enclosing oftype text: '';
+
+	/**
+	* The character to escape enclosing characters in values.
+	*/
+	property enclosingEscape oftype text: '';
+
+
+	/**
+	* Whether the first row should be interpreted as header row.
+	*/
+	property header oftype boolean: true;
+
+	/**
+	* Collection of value type assignments. Uses column names (potentially matched with the header or by sequence depending on the `header` property) to assign a primitive value type to each column.
+	*/
+	property columns oftype Collection<ValuetypeAssignment>;
+}

--- a/libs/language-server/src/stdlib/builtin-block-types/CsvToTableInterpreter.jv
+++ b/libs/language-server/src/stdlib/builtin-block-types/CsvToTableInterpreter.jv
@@ -5,8 +5,8 @@
 /**
 * Interprets a `File` with CSV contents as a `Table`. This combines the functionality of the Blocks `TextFileInterpreter`, `CSVInterpreter` and `TableInterpreter`, leading to increased performance.
 *
-* @example Properties from all the 'subblocks' can be used.
-* block CarsTableInterpreter oftype TableInterpreter {
+* @example All properties from all the 'subblocks' can be used, except 'lineBreak'.
+* block CarsTableInterpreter oftype CSVToTableInterpreter {
 *   encoding: 'utf-8';
 *   delimiter: ',';
 *   header: true;
@@ -26,12 +26,6 @@ publish builtin blocktype CSVToTableInterpreter {
 	* The encoding used for decoding the file contents.
 	*/
 	property encoding oftype text: 'utf-8';
-
-	/**
-	* The regex for identifying line breaks.
-	*/
-	property lineBreak oftype Regex: /\r?\n/;
-
 
 	/**
 	* The delimiter for values in the CSV file.


### PR DESCRIPTION
This PR adds a new builtin block type `CSVToTableInterpreter`, combining `TextFileInterpreter`, `CSVInterpreter` and `TableInterpreter` for the common use case of parsing csv data into a table without modifying it.

This includes making some methods of `TableInterpreterExecutor` `public` in order to share code with `CSVToTableInterpreterExecutor`.

Pipelines can now look like this:
```
pipeline CarsPipeline {
  CarsExtractor
    -> CarsInterpreter
    // ... TableTransformer blocks
    -> CarsLoader;

  block CarsExtractor oftype HttpExtractor {
    url: "https://gist.githubusercontent.com/noamross/e5d3e859aa0c794be10b/raw/b999fb4425b54c63cab088c0ce2c0d6ce961a563/cars.csv";
  }

  block CarsInterpreter oftype CSVToTableInterpreter {
    enclosing: '"';
    header: true;
    columns: [
      "" oftype text,
      "mpg" oftype decimal,
      "cyl" oftype integer,
      "disp" oftype decimal,
      "hp" oftype integer,
      "drat" oftype decimal,
      "wt" oftype decimal,
      "qsec" oftype decimal,
      "vs" oftype integer,
      "am" oftype integer,
      "gear" oftype integer,
      "carb" oftype integer
    ];
  }

  // ...

  block CarsLoader oftype SQLiteLoader {
    table: "Cars";
    file: "./cars.sqlite";
  }
}
```