### PR TITLE
Autogenerate docs for composite block types

### DIFF
--- a/apps/docs-generator/src/UserDocCategoryBuilder.ts
+++ b/apps/docs-generator/src/UserDocCategoryBuilder.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import * as fs from 'node:fs';
+import path from 'node:path';
+
+export class UserDocCategoryBuilder {
+  generateDocsCategory(
+    rootPath: string,
+    dirName: string,
+    label: string,
+    position: number,
+    description: string,
+  ): string {
+    const categoryPath = path.join(rootPath, dirName);
+
+    fs.mkdirSync(categoryPath);
+
+    fs.writeFileSync(
+      path.join(categoryPath, '_category_.json'),
+      this.getCategoryJSONString(label, position, description),
+    );
+
+    fs.writeFileSync(
+      path.join(categoryPath, '_category_.json.license'),
+      this.getCategoryLicenseString(new Date().getFullYear()),
+    );
+
+    fs.writeFileSync(
+      path.join(categoryPath, '.gitignore'),
+      this.getCategoryGitignoreString(new Date().getFullYear()),
+    );
+
+    return categoryPath;
+  }
+
+  private getCategoryJSONString(
+    label: string,
+    position: number,
+    description: string,
+  ): string {
+    return `{
+  "label": "${label}",
+  "position": ${position},
+  "link": {
+    "type": "generated-index",
+    "description": "${description}"
+  }
+}`;
+  }
+
+  private getCategoryLicenseString(year: number): string {
+    return `SPDX-FileCopyrightText: ${year} Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only`;
+  }
+
+  private getCategoryGitignoreString(year: number): string {
+    return `# SPDX-FileCopyrightText: ${year} Friedrich-Alexander-Universitat Erlangen-Nurnberg
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+*.md`;
+  }
+}

--- a/apps/docs-generator/src/UserDocMarkdownBuilder.ts
+++ b/apps/docs-generator/src/UserDocMarkdownBuilder.ts
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import {
+  type ExampleDoc,
+  type IOType,
+  MarkdownBuilder,
+  type PropertySpecification,
+} from '@jvalue/jayvee-language-server';
+
+export class UserDocMarkdownBuilder {
+  private markdownBuilder = new MarkdownBuilder();
+
+  docTitle(blockType: string): UserDocMarkdownBuilder {
+    this.markdownBuilder
+      .line('---')
+      .line(`title: ${blockType}`)
+      .line('---')
+      .newLine();
+    return this;
+  }
+
+  generationComment(): UserDocMarkdownBuilder {
+    this.markdownBuilder
+      .comment(
+        'Do NOT change this document as it is auto-generated from the language server',
+      )
+      .newLine();
+    return this;
+  }
+
+  heading(heading: string, depth = 1): UserDocMarkdownBuilder {
+    this.markdownBuilder.heading(heading, depth);
+    return this;
+  }
+
+  propertyHeading(propertyName: string, depth = 1): UserDocMarkdownBuilder {
+    this.markdownBuilder.heading(`\`${propertyName}\``, depth);
+    return this;
+  }
+
+  propertySpec(propertySpec: PropertySpecification): UserDocMarkdownBuilder {
+    this.markdownBuilder.line(`Type \`${propertySpec.type.getName()}\``);
+    if (propertySpec.defaultValue !== undefined) {
+      this.markdownBuilder
+        .newLine()
+        .line(`Default: \`${JSON.stringify(propertySpec.defaultValue)}\``);
+    }
+    this.markdownBuilder.newLine();
+    return this;
+  }
+
+  ioTypes(inputType: IOType, outputType: IOType): UserDocMarkdownBuilder {
+    this.markdownBuilder
+      .line(`Input type: \`${inputType}\``)
+      .newLine()
+      .line(`Output type: \`${outputType}\``)
+      .newLine();
+    return this;
+  }
+
+  compatibleValueType(type: string): UserDocMarkdownBuilder {
+    this.markdownBuilder.line(`Compatible value type: ${type}`);
+    this.markdownBuilder.newLine();
+    return this;
+  }
+
+  description(text?: string, depth = 2): UserDocMarkdownBuilder {
+    if (text === undefined) {
+      return this;
+    }
+    this.markdownBuilder.heading('Description', depth).line(text).newLine();
+    return this;
+  }
+
+  propertiesHeading(): UserDocMarkdownBuilder {
+    this.markdownBuilder.heading('Properties', 2);
+    return this;
+  }
+
+  validation(text?: string, depth = 2): UserDocMarkdownBuilder {
+    if (text === undefined) {
+      return this;
+    }
+    this.markdownBuilder.heading('Validation', depth).line(text).newLine();
+    return this;
+  }
+
+  examples(examples?: ExampleDoc[], depth = 2): UserDocMarkdownBuilder {
+    if (examples === undefined) {
+      return this;
+    }
+    for (const [index, example] of examples.entries()) {
+      this.markdownBuilder
+        .heading(`Example ${index + 1}`, depth)
+        .code(example.code, 'jayvee')
+        .line(example.description)
+        .newLine();
+    }
+    return this;
+  }
+
+  build(): string {
+    return this.markdownBuilder.build();
+  }
+}

--- a/apps/docs-generator/src/user-doc-generator.ts
+++ b/apps/docs-generator/src/user-doc-generator.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
@@ -9,15 +9,14 @@ import {
   type BlockTypeWrapper,
   type ConstraintTypeWrapper,
   type ExampleDoc,
-  type IOType,
   type JayveeBlockTypeDocGenerator,
   type JayveeConstraintTypeDocGenerator,
   type JayveeServices,
   type JayveeValueTypesDocGenerator,
-  MarkdownBuilder,
   type PrimitiveValueType,
-  type PropertySpecification,
 } from '@jvalue/jayvee-language-server';
+
+import { UserDocMarkdownBuilder } from './UserDocMarkdownBuilder';
 
 export class UserDocGenerator
   implements
@@ -179,102 +178,5 @@ block ExampleTableInterpreter oftype TableInterpreter {
       description: commentSections[0],
       examples: examples,
     };
-  }
-}
-
-class UserDocMarkdownBuilder {
-  private markdownBuilder = new MarkdownBuilder();
-
-  docTitle(blockType: string): UserDocMarkdownBuilder {
-    this.markdownBuilder
-      .line('---')
-      .line(`title: ${blockType}`)
-      .line('---')
-      .newLine();
-    return this;
-  }
-
-  generationComment(): UserDocMarkdownBuilder {
-    this.markdownBuilder
-      .comment(
-        'Do NOT change this document as it is auto-generated from the language server',
-      )
-      .newLine();
-    return this;
-  }
-
-  heading(heading: string, depth = 1): UserDocMarkdownBuilder {
-    this.markdownBuilder.heading(heading, depth);
-    return this;
-  }
-
-  propertyHeading(propertyName: string, depth = 1): UserDocMarkdownBuilder {
-    this.markdownBuilder.heading(`\`${propertyName}\``, depth);
-    return this;
-  }
-
-  propertySpec(propertySpec: PropertySpecification): UserDocMarkdownBuilder {
-    this.markdownBuilder.line(`Type \`${propertySpec.type.getName()}\``);
-    if (propertySpec.defaultValue !== undefined) {
-      this.markdownBuilder
-        .newLine()
-        .line(`Default: \`${JSON.stringify(propertySpec.defaultValue)}\``);
-    }
-    this.markdownBuilder.newLine();
-    return this;
-  }
-
-  ioTypes(inputType: IOType, outputType: IOType): UserDocMarkdownBuilder {
-    this.markdownBuilder
-      .line(`Input type: \`${inputType}\``)
-      .newLine()
-      .line(`Output type: \`${outputType}\``)
-      .newLine();
-    return this;
-  }
-
-  compatibleValueType(type: string): UserDocMarkdownBuilder {
-    this.markdownBuilder.line(`Compatible value type: ${type}`);
-    this.markdownBuilder.newLine();
-    return this;
-  }
-
-  description(text?: string, depth = 2): UserDocMarkdownBuilder {
-    if (text === undefined) {
-      return this;
-    }
-    this.markdownBuilder.heading('Description', depth).line(text).newLine();
-    return this;
-  }
-
-  propertiesHeading(): UserDocMarkdownBuilder {
-    this.markdownBuilder.heading('Properties', 2);
-    return this;
-  }
-
-  validation(text?: string, depth = 2): UserDocMarkdownBuilder {
-    if (text === undefined) {
-      return this;
-    }
-    this.markdownBuilder.heading('Validation', depth).line(text).newLine();
-    return this;
-  }
-
-  examples(examples?: ExampleDoc[], depth = 2): UserDocMarkdownBuilder {
-    if (examples === undefined) {
-      return this;
-    }
-    for (const [index, example] of examples.entries()) {
-      this.markdownBuilder
-        .heading(`Example ${index + 1}`, depth)
-        .code(example.code, 'jayvee')
-        .line(example.description)
-        .newLine();
-    }
-    return this;
-  }
-
-  build(): string {
-    return this.markdownBuilder.build();
   }
 }

--- a/apps/docs-generator/src/user-doc-generator.ts
+++ b/apps/docs-generator/src/user-doc-generator.ts
@@ -45,7 +45,7 @@ that fullfil [_constraints_](./primitive-value-types#constraints).`.trim(),
       .filter((valueType) => valueType.isReferenceableByUser())
       .forEach((valueType) => {
         assert(
-          valueType.getUserDoc(),
+          valueType.getUserDoc() !== undefined,
           `Documentation is missing for user extendable value type: ${valueType.getName()}`,
         );
         builder

--- a/apps/docs-generator/src/util.ts
+++ b/apps/docs-generator/src/util.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import path from 'node:path';
+
+import { type BlockTypeWrapper } from '@jvalue/jayvee-language-server';
+
+/**
+ * Returns the domain of a block type or undefined if it does not come from a domain extension in the stdlib.
+ */
+export function getBlockTypeDomain(
+  blockType: BlockTypeWrapper,
+): string | undefined {
+  const filePath = blockType.astNode.$container?.$document?.uri.path;
+
+  if (filePath === undefined) {
+    return undefined;
+  }
+
+  const pathElements = filePath.split(path.sep);
+
+  // pathElements[0] is an empty string since the path starts with /
+  // pathElements[1] is the stdlib directory
+  if (pathElements[2] === 'domain') {
+    return pathElements[3] ?? undefined;
+  }
+}

--- a/apps/docs/docs/user/block-types/.gitignore
+++ b/apps/docs/docs/user/block-types/.gitignore
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 *.md
+*/*

--- a/apps/docs/docs/user/composite-block-types.md
+++ b/apps/docs/docs/user/composite-block-types.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 7
 ---
 
 # Composite Block Types

--- a/apps/docs/docs/user/expressions.md
+++ b/apps/docs/docs/user/expressions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Expressions

--- a/libs/interpreter-lib/src/std-extension.spec.ts
+++ b/libs/interpreter-lib/src/std-extension.spec.ts
@@ -9,17 +9,19 @@ import { StdExecExtension } from '@jvalue/jayvee-extensions/std/exec';
 import {
   type BlockTypeWrapper,
   createJayveeServices,
-  getAllBuiltinBlockTypes,
+  getAllReferenceableBlockTypes,
   initializeWorkspace,
+  isBuiltinBlockTypeDefinition,
 } from '@jvalue/jayvee-language-server';
 import { NodeFileSystem } from 'langium/node';
 
 async function loadAllBuiltinBlockTypes(): Promise<BlockTypeWrapper[]> {
   const services = createJayveeServices(NodeFileSystem).Jayvee;
   await initializeWorkspace(services);
-  return getAllBuiltinBlockTypes(
+  return getAllReferenceableBlockTypes(
     services.shared.workspace.LangiumDocuments,
     services.WrapperFactories,
+    (blockType) => isBuiltinBlockTypeDefinition(blockType),
   );
 }
 

--- a/libs/language-server/src/lib/lsp/jayvee-completion-provider.ts
+++ b/libs/language-server/src/lib/lsp/jayvee-completion-provider.ts
@@ -39,8 +39,8 @@ import {
   isValuetypeDefinition,
 } from '../ast/generated/ast';
 import {
-  getAllBuiltinBlockTypes,
   getAllBuiltinConstraintTypes,
+  getAllReferenceableBlockTypes,
   getExportedElements,
 } from '../ast/model-util';
 import { LspDocGenerator } from '../docs/lsp-doc-generator';
@@ -112,7 +112,7 @@ export class JayveeCompletionProvider extends DefaultCompletionProvider {
     context: CompletionContext,
     acceptor: CompletionAcceptor,
   ): MaybePromise<void> {
-    const blockTypes = getAllBuiltinBlockTypes(
+    const blockTypes = getAllReferenceableBlockTypes(
       this.langiumDocuments,
       this.wrapperFactories,
     );


### PR DESCRIPTION
This PR adds autogenerated documentation for composite block types.

Because we have a lot of composite block types in domain extensions in the stdlib this PR also introduces an additional level in the documentation, blocks are now categorized as either "builtin" or by domain:
![Screenshot 2024-12-20 at 3 23 34 PM](https://github.com/user-attachments/assets/3f45b874-24f6-4f6d-b6b3-35650e9b86a0)

Inside each domain, the expected block definitions can be found:
![Screenshot 2024-12-20 at 3 24 31 PM](https://github.com/user-attachments/assets/ae9bb76c-215b-4195-9863-5ca6d2ca8576)

