### PR TITLE
[FEATURE] Add custom hook support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ node_modules
 *.launch
 .settings/
 *.sublime-workspace
+.nvim.lua
+.nvimrc
+.exrc
 
 # IDE - VSCode
 .vscode/*

--- a/libs/execution/src/lib/blocks/block-execution-util.ts
+++ b/libs/execution/src/lib/blocks/block-execution-util.ts
@@ -62,13 +62,15 @@ export async function executeBlocks(
 
     executionContext.enterNode(block);
 
-    await executionContext.executeHooks(inputValue); // FIXME #634: Pass the blocktype to also execute block specific hooks
+    await executionContext.executeHooks(inputValue);
+
     const executionResult = await executeBlock(
       inputValue,
       block,
       executionContext,
     );
-    await executionContext.executeHooks(inputValue, executionResult); // FIXME #634: Pass the blocktype to also execute block specific hooks
+    await executionContext.executeHooks(inputValue, executionResult);
+
     if (R.isErr(executionResult)) {
       return executionResult;
     }

--- a/libs/execution/src/lib/blocks/block-execution-util.ts
+++ b/libs/execution/src/lib/blocks/block-execution-util.ts
@@ -62,11 +62,13 @@ export async function executeBlocks(
 
     executionContext.enterNode(block);
 
+    await executionContext.executeHooks(inputValue); // FIXME #634: Pass the blocktype to also execute block specific hooks
     const executionResult = await executeBlock(
       inputValue,
       block,
       executionContext,
     );
+    await executionContext.executeHooks(inputValue, executionResult); // FIXME #634: Pass the blocktype to also execute block specific hooks
     if (R.isErr(executionResult)) {
       return executionResult;
     }

--- a/libs/execution/src/lib/blocks/block-executor.ts
+++ b/libs/execution/src/lib/blocks/block-executor.ts
@@ -36,11 +36,15 @@ export abstract class AbstractBlockExecutor<I extends IOType, O extends IOType>
     input: IOTypeImplementation<I>,
     context: ExecutionContext,
   ): Promise<R.Result<IOTypeImplementation<O> | null>> {
+    await context.executeHooks('before', input, context); // FIXME #634: Pass the blocktype to also execute block specific hooks
+
     const executionResult = await this.doExecute(input, context);
 
     if (R.isOk(executionResult)) {
       this.logBlockResult(executionResult.right, context);
     }
+
+    await context.executeHooks('after', input, context); // FIXME #634: Pass the blocktype to also execute block specific hooks
     return executionResult;
   }
 

--- a/libs/execution/src/lib/blocks/block-executor.ts
+++ b/libs/execution/src/lib/blocks/block-executor.ts
@@ -36,15 +36,11 @@ export abstract class AbstractBlockExecutor<I extends IOType, O extends IOType>
     input: IOTypeImplementation<I>,
     context: ExecutionContext,
   ): Promise<R.Result<IOTypeImplementation<O> | null>> {
-    await context.executeHooks('before', input, context); // FIXME #634: Pass the blocktype to also execute block specific hooks
-
     const executionResult = await this.doExecute(input, context);
 
     if (R.isOk(executionResult)) {
       this.logBlockResult(executionResult.right, context);
     }
-
-    await context.executeHooks('after', input, context); // FIXME #634: Pass the blocktype to also execute block specific hooks
     return executionResult;
   }
 

--- a/libs/execution/src/lib/execution-context.ts
+++ b/libs/execution/src/lib/execution-context.ts
@@ -27,14 +27,14 @@ import {
 } from '@jvalue/jayvee-language-server';
 import { assertUnreachable, isReference } from 'langium';
 
-import { type BlockExecutor } from './blocks';
+import { type Result } from './blocks';
 import { type JayveeConstraintExtension } from './constraints';
 import {
   type DebugGranularity,
   type DebugTargets,
 } from './debugging/debug-configuration';
 import { type JayveeExecExtension } from './extension';
-import { type Hook, type HookContext } from './hooks';
+import { type HookContext, type HookPosition } from './hooks';
 import { type Logger } from './logging/logger';
 import { type IOTypeImplementation } from './types';
 
@@ -138,10 +138,9 @@ export class ExecutionContext {
     return property;
   }
 
-  public async executeHooks(
-    position: 'before' | 'after',
-    input: IOTypeImplementation,
-    context: ExecutionContext,
+  public executeHooks(
+    input: IOTypeImplementation | null,
+    output?: Result<IOTypeImplementation | null>,
   ) {
     const node = this.getCurrentNode();
     assert(
@@ -155,7 +154,7 @@ export class ExecutionContext {
       `Expected block definition to have a blocktype: ${inspect(node)}`,
     );
 
-    return this.hookContext.executeHooks(position, blocktype, input, context);
+    return this.hookContext.executeHooks(blocktype, input, this, output);
   }
 
   private getDefaultPropertyValue<I extends InternalValueRepresentation>(

--- a/libs/execution/src/lib/execution-context.ts
+++ b/libs/execution/src/lib/execution-context.ts
@@ -154,7 +154,16 @@ export class ExecutionContext {
       `Expected block definition to have a blocktype: ${inspect(node)}`,
     );
 
-    return this.hookContext.executeHooks(blocktype, input, this, output);
+    if (output === undefined) {
+      return this.hookContext.executePreBlockHooks(blocktype, input, this);
+    }
+
+    return this.hookContext.executePostBlockHooks(
+      blocktype,
+      input,
+      this,
+      output,
+    );
   }
 
   private getDefaultPropertyValue<I extends InternalValueRepresentation>(

--- a/libs/execution/src/lib/execution-context.ts
+++ b/libs/execution/src/lib/execution-context.ts
@@ -4,6 +4,7 @@
 
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import { strict as assert } from 'assert';
+import { inspect } from 'node:util';
 
 import {
   type BlockDefinition,
@@ -26,13 +27,16 @@ import {
 } from '@jvalue/jayvee-language-server';
 import { assertUnreachable, isReference } from 'langium';
 
+import { type BlockExecutor } from './blocks';
 import { type JayveeConstraintExtension } from './constraints';
 import {
   type DebugGranularity,
   type DebugTargets,
 } from './debugging/debug-configuration';
 import { type JayveeExecExtension } from './extension';
+import { type Hook, type HookContext } from './hooks';
 import { type Logger } from './logging/logger';
+import { type IOTypeImplementation } from './types';
 
 export type StackNode =
   | BlockDefinition
@@ -55,6 +59,7 @@ export class ExecutionContext {
       debugTargets: DebugTargets;
     },
     public readonly evaluationContext: EvaluationContext,
+    public readonly hookContext: HookContext,
   ) {
     logger.setLoggingContext(pipeline.name);
   }
@@ -131,6 +136,26 @@ export class ExecutionContext {
     assert(property !== undefined);
 
     return property;
+  }
+
+  public async executeHooks(
+    position: 'before' | 'after',
+    input: IOTypeImplementation,
+    context: ExecutionContext,
+  ) {
+    const node = this.getCurrentNode();
+    assert(
+      isBlockDefinition(node),
+      `Expected node to be \`BlockDefinition\`: ${inspect(node)}`,
+    );
+
+    const blocktype = node.type.ref?.name;
+    assert(
+      blocktype !== undefined,
+      `Expected block definition to have a blocktype: ${inspect(node)}`,
+    );
+
+    return this.hookContext.executeHooks(position, blocktype, input, context);
   }
 
   private getDefaultPropertyValue<I extends InternalValueRepresentation>(

--- a/libs/execution/src/lib/execution-context.ts
+++ b/libs/execution/src/lib/execution-context.ts
@@ -34,7 +34,7 @@ import {
   type DebugTargets,
 } from './debugging/debug-configuration';
 import { type JayveeExecExtension } from './extension';
-import { type HookContext, type HookPosition } from './hooks';
+import { type HookContext } from './hooks';
 import { type Logger } from './logging/logger';
 import { type IOTypeImplementation } from './types';
 

--- a/libs/execution/src/lib/hooks/hook-context.ts
+++ b/libs/execution/src/lib/hooks/hook-context.ts
@@ -150,11 +150,15 @@ export class HookContext {
     output?: Result<IOTypeImplementation | null>,
   ) {
     if (output === undefined) {
+      context.logger.logInfo(`Executing general pre-block-hooks`);
       const general = executeTheseHooks(
         this.hooks.pre[AllBlocks] ?? [],
         blocktype,
         input,
         context,
+      );
+      context.logger.logInfo(
+        `Executing pre-block-hooks for blocktype ${blocktype}`,
       );
       const blockSpecific = executeTheseHooks(
         this.hooks.pre[blocktype] ?? [],
@@ -166,12 +170,16 @@ export class HookContext {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       return Promise.all([general, blockSpecific]).then(() => {});
     }
+    context.logger.logInfo(`Executing general post-block-hooks`);
     const general = executeTheseHooks(
       this.hooks.post[AllBlocks] ?? [],
       blocktype,
       input,
       context,
       output,
+    );
+    context.logger.logInfo(
+      `Executing post-block-hooks for blocktype ${blocktype}`,
     );
     const blockSpecific = executeTheseHooks(
       this.hooks.post[blocktype] ?? [],

--- a/libs/execution/src/lib/hooks/hook-context.ts
+++ b/libs/execution/src/lib/hooks/hook-context.ts
@@ -85,12 +85,7 @@ export class HookContext {
     hook: PreBlockHook | PostBlockHook,
     opts: HookOptions,
   ) {
-    const blocktypes: string[] =
-      typeof opts.blocktypes === 'string'
-        ? [opts.blocktypes]
-        : opts.blocktypes ?? [AllBlocks];
-
-    blocktypes.forEach((blocktype) => {
+    for (const blocktype of opts.blocktypes ?? [AllBlocks]) {
       if (isPreBlockHook(hook, position)) {
         if (this.hooks.pre[blocktype] === undefined) {
           this.hooks.pre[blocktype] = [];
@@ -108,7 +103,7 @@ export class HookContext {
           hook,
         });
       }
-    });
+    }
   }
 
   public async executePreBlockHooks(

--- a/libs/execution/src/lib/hooks/hook-context.ts
+++ b/libs/execution/src/lib/hooks/hook-context.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import assert from 'assert';
 

--- a/libs/execution/src/lib/hooks/hook-context.ts
+++ b/libs/execution/src/lib/hooks/hook-context.ts
@@ -1,0 +1,183 @@
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
+
+import { type Result } from '../blocks';
+import { type ExecutionContext } from '../execution-context';
+import { type IOTypeImplementation } from '../types';
+
+import {
+  type HookOptions,
+  type HookPosition,
+  type PostBlockHook,
+  type PreBlockHook,
+  isPreBlockHook,
+} from './hook';
+
+const AllBlocks = '*';
+
+interface HookSpec<H extends PreBlockHook | PostBlockHook> {
+  blocking: boolean;
+  hook: H;
+}
+
+async function executeTheseHooks(
+  hooks: HookSpec<PreBlockHook>[],
+  blocktype: string,
+  input: IOTypeImplementation | null,
+  context: ExecutionContext,
+): Promise<void>;
+async function executeTheseHooks(
+  hooks: HookSpec<PostBlockHook>[],
+  blocktype: string,
+  input: IOTypeImplementation | null,
+  context: ExecutionContext,
+  output: Result<IOTypeImplementation | null>,
+): Promise<void>;
+async function executeTheseHooks(
+  hooks: HookSpec<PreBlockHook>[] | HookSpec<PostBlockHook>[],
+  blocktype: string,
+  input: IOTypeImplementation | null,
+  context: ExecutionContext,
+  output?: Result<IOTypeImplementation | null>,
+) {
+  const position = output === undefined ? 'preBlock' : 'postBlock';
+  return (
+    Promise.all(
+      hooks.map(async ({ blocking, hook }) => {
+        if (blocking) {
+          if (isPreBlockHook(hook, position)) {
+            await hook(blocktype, input, context);
+          } else {
+            assert(output !== undefined, 'Guaranteed to be a postBlock hook');
+            await hook(blocktype, input, output, context);
+          }
+        } else {
+          if (isPreBlockHook(hook, position)) {
+            hook(blocktype, input, context)
+              // eslint-disable-next-line @typescript-eslint/no-empty-function
+              .catch(() => {});
+          } else {
+            assert(output !== undefined, 'Guaranteed to be a postBlock hook');
+            hook(blocktype, input, output, context)
+              // eslint-disable-next-line @typescript-eslint/no-empty-function
+              .catch(() => {});
+          }
+        }
+      }),
+    )
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .then(() => {})
+  );
+}
+
+export class HookContext {
+  private hooks: {
+    pre: Record<string, HookSpec<PreBlockHook>[]>;
+    post: Record<string, HookSpec<PostBlockHook>[]>;
+  } = { pre: {}, post: {} };
+
+  public addHook(
+    position: 'preBlock',
+    hook: PreBlockHook,
+    opts: HookOptions,
+  ): void;
+  public addHook(
+    position: 'postBlock',
+    hook: PostBlockHook,
+    opts: HookOptions,
+  ): void;
+  public addHook(
+    position: HookPosition,
+    hook: PreBlockHook | PostBlockHook,
+    opts: HookOptions,
+  ): void;
+  public addHook(
+    position: HookPosition,
+    hook: PreBlockHook | PostBlockHook,
+    opts: HookOptions,
+  ) {
+    const blocktypes: string[] =
+      typeof opts.blocktypes === 'string'
+        ? [opts.blocktypes]
+        : opts.blocktypes ?? [AllBlocks];
+
+    blocktypes.forEach((blocktype) => {
+      if (isPreBlockHook(hook, position)) {
+        if (this.hooks.pre[blocktype] === undefined) {
+          this.hooks.pre[blocktype] = [];
+        }
+        this.hooks.pre[blocktype].push({
+          blocking: opts.blocking ?? false,
+          hook,
+        });
+      } else {
+        if (this.hooks.post[blocktype] === undefined) {
+          this.hooks.post[blocktype] = [];
+        }
+        this.hooks.post[blocktype].push({
+          blocking: opts.blocking ?? false,
+          hook,
+        });
+      }
+    });
+  }
+
+  public async executeHooks(
+    blocktype: string,
+    input: IOTypeImplementation | null,
+    context: ExecutionContext,
+  ): Promise<void>;
+  public async executeHooks(
+    blocktype: string,
+    input: IOTypeImplementation | null,
+    context: ExecutionContext,
+    output: Result<IOTypeImplementation | null>,
+  ): Promise<void>;
+  public async executeHooks(
+    blocktype: string,
+    input: IOTypeImplementation | null,
+    context: ExecutionContext,
+    output?: Result<IOTypeImplementation | null>,
+  ): Promise<void>;
+  public async executeHooks(
+    blocktype: string,
+    input: IOTypeImplementation | null,
+    context: ExecutionContext,
+    output?: Result<IOTypeImplementation | null>,
+  ) {
+    if (output === undefined) {
+      const general = executeTheseHooks(
+        this.hooks.pre[AllBlocks] ?? [],
+        blocktype,
+        input,
+        context,
+      );
+      const blockSpecific = executeTheseHooks(
+        this.hooks.pre[blocktype] ?? [],
+        blocktype,
+        input,
+        context,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return Promise.all([general, blockSpecific]).then(() => {});
+    }
+    const general = executeTheseHooks(
+      this.hooks.post[AllBlocks] ?? [],
+      blocktype,
+      input,
+      context,
+      output,
+    );
+    const blockSpecific = executeTheseHooks(
+      this.hooks.post[blocktype] ?? [],
+      blocktype,
+      input,
+      context,
+      output,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return Promise.all([general, blockSpecific]).then(() => {});
+  }
+}

--- a/libs/execution/src/lib/hooks/hook.ts
+++ b/libs/execution/src/lib/hooks/hook.ts
@@ -13,7 +13,7 @@ export interface HookOptions {
   /** Whether the pipeline should await the hooks completion. `false` if omitted.*/
   blocking?: boolean;
   /** Optionally specify one or more blocks to limit this hook to. If omitted, the hook will be executed on all blocks*/
-  blocktypes?: string | string[];
+  blocktypes?: string[];
 }
 
 /** This function will be executed before a block.*/

--- a/libs/execution/src/lib/hooks/hook.ts
+++ b/libs/execution/src/lib/hooks/hook.ts
@@ -13,7 +13,6 @@ export interface HookOptions {
   /** Whether the pipeline should await the hooks completion. `false` if omitted.*/
   blocking?: boolean;
   /** Optionally specify one or more blocks to limit this hook to. If omitted, the hook will be executed on all blocks*/
-  // FIXME #634: Add `BlockExecutor[]` variant
   blocktypes?: string | string[];
 }
 

--- a/libs/execution/src/lib/hooks/hook.ts
+++ b/libs/execution/src/lib/hooks/hook.ts
@@ -45,7 +45,7 @@ export class HookContext {
         this.hooks[opts.position][blocktype] = [];
       }
       this.hooks[opts.position][blocktype]?.push({
-        blocking: opts.blocking ?? false,
+        blocking: opts.blocking ?? true,
         hook,
       });
     });
@@ -79,7 +79,7 @@ export interface HookOptions {
   /** Whether the hook is executed `before` or `after` a block.*/
   // FIXME: find a better name than `position`
   position: HookPosition;
-  /** Whether the pipeline should await the hooks completion. `false` if omitted.*/
+  /** Whether the pipeline should await the hooks completion. `true` if omitted.*/
   blocking?: boolean;
   /** Optionally specify one or more blocks to limit this hook to. If omitted, the hook will be executed on all blocks*/
   // FIXME #634: Add `BlockExecutor` type

--- a/libs/execution/src/lib/hooks/hook.ts
+++ b/libs/execution/src/lib/hooks/hook.ts
@@ -2,97 +2,46 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { type Result } from '../blocks';
 import { type ExecutionContext } from '../execution-context';
 import { type IOTypeImplementation } from '../types';
 
-/** A hook can be executed `before` or `after` a block*/
-export type HookPosition = 'before' | 'after';
-
-const AllBlocks = '*';
-
-async function executeTheseHooks(
-  hooks: HookSpec[],
-  blocktype: string,
-  input: IOTypeImplementation,
-  context: ExecutionContext,
-) {
-  await Promise.all(
-    hooks.map(async ({ blocking, hook }) => {
-      if (blocking) {
-        await hook(blocktype, input, context);
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        hook(blocktype, input, context).catch(() => {});
-      }
-    }),
-  );
-}
-
-export class HookContext {
-  private hooks: {
-    before: Record<string, HookSpec[]>;
-    after: Record<string, HookSpec[]>;
-  } = { before: {}, after: {} };
-
-  public addHook(hook: Hook, opts: HookOptions) {
-    const blocktypes: string[] =
-      typeof opts.blocktypes === 'string'
-        ? [opts.blocktypes]
-        : opts.blocktypes ?? [AllBlocks];
-
-    blocktypes.forEach((blocktype) => {
-      if (this.hooks[opts.position][blocktype] === undefined) {
-        this.hooks[opts.position][blocktype] = [];
-      }
-      this.hooks[opts.position][blocktype]?.push({
-        blocking: opts.blocking ?? false,
-        hook,
-      });
-    });
-  }
-
-  public async executeHooks(
-    position: HookPosition,
-    blocktype: string,
-    input: IOTypeImplementation,
-    context: ExecutionContext,
-  ) {
-    const general = executeTheseHooks(
-      this.hooks[position][AllBlocks] ?? [],
-      blocktype,
-      input,
-      context,
-    );
-    const blockSpecific = executeTheseHooks(
-      this.hooks[position][blocktype] ?? [],
-      blocktype,
-      input,
-      context,
-    );
-
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    return Promise.all([general, blockSpecific]).then(() => {});
-  }
-}
+/** When to execute the hook.*/
+export type HookPosition = 'preBlock' | 'postBlock';
 
 export interface HookOptions {
-  /** Whether the hook is executed `before` or `after` a block.*/
-  // FIXME: find a better name than `position`
-  position: HookPosition;
   /** Whether the pipeline should await the hooks completion. `false` if omitted.*/
   blocking?: boolean;
   /** Optionally specify one or more blocks to limit this hook to. If omitted, the hook will be executed on all blocks*/
-  // FIXME #634: Add `BlockExecutor` type
+  // FIXME #634: Add `BlockExecutor[]` variant
   blocktypes?: string | string[];
 }
 
-export type Hook = (
+/** This function will be executed before a block.*/
+export type PreBlockHook = (
   blocktype: string,
-  input: IOTypeImplementation,
+  input: IOTypeImplementation | null,
   context: ExecutionContext,
 ) => Promise<void>;
 
-interface HookSpec {
-  blocking: boolean;
-  hook: Hook;
+export function isPreBlockHook(
+  hook: PreBlockHook | PostBlockHook,
+  position: HookPosition,
+): hook is PreBlockHook {
+  return position === 'preBlock';
+}
+
+/** This function will be executed before a block.*/
+export type PostBlockHook = (
+  blocktype: string,
+  input: IOTypeImplementation | null,
+  output: Result<IOTypeImplementation | null>,
+  context: ExecutionContext,
+) => Promise<void>;
+
+export function isPostBlockHook(
+  hook: PreBlockHook | PostBlockHook,
+  position: HookPosition,
+): hook is PreBlockHook {
+  return position === 'postBlock';
 }

--- a/libs/execution/src/lib/hooks/hook.ts
+++ b/libs/execution/src/lib/hooks/hook.ts
@@ -42,6 +42,6 @@ export type PostBlockHook = (
 export function isPostBlockHook(
   hook: PreBlockHook | PostBlockHook,
   position: HookPosition,
-): hook is PreBlockHook {
+): hook is PostBlockHook {
   return position === 'postBlock';
 }

--- a/libs/execution/src/lib/hooks/hook.ts
+++ b/libs/execution/src/lib/hooks/hook.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { type ExecutionContext } from '../execution-context';
+import { type IOTypeImplementation } from '../types';
+
+/** A hook can be executed `before` or `after` a block*/
+export type HookPosition = 'before' | 'after';
+
+const AllBlocks = '*';
+
+async function executeTheseHooks(
+  hooks: HookSpec[],
+  blocktype: string,
+  input: IOTypeImplementation,
+  context: ExecutionContext,
+) {
+  await Promise.all(
+    hooks.map(async ({ blocking, hook }) => {
+      if (blocking) {
+        await hook(blocktype, input, context);
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        hook(blocktype, input, context).catch(() => {});
+      }
+    }),
+  );
+}
+
+export class HookContext {
+  private hooks: {
+    before: Record<string, HookSpec[]>;
+    after: Record<string, HookSpec[]>;
+  } = { before: {}, after: {} };
+
+  public addHook(hook: Hook, opts: HookOptions) {
+    const blocktypes: string[] =
+      typeof opts.blocktypes === 'string'
+        ? [opts.blocktypes]
+        : opts.blocktypes ?? [AllBlocks];
+
+    blocktypes.forEach((blocktype) => {
+      if (this.hooks[opts.position][blocktype] === undefined) {
+        this.hooks[opts.position][blocktype] = [];
+      }
+      this.hooks[opts.position][blocktype]?.push({
+        blocking: opts.blocking ?? false,
+        hook,
+      });
+    });
+  }
+
+  public async executeHooks(
+    position: HookPosition,
+    blocktype: string,
+    input: IOTypeImplementation,
+    context: ExecutionContext,
+  ) {
+    const general = executeTheseHooks(
+      this.hooks[position][AllBlocks] ?? [],
+      blocktype,
+      input,
+      context,
+    );
+    const blockSpecific = executeTheseHooks(
+      this.hooks[position][blocktype] ?? [],
+      blocktype,
+      input,
+      context,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return Promise.all([general, blockSpecific]).then(() => {});
+  }
+}
+
+export interface HookOptions {
+  /** Whether the hook is executed `before` or `after` a block.*/
+  // FIXME: find a better name than `position`
+  position: HookPosition;
+  /** Whether the pipeline should await the hooks completion. `false` if omitted.*/
+  blocking?: boolean;
+  /** Optionally specify one or more blocks to limit this hook to. If omitted, the hook will be executed on all blocks*/
+  // FIXME #634: Add `BlockExecutor` type
+  blocktypes?: string | string[];
+}
+
+export type Hook = (
+  blocktype: string,
+  input: IOTypeImplementation,
+  context: ExecutionContext,
+) => Promise<void>;
+
+interface HookSpec {
+  blocking: boolean;
+  hook: Hook;
+}

--- a/libs/execution/src/lib/hooks/hook.ts
+++ b/libs/execution/src/lib/hooks/hook.ts
@@ -45,7 +45,7 @@ export class HookContext {
         this.hooks[opts.position][blocktype] = [];
       }
       this.hooks[opts.position][blocktype]?.push({
-        blocking: opts.blocking ?? true,
+        blocking: opts.blocking ?? false,
         hook,
       });
     });
@@ -79,7 +79,7 @@ export interface HookOptions {
   /** Whether the hook is executed `before` or `after` a block.*/
   // FIXME: find a better name than `position`
   position: HookPosition;
-  /** Whether the pipeline should await the hooks completion. `true` if omitted.*/
+  /** Whether the pipeline should await the hooks completion. `false` if omitted.*/
   blocking?: boolean;
   /** Optionally specify one or more blocks to limit this hook to. If omitted, the hook will be executed on all blocks*/
   // FIXME #634: Add `BlockExecutor` type

--- a/libs/execution/src/lib/hooks/index.ts
+++ b/libs/execution/src/lib/hooks/index.ts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+export * from './hook';

--- a/libs/execution/src/lib/hooks/index.ts
+++ b/libs/execution/src/lib/hooks/index.ts
@@ -3,3 +3,4 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 export * from './hook';
+export * from './hook-context';

--- a/libs/execution/src/lib/index.ts
+++ b/libs/execution/src/lib/index.ts
@@ -13,3 +13,4 @@ export * from './types/value-types/visitors';
 export * from './execution-context';
 export * from './extension';
 export * from './logging';
+export * from './hooks';

--- a/libs/interpreter-lib/src/interpreter.spec.ts
+++ b/libs/interpreter-lib/src/interpreter.spec.ts
@@ -104,7 +104,7 @@ describe('Interpreter', () => {
         async (blocktype) => {
           return sqlite_spy(blocktype);
         },
-        { blocking: true, blocktypes: 'SQLiteLoader' },
+        { blocking: true, blocktypes: ['SQLiteLoader'] },
       );
 
       const interpreter_spy = vi
@@ -116,7 +116,7 @@ describe('Interpreter', () => {
         async (blocktype) => {
           return interpreter_spy(blocktype);
         },
-        { blocking: true, blocktypes: 'CSVFileInterpreter' },
+        { blocking: true, blocktypes: ['CSVFileInterpreter'] },
       );
 
       const exitCode = await interpreter.interpretProgram(program);
@@ -218,7 +218,7 @@ describe('Interpreter', () => {
 
           return parameter_spy();
         },
-        { blocking: true, blocktypes: 'TableTransformer' },
+        { blocking: true, blocktypes: ['TableTransformer'] },
       );
 
       const exitCode = await interpreter.interpretProgram(program);

--- a/libs/interpreter-lib/src/interpreter.spec.ts
+++ b/libs/interpreter-lib/src/interpreter.spec.ts
@@ -8,12 +8,6 @@ import { readJvTestAssetHelper } from '@jvalue/jayvee-language-server/test';
 import { DefaultJayveeInterpreter } from './interpreter';
 import { ExitCode, extractAstNodeFromString } from './parsing-util';
 
-function infiniteLoop() {
-  setTimeout(function () {
-    infiniteLoop();
-  }, 3000);
-}
-
 describe('Interpreter', () => {
   const readJvTestAsset = readJvTestAssetHelper(__dirname, '../../../');
 
@@ -58,7 +52,9 @@ describe('Interpreter', () => {
       expect(program).toBeDefined();
       assert(program !== undefined);
 
-      const spy = vi.fn<any, Promise<undefined>>().mockResolvedValue(undefined);
+      const spy = vi
+        .fn<unknown[], Promise<undefined>>()
+        .mockResolvedValue(undefined);
 
       program.addHook(
         async () => {
@@ -98,16 +94,15 @@ describe('Interpreter', () => {
 
       program.addHook(
         () => {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, no-constant-condition
-          while (true) {
-            infiniteLoop();
-          }
+          return new Promise((resolve) => {
+            setTimeout(resolve, 30000);
+          });
         },
         { position: 'before', blocking: false },
       );
 
       const exitCode = await interpreter.interpretProgram(program);
       expect(exitCode).toEqual(ExitCode.SUCCESS);
-    });
+    }, 10000);
   });
 });

--- a/libs/interpreter-lib/src/interpreter.spec.ts
+++ b/libs/interpreter-lib/src/interpreter.spec.ts
@@ -57,10 +57,11 @@ describe('Interpreter', () => {
         .mockResolvedValue(undefined);
 
       program.addHook(
+        'preBlock',
         async () => {
           return spy();
         },
-        { position: 'before', blocking: true },
+        { blocking: true },
       );
 
       const exitCode = await interpreter.interpretProgram(program);
@@ -93,12 +94,13 @@ describe('Interpreter', () => {
       assert(program !== undefined);
 
       program.addHook(
-        () => {
+        'postBlock',
+        (): Promise<void> => {
           return new Promise((resolve) => {
             setTimeout(resolve, 30000);
           });
         },
-        { position: 'before', blocking: false },
+        { blocking: false },
       );
 
       const exitCode = await interpreter.interpretProgram(program);

--- a/libs/interpreter-lib/src/interpreter.spec.ts
+++ b/libs/interpreter-lib/src/interpreter.spec.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { Table, isOk } from '@jvalue/jayvee-execution';
 import { type JayveeModel } from '@jvalue/jayvee-language-server';
 import { readJvTestAssetHelper } from '@jvalue/jayvee-language-server/test';
 
@@ -125,6 +126,105 @@ describe('Interpreter', () => {
       expect(sqlite_spy).toHaveBeenCalledWith('SQLiteLoader');
       expect(interpreter_spy).toHaveBeenCalledTimes(1);
       expect(interpreter_spy).toHaveBeenCalledWith('CSVFileInterpreter');
+    });
+
+    it('should be called with the correct parameters', async () => {
+      const exampleFilePath =
+        'libs/interpreter-lib/test/assets/hooks/valid-builtin-and-composite-blocks.jv';
+      const model = readJvTestAsset(exampleFilePath);
+
+      const interpreter = new DefaultJayveeInterpreter({
+        pipelineMatcher: () => true,
+        debug: true,
+        debugGranularity: 'peek',
+        debugTarget: 'all',
+        env: new Map(),
+      });
+
+      const program = await interpreter.parseModel(
+        async (services, loggerFactory) =>
+          await extractAstNodeFromString<JayveeModel>(
+            model,
+            services,
+            loggerFactory.createLogger(),
+          ),
+      );
+      expect(program).toBeDefined();
+      assert(program !== undefined);
+
+      const parameter_spy = vi
+        .fn<unknown[], Promise<undefined>>()
+        .mockResolvedValue(undefined);
+
+      const EXPECTED_NAMES = [
+        'Mazda RX4',
+        'Mazda RX4 Wag',
+        'Datsun 710',
+        'Hornet 4 Drive',
+        'Hornet Sportabout',
+        'Valiant',
+        'Duster 360',
+        'Merc 240D',
+        'Merc 230',
+        'Merc 280',
+        'Merc 280C',
+        'Merc 450SE',
+        'Merc 450SL',
+        'Merc 450SLC',
+        'Cadillac Fleetwood',
+        'Lincoln Continental',
+        'Chrysler Imperial',
+        'Fiat 128',
+        'Honda Civic',
+        'Toyota Corolla',
+        'Toyota Corona',
+        'Dodge Challenger',
+        'AMC Javelin',
+        'Camaro Z28',
+        'Pontiac Firebird',
+        'Fiat X1-9',
+        'Porsche 914-2',
+        'Lotus Europa',
+        'Ford Pantera L',
+        'Ferrari Dino',
+        'Maserati Bora',
+        'Volvo 142E',
+      ];
+
+      program.addHook(
+        'postBlock',
+        async (blocktype, input, output) => {
+          expect(blocktype).toBe('TableTransformer');
+
+          expect(input).not.toBeNull();
+          assert(input != null);
+          assert(input instanceof Table);
+
+          expect(input.getNumberOfColumns()).toBe(1);
+          expect(input.getColumn('name')?.values).toStrictEqual(EXPECTED_NAMES);
+
+          expect(isOk(output)).toBe(true);
+          assert(isOk(output));
+          const out = output.right;
+          expect(out).not.toBeNull();
+          assert(out != null);
+          assert(out instanceof Table);
+
+          expect(out.getNumberOfColumns()).toBe(2);
+          expect(out.getColumn('name')?.values).toStrictEqual(EXPECTED_NAMES);
+          expect(out.getColumn('nameCopy')?.values).toStrictEqual(
+            EXPECTED_NAMES,
+          );
+
+          return parameter_spy();
+        },
+        { blocking: true, blocktypes: 'TableTransformer' },
+      );
+
+      const exitCode = await interpreter.interpretProgram(program);
+      expect(exitCode).toEqual(ExitCode.SUCCESS);
+
+      expect(parameter_spy).toHaveBeenCalledTimes(1);
     });
 
     it('should not wait for non-blocking hooks', async () => {

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -11,12 +11,14 @@ import {
   type DebugTargets,
   DefaultConstraintExtension,
   ExecutionContext,
-  type Hook,
   HookContext,
   type HookOptions,
+  type HookPosition,
   type JayveeConstraintExtension,
   type JayveeExecExtension,
   type Logger,
+  type PostBlockHook,
+  type PreBlockHook,
   executeBlocks,
   isErr,
   logExecutionDuration,
@@ -56,12 +58,18 @@ export interface InterpreterOptions {
 }
 
 export class JayveeProgram {
-  private _hooks: HookContext = new HookContext();
+  private _hooks = new HookContext();
 
   constructor(public model: JayveeModel) {}
 
-  public addHook(hook: Hook, opts: HookOptions) {
-    this._hooks.addHook(hook, opts);
+  // FIXME #634: Pass the blocktype to also execute block specific hooks
+  /** Add a hook to all blocks in the pipeline.*/
+  public addHook(
+    position: HookPosition,
+    hook: PreBlockHook | PostBlockHook,
+    opts: HookOptions,
+  ) {
+    this._hooks.addHook(position, hook, opts);
   }
 
   public get hooks() {

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -62,8 +62,17 @@ export class JayveeProgram {
 
   constructor(public model: JayveeModel) {}
 
-  // FIXME #634: Pass the blocktype to also execute block specific hooks
-  /** Add a hook to all blocks in the pipeline.*/
+  /** Add a hook to one or more blocks in the pipeline.*/
+  public addHook(
+    position: 'preBlock',
+    hook: PreBlockHook,
+    opts?: HookOptions,
+  ): void;
+  public addHook(
+    position: 'postBlock',
+    hook: PostBlockHook,
+    opts?: HookOptions,
+  ): void;
   public addHook(
     position: HookPosition,
     hook: PreBlockHook | PostBlockHook,

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -67,9 +67,9 @@ export class JayveeProgram {
   public addHook(
     position: HookPosition,
     hook: PreBlockHook | PostBlockHook,
-    opts: HookOptions,
+    opts?: HookOptions,
   ) {
-    this._hooks.addHook(position, hook, opts);
+    this._hooks.addHook(position, hook, opts ?? {});
   }
 
   public get hooks() {

--- a/libs/interpreter-lib/test/assets/hooks/valid-builtin-and-composite-blocks.jv
+++ b/libs/interpreter-lib/test/assets/hooks/valid-builtin-and-composite-blocks.jv
@@ -8,6 +8,7 @@ pipeline CarsPipeline {
 		-> CarsInterpreter
 		-> NameHeaderWriter
 		-> CarsTableInterpreter
+		-> CarsTableTransformer
 		-> CarsLoader;
 
 
@@ -31,18 +32,24 @@ pipeline CarsPipeline {
 		header: true;
 		columns: [
 			"name" oftype text,
-			"mpg" oftype decimal,
-			"cyl" oftype integer,
-			"disp" oftype decimal,
-			"hp" oftype integer,
-			"drat" oftype decimal,
-			"wt" oftype decimal,
-			"qsec" oftype decimal,
-			"vs" oftype integer,
-			"am" oftype integer,
-			"gear" oftype integer,
-			"carb" oftype integer
 		];
+	}
+
+	transform copy {
+		from s oftype text;
+		to t oftype text;
+
+		t: s;
+	}
+
+	block CarsTableTransformer oftype TableTransformer {
+		inputColumns: [
+			"name",
+		];
+
+		outputColumn: "nameCopy";
+
+		uses: copy;
 	}
 
 	block CarsLoader oftype SQLiteLoader {

--- a/libs/interpreter-lib/test/assets/hooks/valid-builtin-and-composite-blocks.jv
+++ b/libs/interpreter-lib/test/assets/hooks/valid-builtin-and-composite-blocks.jv
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline CarsPipeline {
+
+	CarsExtractor
+		-> CarsInterpreter
+		-> NameHeaderWriter
+		-> CarsTableInterpreter
+		-> CarsLoader;
+
+
+	block CarsExtractor oftype HttpExtractor {
+		url: "https://gist.githubusercontent.com/noamross/e5d3e859aa0c794be10b/raw/b999fb4425b54c63cab088c0ce2c0d6ce961a563/cars.csv";
+	}
+
+	block CarsInterpreter oftype CSVFileInterpreter {
+		enclosing: '"';
+	}
+
+	block NameHeaderWriter oftype CellWriter {
+		at: cell A1;
+
+		write: [
+			"name"
+		];
+	}
+
+	block CarsTableInterpreter oftype TableInterpreter {
+		header: true;
+		columns: [
+			"name" oftype text,
+			"mpg" oftype decimal,
+			"cyl" oftype integer,
+			"disp" oftype decimal,
+			"hp" oftype integer,
+			"drat" oftype decimal,
+			"wt" oftype decimal,
+			"qsec" oftype decimal,
+			"vs" oftype integer,
+			"am" oftype integer,
+			"gear" oftype integer,
+			"carb" oftype integer
+		];
+	}
+
+	block CarsLoader oftype SQLiteLoader {
+		table: "Cars";
+		file: "./cars.sqlite";
+	}
+}


### PR DESCRIPTION
Closes #633.

This PR adds hook  functionality to the Jayvee interpreter. Hooks are custom functions that are automatically executed before / after blocks. See the `PreBlockHook` and `PostBlockHook` types for such a functions signature.

Library users can add hooks with the `addHook` method:
```typescript
const program = /* parse program ...*/;

const before: PreBlockHook = (blocktype, input, context) => { /* ... */ };
program.addHook('preBlock', before, { blocking: true });

const after: PostBlockHook = (blocktype, input, context, output) => { /* ... */ };
program.addHook('postBlock', after);  // Options can be omitted. Non-blocking is the default

const blockSpecificHook = (blocktype, input, context) => { /* ... */ };
myJayveeProgram.addHook('preBlock', blockSpecificHook, {
  blocktypes: ['BuiltinBlockType', 'MyCustomCompositeBlock'],
})

// interpret model ...
```


Edit: Due to the simplifications outlined in https://github.com/jvalue/jayvee/issues/634#issuecomment-2589640027 this PR also closes #634.