### PR TITLE
[REFRACTOR] Hooks recieve a single parameter

### DIFF
--- a/libs/execution/src/lib/execution-context.ts
+++ b/libs/execution/src/lib/execution-context.ts
@@ -155,15 +155,20 @@ export class ExecutionContext {
     );
 
     if (output === undefined) {
-      return this.hookContext.executePreBlockHooks(blocktype, input, this);
+      return this.hookContext.executePreBlockHooks({
+        blocktype,
+        input,
+        context: this,
+      });
+      // eslint-disable-next-line no-else-return
+    } else {
+      return this.hookContext.executePostBlockHooks({
+        blocktype,
+        input,
+        output,
+        context: this,
+      });
     }
-
-    return this.hookContext.executePostBlockHooks(
-      blocktype,
-      input,
-      this,
-      output,
-    );
   }
 
   private getDefaultPropertyValue<I extends InternalValueRepresentation>(

--- a/libs/execution/src/lib/hooks/hook.ts
+++ b/libs/execution/src/lib/hooks/hook.ts
@@ -16,12 +16,14 @@ export interface HookOptions {
   blocktypes?: string[];
 }
 
+export interface PreBlockHookArgs {
+  blocktype: string;
+  input: IOTypeImplementation | null;
+  context: ExecutionContext;
+}
+
 /** This function will be executed before a block.*/
-export type PreBlockHook = (
-  blocktype: string,
-  input: IOTypeImplementation | null,
-  context: ExecutionContext,
-) => Promise<void>;
+export type PreBlockHook = (args: PreBlockHookArgs) => Promise<void>;
 
 export function isPreBlockHook(
   hook: PreBlockHook | PostBlockHook,
@@ -30,13 +32,12 @@ export function isPreBlockHook(
   return position === 'preBlock';
 }
 
+export interface PostBlockHookArgs extends PreBlockHookArgs {
+  output: Result<IOTypeImplementation | null>;
+}
+
 /** This function will be executed before a block.*/
-export type PostBlockHook = (
-  blocktype: string,
-  input: IOTypeImplementation | null,
-  output: Result<IOTypeImplementation | null>,
-  context: ExecutionContext,
-) => Promise<void>;
+export type PostBlockHook = (args: PostBlockHookArgs) => Promise<void>;
 
 export function isPostBlockHook(
   hook: PreBlockHook | PostBlockHook,

--- a/libs/interpreter-lib/src/interpreter.spec.ts
+++ b/libs/interpreter-lib/src/interpreter.spec.ts
@@ -101,7 +101,7 @@ describe('Interpreter', () => {
 
       program.addHook(
         'preBlock',
-        async (blocktype) => {
+        async ({ blocktype }) => {
           return sqlite_spy(blocktype);
         },
         { blocking: true, blocktypes: ['SQLiteLoader'] },
@@ -113,7 +113,7 @@ describe('Interpreter', () => {
 
       program.addHook(
         'postBlock',
-        async (blocktype) => {
+        async ({ blocktype }) => {
           return interpreter_spy(blocktype);
         },
         { blocking: true, blocktypes: ['CSVFileInterpreter'] },
@@ -193,7 +193,7 @@ describe('Interpreter', () => {
 
       program.addHook(
         'postBlock',
-        async (blocktype, input, output) => {
+        async ({ blocktype, input, output }) => {
           expect(blocktype).toBe('TableTransformer');
 
           expect(input).not.toBeNull();


### PR DESCRIPTION
This PR changes the hook's signature to only receive one object with the previous parameter as properties. This has the following advantages:
- Backwards compatibility: Adding new "parameters" at whatever position doesn't break existing code
- It's easier to ignore unused "parameters".

Depends on #638.
