### PR TITLE
[PERF] Don't split and join lines when using `TextFile`

### DIFF
--- a/libs/execution/src/lib/util/index.ts
+++ b/libs/execution/src/lib/util/index.ts
@@ -4,3 +4,4 @@
 
 export * from './implements-static-decorator';
 export * from './file-util';
+export * from './string-util';

--- a/libs/execution/src/lib/util/string-util.spec.ts
+++ b/libs/execution/src/lib/util/string-util.spec.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import { AssertionError } from 'assert';
+
+import { either } from 'fp-ts';
+
+import { ensureGlobal, findLineBounds } from './string-util';
+
+describe('Validation of string-util', () => {
+  describe('Function ensureGlobal', () => {
+    it('should make a non global RegExp global', () => {
+      const result = ensureGlobal(/someregex/);
+
+      expect(result.global).toBe(true);
+      expect(result.source).toBe('someregex');
+    });
+    it('should keep a global RegExp global', () => {
+      const result = ensureGlobal(/someregex/g);
+
+      expect(result.global).toBe(true);
+      expect(result.source).toBe('someregex');
+    });
+  });
+  describe('Function findLineBounds', () => {
+    it('should return empty array for empty array', () => {
+      const result = findLineBounds([], /\r?\n/, 'some text');
+
+      expect(either.isRight(result)).toBe(true);
+      assert(either.isRight(result));
+      expect(result.right).toStrictEqual([]);
+    });
+    it('should return first non existent lineIdx', () => {
+      const result = findLineBounds(
+        [0, 30, 300],
+        /\r?\n/,
+        `some text
+
+`,
+      );
+
+      expect(either.isLeft(result)).toBe(true);
+      assert(either.isLeft(result));
+      expect(result.left.firstNonExistentLineIdx).toBe(30);
+      expect(result.left.existingBounds).toStrictEqual([
+        { start: 0, length: 10 },
+      ]);
+    });
+    it('should return the entire string if there is no newline', () => {
+      const result = findLineBounds(
+        [0, 1],
+        /\r?\n/,
+        'some text without a newline',
+      );
+
+      expect(either.isLeft(result)).toBe(true);
+      assert(either.isLeft(result));
+      expect(result.left.firstNonExistentLineIdx).toBe(1);
+      expect(result.left.existingBounds).toStrictEqual([
+        { start: 0, length: 27 },
+      ]);
+    });
+    it('should correctly map multiple indices', () => {
+      const result = findLineBounds(
+        [0, 1, 2, 3],
+        /\r?\n/,
+        `some
+text  with
+newlines
+`,
+      );
+
+      expect(either.isLeft(result)).toBe(true);
+      assert(either.isLeft(result));
+      expect(result.left.firstNonExistentLineIdx).toBe(3);
+      expect(result.left.existingBounds).toStrictEqual([
+        { start: 0, length: 5 },
+        { start: 5, length: 11 },
+        { start: 16, length: 9 },
+      ]);
+    });
+    it('should throw an error on out of order indices', () => {
+      expect(() => findLineBounds([1, 0], /\r?\n/, '')).toThrowError(
+        AssertionError,
+      );
+    });
+  });
+});

--- a/libs/execution/src/lib/util/string-util.ts
+++ b/libs/execution/src/lib/util/string-util.ts
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
+
+import { either } from 'fp-ts';
+
+export function ensureGlobal(regex: RegExp): RegExp {
+  if (regex.global) {
+    return regex;
+  }
+
+  return RegExp(regex.source, regex.flags + 'g');
+}
+
+function isSortedAscending(numbers: number[]): boolean {
+  return numbers.every((lineIdx, i, arr) => {
+    if (i === 0) {
+      return true;
+    }
+    const prev = arr[i - 1];
+    assert(prev !== undefined);
+    return prev <= lineIdx;
+  });
+}
+
+function findSingleLineBounds(
+  searchIdx: number,
+  lineBreakPattern: RegExp,
+  text: string,
+): { start: number; length: number } | undefined {
+  let currentLineIdx = 0;
+  let currentLineStart = 0;
+
+  for (const lineBreak of text.matchAll(ensureGlobal(lineBreakPattern))) {
+    assert(currentLineIdx <= searchIdx);
+    if (currentLineIdx < searchIdx) {
+      currentLineIdx += 1;
+      currentLineStart += lineBreak.index + 1;
+      continue;
+    }
+
+    const lineLengthWithoutNewline = lineBreak.index - currentLineStart;
+    return {
+      start: currentLineStart,
+      length: lineLengthWithoutNewline + 1,
+    };
+  }
+
+  // HINT: Line with idx `lineIdx` not found.
+  if (currentLineIdx !== searchIdx) {
+    return undefined;
+  }
+  return {
+    start: currentLineStart,
+    length: text.length - currentLineStart,
+  };
+}
+
+type Bounds = { start: number; length: number }[];
+
+/**
+ * Map line idxs to line bounds.
+ *
+ * @param lineIdxs the indices of the lines to find bounds for. MUST be sorted in ASCENDING order.
+ * @param lineBreakPattern the pattern that marks a new line.
+ * @param text the text containing newlines.
+ * @returns a new array which contains either the bounds for the requested line or undefined
+ *
+ * @example
+ * let [{start, length}, outOfBounds ] = findLineBounds("some\ntext\n", /\r?\n/, [0, 300]);
+ * assert(inclusiveStart === 0);
+ * assert(length === 5);
+ * assert(outOfBounds === undefined);
+ */
+export function findLineBounds(
+  lineIdxs: number[],
+  lineBreakPattern: RegExp,
+  text: string,
+): either.Either<
+  { existingBounds: Bounds; firstNonExistentLineIdx: number },
+  Bounds
+> {
+  assert(isSortedAscending(lineIdxs));
+  let lineIdxOffset = 0;
+  let charIdxOffset = 0;
+
+  const bounds: { start: number; length: number }[] = [];
+
+  for (const searchIdx of lineIdxs) {
+    if (searchIdx > 0 && text.length === 0) {
+      return either.left({
+        existingBounds: bounds,
+        firstNonExistentLineIdx: searchIdx,
+      });
+    }
+    assert(searchIdx >= lineIdxOffset);
+    const tmp = findSingleLineBounds(
+      searchIdx - lineIdxOffset,
+      lineBreakPattern,
+      text,
+    );
+    if (tmp === undefined) {
+      return either.left({
+        existingBounds: bounds,
+        firstNonExistentLineIdx: searchIdx,
+      });
+    }
+
+    const { start, length } = tmp;
+
+    bounds.push({
+      start: charIdxOffset + start,
+      length,
+    });
+
+    charIdxOffset += start + length;
+    lineIdxOffset = searchIdx + 1;
+    text = text.slice(length);
+  }
+
+  return either.right(bounds);
+}

--- a/libs/extensions/std/exec/src/text-line-deleter-executor.spec.ts
+++ b/libs/extensions/std/exec/src/text-line-deleter-executor.spec.ts
@@ -125,7 +125,7 @@ Test  File
     expect(R.isOk(result)).toEqual(false);
     if (R.isErr(result)) {
       expect(result.left.message).toEqual(
-        'Line 1 does not exist in the text file, only 0 line(s) are present',
+        'Line 1 does not exist in the text file.',
       );
     }
   });

--- a/libs/extensions/std/exec/src/text-range-selector-executor.ts
+++ b/libs/extensions/std/exec/src/text-range-selector-executor.ts
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
+
 import * as R from '@jvalue/jayvee-execution';
 import {
   AbstractBlockExecutor,
@@ -11,6 +14,7 @@ import {
   implementsStatic,
 } from '@jvalue/jayvee-execution';
 import { IOType } from '@jvalue/jayvee-language-server';
+import { either } from 'fp-ts';
 
 @implementsStatic<BlockExecutorClass>()
 export class TextRangeSelectorExecutor extends AbstractBlockExecutor<
@@ -23,6 +27,7 @@ export class TextRangeSelectorExecutor extends AbstractBlockExecutor<
     super(IOType.TEXT_FILE, IOType.TEXT_FILE);
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async doExecute(
     file: TextFile,
     context: ExecutionContext,
@@ -40,16 +45,48 @@ export class TextRangeSelectorExecutor extends AbstractBlockExecutor<
       context.valueTypeProvider.Primitives.Regex,
     );
 
-    // eslint-disable-next-line @typescript-eslint/require-await
-    return R.transformTextFileLines(file, lineBreakPattern, async (lines) => {
-      context.logger.logDebug(
-        `Selecting lines from ${lineFrom} to ${
-          lineTo === Number.MAX_SAFE_INTEGER || lineTo >= lines.length
-            ? 'the end'
-            : `${lineTo}`
-        }`,
-      );
-      return R.ok(lines.slice(lineFrom - 1, lineTo));
-    });
+    context.logger.logDebug(
+      `Selecting lines from ${lineFrom} to ${
+        lineTo === Number.MAX_SAFE_INTEGER ? 'the end' : `${lineTo}`
+      }`,
+    );
+
+    const result = R.findLineBounds(
+      [lineFrom - 1, lineTo],
+      lineBreakPattern,
+      file.content,
+    );
+
+    let start: number | undefined = undefined;
+    let end: number | undefined = undefined;
+    if (either.isLeft(result)) {
+      switch (result.left.firstNonExistentLineIdx) {
+        case lineFrom - 1: {
+          break;
+        }
+        case lineTo:
+          start = result.left.existingBounds[0]?.start;
+          assert(start !== undefined);
+          end = file.content.length;
+          break;
+        default:
+          assert(false, 'Unreachable');
+      }
+    } else {
+      const [boundFrom, boundTo] = result.right;
+      assert(boundFrom !== undefined);
+      assert(boundTo !== undefined);
+      start = boundFrom.start;
+      end = boundTo.start;
+    }
+
+    const newContent =
+      start !== undefined && end !== undefined
+        ? file.content.substring(start, end)
+        : '';
+
+    return R.ok(
+      new TextFile(file.name, file.extension, file.mimeType, newContent),
+    );
   }
 }


### PR DESCRIPTION
**Problem**: When chaining `TextRangeSelector` and `TextLineDeleter` the following happens:
```typescript
// TextRangeSelector
let lines = splitLines(file.content);
let newLines = /* ... select range ... */;
return new TextFile(newLines.join());

// ...

// TextLineDeleter
let lines = splitLines(file.content);
let newLines = /* ... deleteLines ... */;
return new TextFile(newLines.join());
```
This might mean a lot of "useless" splits and joins, which becomes especially problematic for large files.

**Solution**: Introduce the new util function `findLineBounds()`. This function takes a sorted array of line indices, a regex to find line breaks and the text as parameters. It maps each line index to the start of the line and its length, stopping at the first non existent line index.

I didn't remove the now unused `transformTextFileLines()`, because deleting working, tested code seems unnecessary, but let me know it you think otherwise.