### PR TITLE
Replace `Date` with `perf-hooks` for time measurement

### DIFF
--- a/libs/execution/src/lib/index.ts
+++ b/libs/execution/src/lib/index.ts
@@ -9,6 +9,7 @@ export * from './types';
 export * from './util';
 export * from './debugging';
 export * from './types/value-types/visitors';
+export * from './perf';
 
 export * from './execution-context';
 export * from './extension';

--- a/libs/execution/src/lib/perf.ts
+++ b/libs/execution/src/lib/perf.ts
@@ -10,6 +10,12 @@ export type BlockInternalLocation =
   | 'blockExecution'
   | 'postBlockHooks';
 
+/**
+ * The location/type of a measure. Can be one of:
+ * - pipeline
+ * - block
+ * - block-internal @see BlockInternalLocation
+ */
 export class MeasureLocation {
   private readonly _pipeline: string;
   private readonly _block?: {
@@ -18,6 +24,12 @@ export class MeasureLocation {
     internalLocation?: BlockInternalLocation;
   };
 
+  /**
+   * Creates a new measure location. If the measures location is block-internal, use `withBlockInternalLocation()`.
+   * @param pipeline The name of the pipeline the measure is in.
+   * @param block If the measure is inside a block, this parameter specifies name and type.
+   * @returns A measure location
+   */
   constructor(pipeline: string, block?: { name: string; type: string }) {
     this._pipeline = pipeline;
     if (block === undefined) {
@@ -117,21 +129,63 @@ function assertMeasureLocation(obj: unknown): MeasureLocation {
   return location.withBlockInternalLocation(obj._block.internalLocation);
 }
 
+/**
+ * The measured duration of a pipeline. Includes a list of block measures.
+ */
 export interface PipelineMeasure {
+  /**
+   * The pipeline's name.
+   */
   name: string;
+  /**
+   * The pipeline's duration in milliseconds
+   */
   durationMs: number;
+  /**
+   * The measures of blocks executed as part of the pipeline.
+   * @see BlockMeasure
+   */
   blocks: BlockMeasure[];
 }
 
+/**
+ * The measured duration of a block. Also includes the duration of the pre- and
+ * post-block hooks.
+ */
 export interface BlockMeasure {
+  /**
+   * The block's name.
+   */
   name: string;
+  /**
+   * The block's block type (e.g. 'TableInterpreter').
+   */
   type: string;
+  /**
+   * The block's total duration in milliseconds.
+   */
   durationMs: number;
+  /**
+   * The duration of the pre-block hooks in milliseconds.
+   */
   preBlockHooksDurationMs: number;
+  /**
+   * The duration of the block execution method itself in milliseconds.
+   */
   blockExecutionDurationMs: number;
+  /**
+   * The duration of the post-block hooks in milliseconds.
+   */
   postBlockHooksDurationMs: number;
 }
 
+/**
+ * List all measures made until this point. Should only be called after
+ * interpreting a model.
+ *
+ * @returns a list of pipeline durations
+ * @see PipelineMeasure
+ */
 export function listMeasures(): PipelineMeasure[] {
   const pipelines: PipelineMeasure[] = [];
   for (const entry of performance.getEntriesByType('measure')) {

--- a/libs/execution/src/lib/perf.ts
+++ b/libs/execution/src/lib/perf.ts
@@ -1,0 +1,184 @@
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
+
+export type BlockInternalLocation =
+  | 'preBlockHooks'
+  | 'blockExecution'
+  | 'postBlockHooks';
+
+export class MeasureLocation {
+  private readonly _pipeline: string;
+  private readonly _block?: {
+    name: string;
+    type: string;
+    internalLocation?: BlockInternalLocation;
+  };
+
+  constructor(pipeline: string, block?: { name: string; type: string }) {
+    this._pipeline = pipeline;
+    if (block === undefined) {
+      return;
+    }
+    this._block = block;
+  }
+
+  withBlockInternalLocation(
+    blockInternalLocation: BlockInternalLocation,
+  ): MeasureLocation {
+    const cpy = new MeasureLocation(
+      this._pipeline,
+      structuredClone(this._block),
+    );
+    assert(cpy._block !== undefined);
+    cpy._block.internalLocation = blockInternalLocation;
+    return cpy;
+  }
+
+  get pipeline(): string {
+    return this._pipeline;
+  }
+
+  get block():
+    | {
+        name: string;
+        type: string;
+        internalLocation?: BlockInternalLocation;
+      }
+    | undefined {
+    return this._block;
+  }
+
+  get name(): string {
+    if (this._block === undefined) {
+      return this._pipeline;
+    }
+    if (this._block.internalLocation === undefined) {
+      return this._block.name;
+    }
+    return this._block.internalLocation;
+  }
+}
+
+export async function measure<R>(
+  location: MeasureLocation,
+  action: () => Promise<R>,
+): Promise<{ result: R; durationMs: number }> {
+  const name = location.name;
+  const start = name + '::start';
+  const end = name + '::end';
+
+  performance.mark(start);
+  const result = await action();
+  performance.mark(end);
+
+  const measure = performance.measure(name, {
+    start,
+    end,
+    detail: location,
+  });
+  return { result, durationMs: measure.duration };
+}
+
+function assertMeasureLocation(obj: unknown): MeasureLocation {
+  assert(obj != null);
+  assert(typeof obj === 'object');
+  assert('_pipeline' in obj);
+  assert(typeof obj._pipeline === 'string');
+
+  if (!('_block' in obj)) {
+    return new MeasureLocation(obj._pipeline);
+  }
+
+  assert(typeof obj._block === 'object');
+  assert(obj._block != null);
+  assert('name' in obj._block);
+  assert(typeof obj._block.name === 'string');
+  assert('type' in obj._block);
+  assert(typeof obj._block.type === 'string');
+
+  const location = new MeasureLocation(obj._pipeline, {
+    name: obj._block.name,
+    type: obj._block.type,
+  });
+
+  if (!('internalLocation' in obj._block)) {
+    return location;
+  }
+  assert(typeof obj._block.internalLocation === 'string');
+  assert(
+    obj._block.internalLocation === 'preBlockHooks' ||
+      obj._block.internalLocation === 'blockExecution' ||
+      obj._block.internalLocation === 'postBlockHooks',
+  );
+  return location.withBlockInternalLocation(obj._block.internalLocation);
+}
+
+export interface PipelineMeasure {
+  name: string;
+  durationMs: number;
+  blocks: BlockMeasure[];
+}
+
+export interface BlockMeasure {
+  name: string;
+  type: string;
+  durationMs: number;
+  preBlockHooksDurationMs: number;
+  blockExecutionDurationMs: number;
+  postBlockHooksDurationMs: number;
+}
+
+export function listMeasures(): PipelineMeasure[] {
+  const pipelines: PipelineMeasure[] = [];
+  for (const entry of performance.getEntriesByType('measure')) {
+    const location = assertMeasureLocation(entry.detail);
+    if (location.block === undefined) {
+      assert(entry.name === location.pipeline);
+      pipelines.push({
+        name: entry.name,
+        durationMs: entry.duration,
+        blocks: [],
+      });
+      continue;
+    }
+
+    const pipeline = pipelines.pop();
+    assert(pipeline !== undefined);
+    assert(location.pipeline === pipeline.name);
+
+    if (location.block.internalLocation === undefined) {
+      assert(entry.name === location.block.name);
+      pipeline.blocks.push({
+        name: entry.name,
+        type: location.block.type,
+        durationMs: entry.duration,
+        preBlockHooksDurationMs: 0,
+        blockExecutionDurationMs: 0,
+        postBlockHooksDurationMs: 0,
+      });
+      pipelines.push(pipeline);
+      continue;
+    }
+
+    const block = pipeline.blocks.pop();
+    assert(block !== undefined);
+    assert(location.block.name === block.name);
+    assert(entry.name === location.block.internalLocation);
+
+    switch (location.block.internalLocation) {
+      case 'preBlockHooks':
+        block.preBlockHooksDurationMs = entry.duration;
+        break;
+      case 'blockExecution':
+        block.blockExecutionDurationMs = entry.duration;
+        break;
+      case 'postBlockHooks':
+        block.postBlockHooksDurationMs = entry.duration;
+        break;
+    }
+    pipeline.blocks.push(block);
+    pipelines.push(pipeline);
+  }
+
+  return pipelines;
+}

--- a/libs/execution/src/lib/perf.ts
+++ b/libs/execution/src/lib/perf.ts
@@ -14,7 +14,7 @@ export type BlockInternalLocation =
  * The location/type of a measure. Can be one of:
  * - pipeline
  * - block
- * - block-internal @see BlockInternalLocation
+ * - block-internal {@link BlockInternalLocation}
  */
 export class MeasureLocation {
   private readonly _pipeline: string;
@@ -180,7 +180,7 @@ export interface PipelineMeasure {
   durationMs: number;
   /**
    * The measures of blocks executed as part of the pipeline.
-   * @see BlockMeasure
+   * {@link BlockMeasure}
    */
   blocks: BlockMeasure[];
 }
@@ -221,7 +221,7 @@ export interface BlockMeasure {
  * interpreting a model.
  *
  * @returns a list of pipeline durations
- * @see PipelineMeasure
+ * {@link PipelineMeasure}
  */
 export function listMeasures(): PipelineMeasure[] {
   const pipelines: PipelineMeasure[] = [];

--- a/libs/execution/src/lib/perf.ts
+++ b/libs/execution/src/lib/perf.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import assert from 'assert';
 

--- a/libs/execution/src/lib/perf.ts
+++ b/libs/execution/src/lib/perf.ts
@@ -86,13 +86,39 @@ export class MeasureLocation {
   }
 }
 
+/**
+ * Measure the duration of any action.
+ * @param id The action's name/identifier
+ * @param action The action to measure
+ * @returns The action's result and the actions duration in milliseconds
+ */
 export async function measure<R>(
-  location: MeasureLocation,
   action: () => Promise<R>,
+  id: string,
+  detail?: unknown,
+): Promise<{ result: R; durationMs: number }>;
+/**
+ * Measure the duration of a pipeline, block or block-internal.
+ * @param location The measure's location
+ * @param action The action to measure
+ * @returns The action's result and the actions duration in milliseconds
+ */
+export async function measure<R>(
+  action: () => Promise<R>,
+  location: MeasureLocation,
+): Promise<{ result: R; durationMs: number }>;
+export async function measure<R>(
+  action: () => Promise<R>,
+  location: MeasureLocation | string,
+  detail?: unknown,
 ): Promise<{ result: R; durationMs: number }> {
-  const name = location.name;
-  const start = name + '::start';
-  const end = name + '::end';
+  const id = typeof location === 'string' ? location : location.id;
+  if (typeof location !== 'string') {
+    assert(detail === undefined);
+    detail = location;
+  }
+  const start = id + '::start';
+  const end = id + '::end';
 
   performance.mark(start);
   const result = await action();

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -318,23 +318,20 @@ export class DefaultJayveeInterpreter implements JayveeInterpreter {
       this.services.WrapperFactories,
     );
 
-    const { result, durationMs } = await measure(
-      new MeasureLocation(pipeline.name),
-      async () => {
-        const executionResult = await executeBlocks(executionContext, pipeline);
+    const { result, durationMs } = await measure(async () => {
+      const executionResult = await executeBlocks(executionContext, pipeline);
 
-        if (isErr(executionResult)) {
-          const diagnosticError = executionResult.left;
-          executionContext.logger.logErrDiagnostic(
-            diagnosticError.message,
-            diagnosticError.diagnostic,
-          );
-          return ExitCode.FAILURE;
-        }
+      if (isErr(executionResult)) {
+        const diagnosticError = executionResult.left;
+        executionContext.logger.logErrDiagnostic(
+          diagnosticError.message,
+          diagnosticError.diagnostic,
+        );
+        return ExitCode.FAILURE;
+      }
 
-        return ExitCode.SUCCESS;
-      },
-    );
+      return ExitCode.SUCCESS;
+    }, new MeasureLocation(pipeline.name));
     executionContext.logger.logDebug(
       `${pipeline.name} took ${Math.round(durationMs)} ms`,
     );


### PR DESCRIPTION
Currently, Jayvee uses [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date)  to measure the duration of hooks, blocks and pipelines.


With this PR, the Jayvee interpreter now sets ["performance marks"](https://nodejs.org/api/perf_hooks.html) at relevant points during execution (before/after blocks/pipelines) and then measures the time between these marks. For now, marks are named with the following schema, with the goal of "encoding" the mark's location in the name:
```
`${pipeline name}::${block name}::${preBlockHook or BlockExecution or postBlockHook}::{start or end}`
```
This isn't final though, and I other ideas are welcome.

IMO this is a better approach than using the standard Jayvee hooks. Quoting https://github.com/jvalue/jayvee/issues/636#issuecomment-2593209146:
> As of now, the hooks' execution order is not sophisticated enough to log execution duration. Currently generic hooks are executed before block specific hooks in the order they are added. Considering https://github.com/jvalue/jayvee/issues/637, the hook logging execution duration would have to be executed after all other hooks, which cannot be guaranteed at this point.

I hope, that performance hooks can be used to implement a benchmarking tool using [PerformanceObserver](https://nodejs.org/api/perf_hooks.html#class-performanceobserver). That need's further testing though, so this PR is a draft for now.
