### PR TITLE
Add benchmarking into the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
       - name: Test
         run: npx nx affected --target=test --verbose --parallel=1 --base=remotes/origin/main --head=HEAD --ci
 
+      - name: Benchmark
+        run: npm run benchmark
+
       # Ensure this works for future release publishing
       - name: Publish Dry-Run
         run: npx nx affected --target=pre-publish --verbose --parallel=1 --base=remotes/origin/main --head=HEAD --ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,9 +45,6 @@ jobs:
       - name: Test
         run: npx nx affected --target=test --verbose --parallel=1 --base=remotes/origin/main --head=HEAD --ci
 
-      - name: Benchmark
-        run: npm run benchmark
-
       # Ensure this works for future release publishing
       - name: Publish Dry-Run
         run: npx nx affected --target=pre-publish --verbose --parallel=1 --base=remotes/origin/main --head=HEAD --ci
@@ -55,3 +52,23 @@ jobs:
       # Ensure this works for future release publishing
       - name: Pack VSCode Extension
         run: npx nx run vs-code-extension:pack:prod
+
+  benchmark:
+    name: benchmark
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Benchmark
+        run: npm run benchmark
+

--- a/apps/benchmark/.eslintrc.json
+++ b/apps/benchmark/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "parserOptions": {
+    "project": ["apps/benchmark/tsconfig.app.json", "apps/benchmark/tsconfig.spec.json"]
+  },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/apps/benchmark/.eslintrc.json.license
+++ b/apps/benchmark/.eslintrc.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/benchmark/package.json
+++ b/apps/benchmark/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@jvalue/jayvee-benchmark",
+  "description": "Benchmark tool for the Jayvee interpreter",
+  "main": "main.js",
+  "bin": {
+    "jv-bench": "main.js",
+    "jayvee-bench": "main.js"
+  },
+  "bugs": {
+    "url": "https://github.com/jvalue/jayvee/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jvalue/jayvee.git"
+  },
+  "homepage": "https://github.com/jvalue/jayvee",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "version": "$REPLACE_WITH_PROGRAM_VERSION_IN_PREPUBLISH_STEP"
+}

--- a/apps/benchmark/package.json.license
+++ b/apps/benchmark/package.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/benchmark/project.json
+++ b/apps/benchmark/project.json
@@ -1,0 +1,95 @@
+{
+  "name": "benchmark",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/benchmark/src",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "options": {
+        "tsConfig": "{projectRoot}/tsconfig.app.json",
+        "external": []
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    },
+    "run": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          {
+            "command": "nx run benchmark:build:development",
+            "forwardAllArgs": false
+          },
+          "node --enable-source-maps dist/apps/benchmark/main.js"
+        ],
+        "parallel": false
+      }
+    },
+    "test": {
+      "executor": "@nx/vite:test",
+      "outputs": [
+        "{workspaceRoot}/coverage/{projectRoot}"
+      ],
+      "options": {
+        "configFile": "{projectRoot}/vite.config.ts",
+        "passWithNoTests": false
+      }
+    },
+    "pre-publish": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        "build"
+      ],
+      "options": {
+        "commands": [
+          "node tools/scripts/benchmark/prepend-shebang.mjs benchmark main.js",
+          "node tools/scripts/add-package-json-version.mjs benchmark",
+          "node tools/scripts/benchmark/rewrite-version-mainjs.mjs benchmark",
+          "node tools/scripts/publish.mjs benchmark false"
+        ],
+        "parallel": false
+      }
+    },
+    "publish": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        "pre-publish"
+      ],
+      "options": {
+        "commands": [
+          "node tools/scripts/publish.mjs benchmark true"
+        ],
+        "parallel": false
+      }
+    },
+    "pack": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        "pre-publish"
+      ],
+      "options": {
+        "commands": [
+          "node tools/scripts/pack.mjs benchmark"
+        ],
+        "parallel": false
+      }
+    },
+    "install": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        "pack"
+      ],
+      "options": {
+        "commands": [
+          "npm i -g dist/apps/benchmark/jvalue-jayvee-benchmark-*.tgz"
+        ],
+        "parallel": false
+      }
+    }
+  },
+  "tags": []
+}

--- a/apps/benchmark/project.json
+++ b/apps/benchmark/project.json
@@ -38,57 +38,6 @@
         "configFile": "{projectRoot}/vite.config.ts",
         "passWithNoTests": false
       }
-    },
-    "pre-publish": {
-      "executor": "nx:run-commands",
-      "dependsOn": [
-        "build"
-      ],
-      "options": {
-        "commands": [
-          "node tools/scripts/benchmark/prepend-shebang.mjs benchmark main.js",
-          "node tools/scripts/add-package-json-version.mjs benchmark",
-          "node tools/scripts/benchmark/rewrite-version-mainjs.mjs benchmark",
-          "node tools/scripts/publish.mjs benchmark false"
-        ],
-        "parallel": false
-      }
-    },
-    "publish": {
-      "executor": "nx:run-commands",
-      "dependsOn": [
-        "pre-publish"
-      ],
-      "options": {
-        "commands": [
-          "node tools/scripts/publish.mjs benchmark true"
-        ],
-        "parallel": false
-      }
-    },
-    "pack": {
-      "executor": "nx:run-commands",
-      "dependsOn": [
-        "pre-publish"
-      ],
-      "options": {
-        "commands": [
-          "node tools/scripts/pack.mjs benchmark"
-        ],
-        "parallel": false
-      }
-    },
-    "install": {
-      "executor": "nx:run-commands",
-      "dependsOn": [
-        "pack"
-      ],
-      "options": {
-        "commands": [
-          "npm i -g dist/apps/benchmark/jvalue-jayvee-benchmark-*.tgz"
-        ],
-        "parallel": false
-      }
     }
   },
   "tags": []

--- a/apps/benchmark/project.json.license
+++ b/apps/benchmark/project.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/benchmark/src/benchmark-dummy-test.spec.ts
+++ b/apps/benchmark/src/benchmark-dummy-test.spec.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+describe('Dummy Test for Benchmark', () => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  it('should not do anything', async () => {});
+});

--- a/apps/benchmark/src/benchmark_definitions.json
+++ b/apps/benchmark/src/benchmark_definitions.json
@@ -1,0 +1,11 @@
+[
+  {
+    "modelPath": "example/cars.jv",
+    "expectedMeasure": {
+      "name": "cars",
+      "durationMs": 30,
+      "blocks": []
+    },
+    "allowedDeviationFactor": 0.5
+  }
+]

--- a/apps/benchmark/src/benchmark_definitions.json
+++ b/apps/benchmark/src/benchmark_definitions.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "cars",
     "modelPath": "example/cars.jv",
     "expectedMeasure": {
       "name": "cars",

--- a/apps/benchmark/src/benchmark_definitions.json.license
+++ b/apps/benchmark/src/benchmark_definitions.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/benchmark/src/calc.ts
+++ b/apps/benchmark/src/calc.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
+
+import {
+  type BlockMeasure,
+  type PipelineMeasure,
+} from '@jvalue/jayvee-interpreter-lib';
+
+function avgWith(
+  oldAverage: number,
+  newValue: number,
+  newSize: number,
+): number {
+  return oldAverage + (newValue - oldAverage) / newSize;
+}
+
+function avgBlkMeasure(b1: BlockMeasure, b2: BlockMeasure, bIdx: number) {
+  assert(b1.name === b2.name);
+  assert(b1.type === b2.type);
+  const bRes: BlockMeasure = {
+    name: b1.name,
+    type: b1.type,
+    durationMs: avgWith(b1.durationMs, b2.durationMs, bIdx + 1),
+    preBlockHooksDurationMs: avgWith(
+      b1.preBlockHooksDurationMs,
+      b2.preBlockHooksDurationMs,
+      bIdx + 1,
+    ),
+    blockExecutionDurationMs: avgWith(
+      b1.blockExecutionDurationMs,
+      b2.blockExecutionDurationMs,
+      bIdx + 1,
+    ),
+    postBlockHooksDurationMs: avgWith(
+      b1.postBlockHooksDurationMs,
+      b2.postBlockHooksDurationMs,
+      bIdx + 1,
+    ),
+  };
+  return bRes;
+}
+
+export function avgPipelineMeasure(
+  p1: PipelineMeasure,
+  p2: PipelineMeasure,
+  pIdx: number,
+): PipelineMeasure {
+  assert(p1.name === p2.name);
+
+  const blocks = p1.blocks.map((b1, bIdx) => {
+    const b2 = p2.blocks[bIdx];
+    assert(b2 !== undefined);
+    return avgBlkMeasure(b1, b2, bIdx);
+  });
+
+  const pRes: PipelineMeasure = {
+    name: p1.name,
+    durationMs: avgWith(p1.durationMs, p2.durationMs, pIdx + 1),
+    blocks: blocks,
+  };
+  return pRes;
+}

--- a/apps/benchmark/src/calc.ts
+++ b/apps/benchmark/src/calc.ts
@@ -6,8 +6,8 @@
 import assert from 'assert';
 
 import {
-  type BlockMeasure,
-  type PipelineMeasure,
+  type BlockMeasurement,
+  type PipelineMeasurement,
 } from '@jvalue/jayvee-interpreter-lib';
 
 function avgWith(
@@ -18,10 +18,14 @@ function avgWith(
   return oldAverage + (newValue - oldAverage) / newSize;
 }
 
-function avgBlkMeasure(b1: BlockMeasure, b2: BlockMeasure, bIdx: number) {
+function avgBlkMeasure(
+  b1: BlockMeasurement,
+  b2: BlockMeasurement,
+  bIdx: number,
+) {
   assert(b1.name === b2.name);
   assert(b1.type === b2.type);
-  const bRes: BlockMeasure = {
+  const bRes: BlockMeasurement = {
     name: b1.name,
     type: b1.type,
     durationMs: avgWith(b1.durationMs, b2.durationMs, bIdx + 1),
@@ -45,10 +49,10 @@ function avgBlkMeasure(b1: BlockMeasure, b2: BlockMeasure, bIdx: number) {
 }
 
 export function avgPipelineMeasure(
-  p1: PipelineMeasure,
-  p2: PipelineMeasure,
+  p1: PipelineMeasurement,
+  p2: PipelineMeasurement,
   pIdx: number,
-): PipelineMeasure {
+): PipelineMeasurement {
   assert(p1.name === p2.name);
 
   const blocks = p1.blocks.map((b1, bIdx) => {
@@ -57,7 +61,7 @@ export function avgPipelineMeasure(
     return avgBlkMeasure(b1, b2, bIdx);
   });
 
-  const pRes: PipelineMeasure = {
+  const pRes: PipelineMeasurement = {
     name: p1.name,
     durationMs: avgWith(p1.durationMs, p2.durationMs, pIdx + 1),
     blocks: blocks,

--- a/apps/benchmark/src/index.ts
+++ b/apps/benchmark/src/index.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import assert from 'assert';
 import path from 'node:path';

--- a/apps/benchmark/src/index.ts
+++ b/apps/benchmark/src/index.ts
@@ -1,60 +1,19 @@
-// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
 //
 // SPDX-License-Identifier: AGPL-3.0-only
-
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import assert from 'assert';
-
-import { type PipelineMeasure } from '@jvalue/jayvee-execution';
 
 import benchmarkDefinitions from './benchmark_definitions.json';
 import { createInterpreter, runBenchmark } from './run';
 
-function measureCompare(
-  actual: PipelineMeasure,
-  expected: PipelineMeasure,
-  allowedDeviationFactor: number,
-): '=' | '<' | '>' {
-  const lower = allowedDeviationFactor * expected.durationMs;
-  const upper = (1 + allowedDeviationFactor) * expected.durationMs;
-
-  if (actual.durationMs < lower) {
-    return '<';
-  } else if (actual.durationMs > upper) {
-    return '>';
-  }
-  return '=';
-}
-
 async function main() {
   const interpreter = createInterpreter();
-  const results = await Promise.all(
-    benchmarkDefinitions.map(async (benchmark) => {
-      const result = await runBenchmark(interpreter, benchmark);
-      const cmp = measureCompare(
-        result.actualMeasure,
-        result.expectedMeasure,
-        result.allowedDeviationFactor,
-      );
-      return { result, cmp };
-    }),
+  const deviations = await Promise.all(
+    benchmarkDefinitions.map((benchmark) =>
+      runBenchmark(interpreter, benchmark),
+    ),
   );
 
-  const outOfBounds = results.filter(({ cmp }) => cmp !== '=');
-
-  if (outOfBounds.length === 0) {
-    console.info('No anomalies in the benchmark');
-    process.exitCode = 0;
-    return;
-  }
-
-  process.exitCode = 1;
-
-  for (const { result, cmp } of outOfBounds) {
-    assert(cmp !== '=', "`'='` is filtered out above");
-    const msg = cmp === '<' ? 'Faster than expected:' : 'Slower than expected:';
-    console.warn(msg, result);
-  }
+  process.exitCode = deviations.some((deviates) => deviates) ? 1 : 0;
 }
 
 await main();

--- a/apps/benchmark/src/index.ts
+++ b/apps/benchmark/src/index.ts
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
+
 import { type PipelineMeasure } from '@jvalue/jayvee-execution';
 
 import benchmarkDefinitions from './benchmark_definitions.json';
@@ -37,28 +40,20 @@ async function main() {
     }),
   );
 
-  const outOfBounds = results.find(({ cmp }) => cmp !== '=');
+  const outOfBounds = results.filter(({ cmp }) => cmp !== '=');
 
-  if (outOfBounds === undefined) {
+  if (outOfBounds.length === 0) {
     console.info('No anomalies in the benchmark');
     process.exitCode = 0;
     return;
   }
 
-  console.warn(outOfBounds);
+  process.exitCode = 1;
 
-  switch (outOfBounds.cmp) {
-    case '<': {
-      process.exitCode = 1;
-      break;
-    }
-    case '>': {
-      process.exitCode = 2;
-      break;
-    }
-    case '=': {
-      throw new Error("`cmp` cannot be `'='`");
-    }
+  for (const { result, cmp } of outOfBounds) {
+    assert(cmp !== '=', "`'='` is filtered out above");
+    const msg = cmp === '<' ? 'Faster than expected:' : 'Slower than expected:';
+    console.warn(msg, result);
   }
 }
 

--- a/apps/benchmark/src/index.ts
+++ b/apps/benchmark/src/index.ts
@@ -1,0 +1,64 @@
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
+import path from 'node:path';
+import process from 'node:process';
+
+import { type PipelineMeasure } from '@jvalue/jayvee-execution';
+import {
+  DefaultJayveeInterpreter,
+  ExitCode,
+  type JayveeInterpreter,
+} from '@jvalue/jayvee-interpreter-lib';
+
+function createInterpreter(): JayveeInterpreter {
+  const currentDir = process.cwd();
+  const workingDir = currentDir;
+
+  return new DefaultJayveeInterpreter().addWorkspace(workingDir);
+}
+
+async function runOneModelOnce(
+  interpreter: JayveeInterpreter,
+  modelPath: string,
+): Promise<PipelineMeasure[]> {
+  const logBackup = console.log;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  console.log = () => {};
+  const exitCode = await interpreter.interpretFile(
+    path.relative(process.cwd(), modelPath),
+  );
+  console.log = logBackup;
+  assert(exitCode === ExitCode.SUCCESS);
+
+  const measures = interpreter.listMeasures();
+  interpreter.clearMeasures();
+  return measures;
+}
+
+async function runOneModel(
+  interpreter: JayveeInterpreter,
+  modelPath: string,
+  times = 10,
+): Promise<PipelineMeasure[]> {
+  assert(times >= 0);
+  let measures: PipelineMeasure[] = [];
+  for (let i = 0; i < times; i += 1) {
+    const newMeasures = await runOneModelOnce(interpreter, modelPath);
+    measures = measures.concat(newMeasures);
+  }
+  return measures;
+}
+
+async function main() {
+  const interpreter = createInterpreter();
+  const measures = await runOneModel(interpreter, './example/cars.jv');
+
+  const pipelineDurations = measures.map((measure) => measure.durationMs);
+  const len = pipelineDurations.length;
+
+  console.log('Average:', pipelineDurations.reduce((a, b) => a + b) / len);
+  console.log('Max:', Math.max(...pipelineDurations));
+  console.log('Min:', Math.min(...pipelineDurations));
+}
+
+await main();

--- a/apps/benchmark/src/index.ts
+++ b/apps/benchmark/src/index.ts
@@ -2,60 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import assert from 'assert';
 import path from 'node:path';
-import process from 'node:process';
 
-import {
-  DefaultJayveeInterpreter,
-  ExitCode,
-  type JayveeInterpreter,
-  type PipelineMeasure,
-} from '@jvalue/jayvee-interpreter-lib';
-
-function createInterpreter(): JayveeInterpreter {
-  const currentDir = process.cwd();
-  const workingDir = currentDir;
-
-  return new DefaultJayveeInterpreter().addWorkspace(workingDir);
-}
-
-async function runOneModelOnce(
-  interpreter: JayveeInterpreter,
-  modelPath: string,
-): Promise<PipelineMeasure[]> {
-  const logBackup = console.log;
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  console.log = () => {};
-  const exitCode = await interpreter.interpretFile(
-    path.relative(process.cwd(), modelPath),
-  );
-  console.log = logBackup;
-  assert(exitCode === ExitCode.SUCCESS);
-
-  const measures = interpreter.listMeasures();
-  interpreter.clearMeasures();
-  return measures;
-}
-
-async function runOneModel(
-  interpreter: JayveeInterpreter,
-  modelPath: string,
-  times = 10,
-): Promise<PipelineMeasure[]> {
-  assert(times >= 0);
-  let measures: PipelineMeasure[] = [];
-  for (let i = 0; i < times; i += 1) {
-    const newMeasures = await runOneModelOnce(interpreter, modelPath);
-    measures = measures.concat(newMeasures);
-  }
-  return measures;
-}
+import { createInterpreter, runOneModel } from './runModels';
 
 async function main() {
   const interpreter = createInterpreter();
-  const measures = await runOneModel(interpreter, './example/cars.jv');
+  const measures = await runOneModel(
+    interpreter,
+    path.join('example', 'cars.jv'),
+  );
 
   const pipelineDurations = measures.map((measure) => measure.durationMs);
   const len = pipelineDurations.length;

--- a/apps/benchmark/src/index.ts
+++ b/apps/benchmark/src/index.ts
@@ -2,23 +2,64 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import path from 'node:path';
+import { type PipelineMeasure } from '@jvalue/jayvee-execution';
 
-import { createInterpreter, runOneModel } from './runModels';
+import benchmarkDefinitions from './benchmark_definitions.json';
+import { createInterpreter, runBenchmark } from './run';
+
+function measureCompare(
+  actual: PipelineMeasure,
+  expected: PipelineMeasure,
+  allowedDeviationFactor: number,
+): '=' | '<' | '>' {
+  const lower = allowedDeviationFactor * expected.durationMs;
+  const upper = (1 + allowedDeviationFactor) * expected.durationMs;
+
+  if (actual.durationMs < lower) {
+    return '<';
+  } else if (actual.durationMs > upper) {
+    return '>';
+  }
+  return '=';
+}
 
 async function main() {
   const interpreter = createInterpreter();
-  const measures = await runOneModel(
-    interpreter,
-    path.join('example', 'cars.jv'),
+  const results = await Promise.all(
+    benchmarkDefinitions.map(async (benchmark) => {
+      const result = await runBenchmark(interpreter, benchmark);
+      const cmp = measureCompare(
+        result.actualMeasure,
+        result.expectedMeasure,
+        result.allowedDeviationFactor,
+      );
+      return { result, cmp };
+    }),
   );
 
-  const pipelineDurations = measures.map((measure) => measure.durationMs);
-  const len = pipelineDurations.length;
+  const outOfBounds = results.find(({ cmp }) => cmp !== '=');
 
-  console.log('Average:', pipelineDurations.reduce((a, b) => a + b) / len);
-  console.log('Max:', Math.max(...pipelineDurations));
-  console.log('Min:', Math.min(...pipelineDurations));
+  if (outOfBounds === undefined) {
+    console.info('No anomalies in the benchmark');
+    process.exitCode = 0;
+    return;
+  }
+
+  console.warn(outOfBounds);
+
+  switch (outOfBounds.cmp) {
+    case '<': {
+      process.exitCode = 1;
+      break;
+    }
+    case '>': {
+      process.exitCode = 2;
+      break;
+    }
+    case '=': {
+      throw new Error("`cmp` cannot be `'='`");
+    }
+  }
 }
 
 await main();

--- a/apps/benchmark/src/index.ts
+++ b/apps/benchmark/src/index.ts
@@ -7,11 +7,11 @@ import assert from 'assert';
 import path from 'node:path';
 import process from 'node:process';
 
-import { type PipelineMeasure } from '@jvalue/jayvee-execution';
 import {
   DefaultJayveeInterpreter,
   ExitCode,
   type JayveeInterpreter,
+  type PipelineMeasure,
 } from '@jvalue/jayvee-interpreter-lib';
 
 function createInterpreter(): JayveeInterpreter {

--- a/apps/benchmark/src/run.ts
+++ b/apps/benchmark/src/run.ts
@@ -14,6 +14,8 @@ import {
   type PipelineMeasure,
 } from '@jvalue/jayvee-interpreter-lib';
 
+import { avgPipelineMeasure } from './calc';
+
 export function createInterpreter(): JayveeInterpreter {
   const currentDir = process.cwd();
   const workingDir = currentDir;
@@ -51,4 +53,31 @@ export async function runOneModel(
     measures = measures.concat(newMeasures);
   }
   return measures;
+}
+
+interface BenchmarkDefinition {
+  modelPath: string;
+  expectedMeasure: PipelineMeasure;
+  times?: number;
+  allowedDeviationFactor: number;
+}
+
+interface BenchmarkResult extends BenchmarkDefinition {
+  actualMeasure: PipelineMeasure;
+}
+
+export async function runBenchmark(
+  interpreter: JayveeInterpreter,
+  benchmark: BenchmarkDefinition,
+): Promise<BenchmarkResult> {
+  const actualMeasures = await runOneModel(
+    interpreter,
+    benchmark.modelPath,
+    benchmark.times,
+  );
+
+  return {
+    actualMeasure: actualMeasures.reduce(avgPipelineMeasure),
+    ...benchmark,
+  };
 }

--- a/apps/benchmark/src/run.ts
+++ b/apps/benchmark/src/run.ts
@@ -11,7 +11,7 @@ import {
   DefaultJayveeInterpreter,
   ExitCode,
   type JayveeInterpreter,
-  type PipelineMeasure,
+  type PipelineMeasurement,
 } from '@jvalue/jayvee-interpreter-lib';
 
 import { avgPipelineMeasure } from './calc';
@@ -26,7 +26,7 @@ export function createInterpreter(): JayveeInterpreter {
 async function runOneModelOnce(
   interpreter: JayveeInterpreter,
   modelPath: string,
-): Promise<PipelineMeasure[]> {
+): Promise<PipelineMeasurement[]> {
   const logBackup = console.log;
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   console.log = () => {};
@@ -36,9 +36,9 @@ async function runOneModelOnce(
   console.log = logBackup;
   assert(exitCode === ExitCode.SUCCESS);
 
-  const measures = interpreter.listMeasures();
-  interpreter.clearMeasures();
-  return measures;
+  const measurements = interpreter.listMeasures();
+  interpreter.clearMeasurements();
+  return measurements;
 }
 
 export async function runOneModel(
@@ -46,22 +46,22 @@ export async function runOneModel(
   interpreter: JayveeInterpreter,
   modelPath: string,
   times = 10,
-): Promise<PipelineMeasure[]> {
+): Promise<PipelineMeasurement[]> {
   assert(times >= 0);
   console.log(`[${name}] Running model '${modelPath}' ${times} times`);
 
-  let measures: PipelineMeasure[] = [];
+  let measurements: PipelineMeasurement[] = [];
   for (let i = 0; i < times; i += 1) {
     const newMeasures = await runOneModelOnce(interpreter, modelPath);
-    measures = measures.concat(newMeasures);
+    measurements = measurements.concat(newMeasures);
   }
-  return measures;
+  return measurements;
 }
 
 interface BenchmarkDefinition {
   name: string;
   modelPath: string;
-  expectedMeasure: PipelineMeasure;
+  expectedMeasure: PipelineMeasurement;
   times?: number;
   allowedDeviationFactor: number;
 }

--- a/apps/benchmark/src/runModels.ts
+++ b/apps/benchmark/src/runModels.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
+import path from 'node:path';
+import process from 'node:process';
+
+import {
+  DefaultJayveeInterpreter,
+  ExitCode,
+  type JayveeInterpreter,
+  type PipelineMeasure,
+} from '@jvalue/jayvee-interpreter-lib';
+
+export function createInterpreter(): JayveeInterpreter {
+  const currentDir = process.cwd();
+  const workingDir = currentDir;
+
+  return new DefaultJayveeInterpreter().addWorkspace(workingDir);
+}
+
+async function runOneModelOnce(
+  interpreter: JayveeInterpreter,
+  modelPath: string,
+): Promise<PipelineMeasure[]> {
+  const logBackup = console.log;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  console.log = () => {};
+  const exitCode = await interpreter.interpretFile(
+    path.relative(process.cwd(), modelPath),
+  );
+  console.log = logBackup;
+  assert(exitCode === ExitCode.SUCCESS);
+
+  const measures = interpreter.listMeasures();
+  interpreter.clearMeasures();
+  return measures;
+}
+
+export async function runOneModel(
+  interpreter: JayveeInterpreter,
+  modelPath: string,
+  times = 10,
+): Promise<PipelineMeasure[]> {
+  assert(times >= 0);
+  let measures: PipelineMeasure[] = [];
+  for (let i = 0; i < times; i += 1) {
+    const newMeasures = await runOneModelOnce(interpreter, modelPath);
+    measures = measures.concat(newMeasures);
+  }
+  return measures;
+}

--- a/apps/benchmark/tsconfig.app.json
+++ b/apps/benchmark/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "module": "es2022",
+    "target": "es2020",
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "vite.config.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts"
+  ],
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/apps/benchmark/tsconfig.app.json.license
+++ b/apps/benchmark/tsconfig.app.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/benchmark/tsconfig.json
+++ b/apps/benchmark/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/apps/benchmark/tsconfig.json.license
+++ b/apps/benchmark/tsconfig.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/benchmark/tsconfig.spec.json
+++ b/apps/benchmark/tsconfig.spec.json
@@ -1,0 +1,27 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/apps/benchmark/tsconfig.spec.json.license
+++ b/apps/benchmark/tsconfig.spec.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only

--- a/apps/benchmark/vite.config.ts
+++ b/apps/benchmark/vite.config.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// / <reference types='vitest' />
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/apps/interpreter',
+
+  plugins: [nxViteTsPaths()],
+
+  test: {
+    globals: true,
+    cacheDir: '../../node_modules/.vitest',
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/apps/interpreter',
+      provider: 'v8',
+    },
+  },
+});

--- a/apps/benchmark/vite.config.ts
+++ b/apps/benchmark/vite.config.ts
@@ -8,7 +8,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   root: __dirname,
-  cacheDir: '../../node_modules/.vite/apps/interpreter',
+  cacheDir: '../../node_modules/.vite/apps/benchmark',
 
   plugins: [nxViteTsPaths()],
 
@@ -20,7 +20,7 @@ export default defineConfig({
 
     reporters: ['default'],
     coverage: {
-      reportsDirectory: '../../coverage/apps/interpreter',
+      reportsDirectory: '../../coverage/apps/benchmark',
       provider: 'v8',
     },
   },

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -13,10 +13,12 @@ import { runAction } from './run-action';
 import { type RunOptions } from './run-options';
 
 const interpreterMock: JayveeInterpreter = {
-  interpretModel: vi.fn(),
+  interpretProgram: vi.fn(),
   interpretFile: vi.fn(),
   interpretString: vi.fn(),
   parseModel: vi.fn(),
+  listMeasures: vi.fn(),
+  clearMeasures: vi.fn(),
 };
 
 vi.stubGlobal('DefaultJayveeInterpreter', interpreterMock);
@@ -46,7 +48,7 @@ describe('Parse Only', () => {
   afterEach(() => {
     // Assert that model is not executed
     expect(interpreterMock.interpretString).not.toBeCalled();
-    expect(interpreterMock.interpretModel).not.toBeCalled();
+    expect(interpreterMock.interpretProgram).not.toBeCalled();
   });
 
   beforeEach(() => {

--- a/libs/execution/src/lib/blocks/block-execution-util.ts
+++ b/libs/execution/src/lib/blocks/block-execution-util.ts
@@ -12,7 +12,7 @@ import {
 } from '@jvalue/jayvee-language-server';
 
 import { type ExecutionContext } from '../execution-context';
-import { MeasureLocation, measure } from '../perf';
+import { MeasurementLocation, measure } from '../perf';
 import { type IOTypeImplementation, NONE } from '../types';
 
 import * as R from './execution-result';
@@ -94,7 +94,7 @@ export async function executeBlock(
   const blockType = block.type.ref?.name;
   assert(blockType !== undefined);
 
-  const location = new MeasureLocation(executionContext.pipeline.name, {
+  const location = new MeasurementLocation(executionContext.pipeline.name, {
     name: block.name,
     type: blockType,
   });

--- a/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
@@ -43,6 +43,7 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
     super(IOType.SHEET, IOType.TABLE);
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async doExecute(
     inputSheet: Sheet,
     context: ExecutionContext,
@@ -65,12 +66,6 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
       'skipTrailingWhitespace',
       context.valueTypeProvider.Primitives.Boolean,
     );
-
-    // FIXME: REMOVE THIS BEFORE MERGING
-    function sleep(ms: number) {
-      return new Promise((resolve) => setTimeout(resolve, ms));
-    }
-    await sleep(100);
 
     let columnEntries: ColumnDefinitionEntry[];
 

--- a/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
@@ -43,7 +43,6 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
     super(IOType.SHEET, IOType.TABLE);
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async doExecute(
     inputSheet: Sheet,
     context: ExecutionContext,
@@ -66,6 +65,12 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
       'skipTrailingWhitespace',
       context.valueTypeProvider.Primitives.Boolean,
     );
+
+    // FIXME: REMOVE THIS BEFORE MERGING
+    function sleep(ms: number) {
+      return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+    await sleep(100);
 
     let columnEntries: ColumnDefinitionEntry[];
 

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -18,13 +18,13 @@ import {
   type JayveeConstraintExtension,
   type JayveeExecExtension,
   type Logger,
-  MeasureLocation,
-  type PipelineMeasure,
+  MeasurementLocation,
+  type PipelineMeasurement,
   type PostBlockHook,
   type PreBlockHook,
   executeBlocks,
   isErr,
-  listMeasures,
+  listMeasurements,
   measure,
   parseValueToInternalRepresentation,
 } from '@jvalue/jayvee-execution';
@@ -54,8 +54,8 @@ import {
 import { validateRuntimeParameterLiteral } from './validation-checks';
 
 export {
-  type PipelineMeasure,
-  type BlockMeasure,
+  type PipelineMeasurement,
+  type BlockMeasurement,
 } from '@jvalue/jayvee-execution';
 
 export interface InterpreterOptions {
@@ -137,18 +137,18 @@ export interface JayveeInterpreter {
   ): Promise<JayveeProgram | undefined>;
 
   /**
-   * List all measures made until this point. Should only be called after
+   * List all measurements made until this point. Should only be called after
    * interpreting a model.
    *
    * @returns a list of pipeline durations
    * {@link PipelineMeasure}
    */
-  listMeasures(): PipelineMeasure[];
+  listMeasures(): PipelineMeasurement[];
 
   /**
-   * Clear all existing measures.
+   * Clear all existing measurements.
    */
-  clearMeasures(): void;
+  clearMeasurements(): void;
 }
 
 export const DefaultInterpreterOptions: InterpreterOptions = {
@@ -256,11 +256,11 @@ export class DefaultJayveeInterpreter implements JayveeInterpreter {
     }
   }
 
-  listMeasures(): PipelineMeasure[] {
-    return listMeasures();
+  listMeasures(): PipelineMeasurement[] {
+    return listMeasurements();
   }
 
-  clearMeasures() {
+  clearMeasurements() {
     performance.clearMarks();
     performance.clearMeasures();
   }
@@ -373,7 +373,7 @@ export class DefaultJayveeInterpreter implements JayveeInterpreter {
       }
 
       return ExitCode.SUCCESS;
-    }, new MeasureLocation(pipeline.name));
+    }, new MeasurementLocation(pipeline.name));
     executionContext.logger.logDebug(
       `${pipeline.name} took ${Math.round(durationMs)} ms`,
     );

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -132,15 +132,16 @@ export interface JayveeInterpreter {
   ): Promise<JayveeProgram | undefined>;
 
   /**
-   * WARN: Only call this FULLY interpreting a model.
-   * Lists the duration measures made while interpreting.
+   * List all measures made until this point. Should only be called after
+   * interpreting a model.
    *
-   * @returns a list containing the measures made, grouped by pipelines and blocks.
+   * @returns a list of pipeline durations
+   * {@link PipelineMeasure}
    */
   listMeasures(): PipelineMeasure[];
 
   /**
-   * Clear all existing measures
+   * Clear all existing measures.
    */
   clearMeasures(): void;
 }

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -53,6 +53,11 @@ import {
 } from './parsing-util';
 import { validateRuntimeParameterLiteral } from './validation-checks';
 
+export {
+  type PipelineMeasure,
+  type BlockMeasure,
+} from '@jvalue/jayvee-execution';
+
 export interface InterpreterOptions {
   pipelineMatcher: (pipelineDefinition: PipelineDefinition) => boolean;
   env: Map<string, string>;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "nx run-many --target test",
     "generate": "nx run language-server:generate",
     "reproduce": "nx run interpreter:run -d repro.jv -dg exhaustive",
+    "bench": "nx run benchmark:run",
     "example:cars": "nx run interpreter:run -d example/cars.jv -dg peek",
     "example:gtfs": "nx run interpreter:run -d example/gtfs-static.jv -dg peek",
     "example:gtfs-rt": "nx run interpreter:run -d example/gtfs-rt.jv -dg peek",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "nx run-many --target test",
     "generate": "nx run language-server:generate",
     "reproduce": "nx run interpreter:run -d repro.jv -dg exhaustive",
-    "bench": "nx run benchmark:run",
+    "benchmark": "nx run benchmark:run",
     "example:cars": "nx run interpreter:run -d example/cars.jv -dg peek",
     "example:gtfs": "nx run interpreter:run -d example/gtfs-static.jv -dg peek",
     "example:gtfs-rt": "nx run interpreter:run -d example/gtfs-rt.jv -dg peek",


### PR DESCRIPTION
Depends on #649.

This PR implements a simple benchmarking tool (`npm run benchmark`) and adds a CI step to verify that no performance regression is introduced.

Benchmarks are specified in `apps/benchmark/src/benchmark_definitions.json`. For now, only the total pipeline duration is tested.

Failed benchmark step: https://github.com/jvalue/jayvee/actions/runs/14313480465/job/40113976972