### PR TITLE
[FEATURE] Generate mermaid.js syntax from a model

### DIFF
--- a/apps/benchmark/src/run.ts
+++ b/apps/benchmark/src/run.ts
@@ -36,7 +36,7 @@ async function runOneModelOnce(
   console.log = logBackup;
   assert(exitCode === ExitCode.SUCCESS);
 
-  const measurements = interpreter.listMeasures();
+  const measurements = interpreter.listMeasurements();
   interpreter.clearMeasurements();
   return measurements;
 }

--- a/apps/interpreter/src/examples-smoke-test.spec.ts
+++ b/apps/interpreter/src/examples-smoke-test.spec.ts
@@ -47,6 +47,7 @@ describe('jv example smoke tests', () => {
     debugGranularity: 'minimal',
     debugTarget: 'all',
     parseOnly: false,
+    graph: false,
   };
 
   let exitSpy: MockInstance;

--- a/apps/interpreter/src/index.ts
+++ b/apps/interpreter/src/index.ts
@@ -47,6 +47,7 @@ program
     collectRuntimeParameters,
     new Map<string, string>(),
   )
+  .option('-g, --graph', 'parse the model and print a mermaid.js graph', false)
   .option('-d, --debug', 'enable debug logging', false)
   .option(
     '-dg, --debug-granularity <granularity>',

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -17,8 +17,8 @@ const interpreterMock: JayveeInterpreter = {
   interpretFile: vi.fn(),
   interpretString: vi.fn(),
   parseModel: vi.fn(),
-  listMeasures: vi.fn(),
-  clearMeasures: vi.fn(),
+  listMeasurements: vi.fn(),
+  clearMeasurements: vi.fn(),
 };
 
 vi.stubGlobal('DefaultJayveeInterpreter', interpreterMock);

--- a/apps/interpreter/src/parse-only.spec.ts
+++ b/apps/interpreter/src/parse-only.spec.ts
@@ -19,6 +19,7 @@ const interpreterMock: JayveeInterpreter = {
   parseModel: vi.fn(),
   listMeasurements: vi.fn(),
   clearMeasurements: vi.fn(),
+  graphProgram: vi.fn(),
 };
 
 vi.stubGlobal('DefaultJayveeInterpreter', interpreterMock);
@@ -43,6 +44,7 @@ describe('Parse Only', () => {
     debugGranularity: 'minimal',
     debugTarget: 'all',
     parseOnly: false,
+    graph: false,
   };
 
   afterEach(() => {

--- a/apps/interpreter/src/run-action.ts
+++ b/apps/interpreter/src/run-action.ts
@@ -87,9 +87,12 @@ async function printGraph(
         loggerFactory.createLogger(),
       ),
   );
-  const graph =
-    program !== undefined ? interpreter.graphProgram(program) : undefined;
-  console.log(graph?.toString() ?? 'Parsing error');
+
+  if (program !== undefined) {
+    const graph = interpreter.graphProgram(program);
+    const log = graph === 'No pipelines to graph' ? console.warn : console.log;
+    log(graph.toString());
+  }
 
   const exitCode = program === undefined ? ExitCode.FAILURE : ExitCode.SUCCESS;
   process.exit(exitCode);

--- a/apps/interpreter/src/run-options.ts
+++ b/apps/interpreter/src/run-options.ts
@@ -18,6 +18,7 @@ export interface RunOptions {
   debugGranularity: DebugGranularity;
   debugTarget: DebugTargets;
   parseOnly: boolean;
+  graph: boolean;
 }
 
 export function parseRunOptions(
@@ -38,6 +39,7 @@ export function parseRunOptions(
     'debugGranularity',
     'debugTarget',
     'parseOnly',
+    'graph',
   ];
   if (requiredFields.some((f) => !(f in optionsRaw))) {
     logger.logErr(
@@ -56,7 +58,8 @@ export function parseRunOptions(
     !isDebugArgument(options.debug, logger) ||
     !isDebugGranularityArgument(options.debugGranularity, logger) ||
     !isDebugTargetArgument(options.debugTarget, logger) ||
-    !isParseOnlyArgument(options.parseOnly, logger)
+    !isParseOnlyArgument(options.parseOnly, logger) ||
+    !isGraphArgument(options.graph, logger)
   ) {
     return undefined;
   }
@@ -68,6 +71,7 @@ export function parseRunOptions(
     debugGranularity: options.debugGranularity,
     debugTarget: getDebugTargets(options.debugTarget),
     parseOnly: options.parseOnly === true || options.parseOnly === 'true',
+    graph: options.graph === true || options.parseOnly === 'true',
   };
 }
 
@@ -148,6 +152,20 @@ function isParseOnlyArgument(
       `Invalid value "${JSON.stringify(
         arg,
       )}" for parse-only option: -po --parse-only.\n` +
+        'Must be true or false.',
+    );
+    return false;
+  }
+  return true;
+}
+
+function isGraphArgument(
+  arg: unknown,
+  logger: Logger,
+): arg is boolean | 'true' | 'false' {
+  if (typeof arg !== 'boolean' && arg !== 'true' && arg !== 'false') {
+    logger.logErr(
+      `Invalid value "${JSON.stringify(arg)}" for graph option: -g --graph.\n` +
         'Must be true or false.',
     );
     return false;

--- a/apps/interpreter/src/run-options.ts
+++ b/apps/interpreter/src/run-options.ts
@@ -71,7 +71,7 @@ export function parseRunOptions(
     debugGranularity: options.debugGranularity,
     debugTarget: getDebugTargets(options.debugTarget),
     parseOnly: options.parseOnly === true || options.parseOnly === 'true',
-    graph: options.graph === true || options.parseOnly === 'true',
+    graph: options.graph === true || options.graph === 'true',
   };
 }
 

--- a/libs/execution/src/lib/blocks/block-execution-util.ts
+++ b/libs/execution/src/lib/blocks/block-execution-util.ts
@@ -174,7 +174,6 @@ export async function executeBlock(
 export function executionGraph(
   executionContext: ExecutionContext,
   pipesContainer: CompositeBlockTypeDefinition | PipelineDefinition,
-  _initialInputValue: IOTypeImplementation | undefined = undefined,
 ): Graph {
   const pipelineWrapper =
     executionContext.wrapperFactories.Pipeline.wrap(pipesContainer);

--- a/libs/execution/src/lib/blocks/block-execution-util.ts
+++ b/libs/execution/src/lib/blocks/block-execution-util.ts
@@ -14,6 +14,7 @@ import {
 import { type ExecutionContext } from '../execution-context';
 import { MeasurementLocation, measure } from '../perf';
 import { type IOTypeImplementation, NONE } from '../types';
+import { Graph } from '../util/mermaid-util';
 
 import * as R from './execution-result';
 
@@ -159,4 +160,36 @@ export async function executeBlock(
     `${block.name} took ${Math.round(totalDurMs)} ms`,
   );
   return result;
+}
+
+/**
+ * Visualizes the pipelines exectution order
+ *
+ * @param executionContext The context the blocks are executed in, e.g., a pipeline or composite block
+ * @param pipesContainer The pipelines to be executed
+ * @param initialInputValue An initial input that was produced outside of this block chain, e.g., as input to a composite block
+ *
+ * @returns A graph representantion of the execution
+ */
+export function executionGraph(
+  executionContext: ExecutionContext,
+  pipesContainer: CompositeBlockTypeDefinition | PipelineDefinition,
+  _initialInputValue: IOTypeImplementation | undefined = undefined,
+): Graph {
+  const pipelineWrapper =
+    executionContext.wrapperFactories.Pipeline.wrap(pipesContainer);
+
+  const graph = new Graph(pipesContainer.name);
+
+  for (const block of pipelineWrapper.getBlocksInTopologicalSorting()) {
+    const parents = pipelineWrapper.getParentBlocks(block).flatMap((parent) => {
+      const parentId = graph.getBlockId(parent);
+      return parentId !== undefined ? [parentId] : [];
+    });
+    executionContext.enterNode(block);
+    graph.addBlock(executionContext, block, parents);
+    executionContext.exitNode(block);
+  }
+
+  return graph;
 }

--- a/libs/execution/src/lib/blocks/block-executor.ts
+++ b/libs/execution/src/lib/blocks/block-executor.ts
@@ -11,6 +11,7 @@ import { isBlockTargetedForDebugLogging } from '../debugging/debug-configuration
 import { DebugLogVisitor } from '../debugging/debug-log-visitor';
 import { type ExecutionContext } from '../execution-context';
 import { type IOTypeImplementation } from '../types/io-types/io-type-implementation';
+import { Edge, type Graph, type Id, Node } from '../util';
 
 import * as R from './execution-result';
 
@@ -25,6 +26,8 @@ export interface BlockExecutor<
     input: IOTypeImplementation<I>,
     context: ExecutionContext,
   ): Promise<R.Result<IOTypeImplementation<O> | null>>;
+
+  addToGraph(graph: Graph, parents: Id[], context: ExecutionContext): Id;
 }
 
 export abstract class AbstractBlockExecutor<I extends IOType, O extends IOType>
@@ -80,4 +83,19 @@ export abstract class AbstractBlockExecutor<I extends IOType, O extends IOType>
     input: IOTypeImplementation<I>,
     context: ExecutionContext,
   ): Promise<R.Result<IOTypeImplementation<O> | null>>;
+
+  addToGraph(graph: Graph, parents: Id[], context: ExecutionContext): Id {
+    const node = new Node(context.getCurrentNode().name, {
+      start: '[',
+      end: ']',
+    });
+    graph.addNode(node);
+
+    for (const parent of parents) {
+      const edge = new Edge(parent, node.id, this.inputType, '-->');
+      graph.addEdge(edge);
+    }
+
+    return node.id;
+  }
 }

--- a/libs/execution/src/lib/blocks/block-executor.ts
+++ b/libs/execution/src/lib/blocks/block-executor.ts
@@ -11,7 +11,7 @@ import { isBlockTargetedForDebugLogging } from '../debugging/debug-configuration
 import { DebugLogVisitor } from '../debugging/debug-log-visitor';
 import { type ExecutionContext } from '../execution-context';
 import { type IOTypeImplementation } from '../types/io-types/io-type-implementation';
-import { Edge, type Graph, type Id, Node } from '../util';
+import { Edge, type Graph, type Id, Node } from '../util/mermaid-util';
 
 import * as R from './execution-result';
 

--- a/libs/execution/src/lib/blocks/block-executor.ts
+++ b/libs/execution/src/lib/blocks/block-executor.ts
@@ -85,10 +85,7 @@ export abstract class AbstractBlockExecutor<I extends IOType, O extends IOType>
   ): Promise<R.Result<IOTypeImplementation<O> | null>>;
 
   addToGraph(graph: Graph, parents: Id[], context: ExecutionContext): Id {
-    const node = new Node(context.getCurrentNode().name, {
-      start: '[',
-      end: ']',
-    });
+    const node = new Node(context.getCurrentNode().name, '[ ]');
     graph.addNode(node);
 
     for (const parent of parents) {

--- a/libs/execution/src/lib/blocks/composite-block-executor.ts
+++ b/libs/execution/src/lib/blocks/composite-block-executor.ts
@@ -70,7 +70,7 @@ export function createCompositeBlockExecutor(
         graph.addEdge(edge);
       }
 
-      return graph.id;
+      return subgraph.id;
     }
 
     async doExecute(

--- a/libs/execution/src/lib/blocks/composite-block-executor.ts
+++ b/libs/execution/src/lib/blocks/composite-block-executor.ts
@@ -23,8 +23,9 @@ import {
 
 import { type ExecutionContext } from '../execution-context';
 import { type IOTypeImplementation } from '../types';
+import { Edge, type Graph, type Id } from '../util';
 
-import { executeBlocks } from './block-execution-util';
+import { executeBlocks, executionGraph } from './block-execution-util';
 import { AbstractBlockExecutor, type BlockExecutor } from './block-executor';
 import { type BlockExecutorClass } from './block-executor-class';
 import * as R from './execution-result';
@@ -54,6 +55,22 @@ export function createCompositeBlockExecutor(
 
     constructor() {
       super(inputType, outputType);
+    }
+
+    override addToGraph(
+      graph: Graph,
+      parents: Id[],
+      context: ExecutionContext,
+    ): Id {
+      const subgraph = executionGraph(context, blockTypeReference);
+      graph.addSubgraph(subgraph);
+
+      for (const parent of parents) {
+        const edge = new Edge(parent, subgraph.id, this.inputType, '-->');
+        graph.addEdge(edge);
+      }
+
+      return graph.id;
     }
 
     async doExecute(

--- a/libs/execution/src/lib/util/index.ts
+++ b/libs/execution/src/lib/util/index.ts
@@ -5,3 +5,4 @@
 export * from './implements-static-decorator';
 export * from './file-util';
 export * from './string-util';
+export * from './mermaid-util';

--- a/libs/execution/src/lib/util/mermaid-util.spec.ts
+++ b/libs/execution/src/lib/util/mermaid-util.spec.ts
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import {
+  ClassAssignment,
+  ClassDefinition,
+  Edge,
+  EdgeAttribute,
+  Graph,
+  Node,
+  getId,
+} from './mermaid-util';
+
+describe('Validation of mermaid-util', () => {
+  describe('Function getId', () => {
+    it('Correct first 28 ids', () => {
+      // NOTE: The id is expected to increase from `z` to `ba`
+      // just as decimal increases from `9` to `10` (not `00`)
+      expect(getId()).toBe('a');
+      expect(getId()).toBe('b');
+      expect(getId()).toBe('c');
+      expect(getId()).toBe('d');
+      expect(getId()).toBe('e');
+      expect(getId()).toBe('f');
+      expect(getId()).toBe('g');
+      expect(getId()).toBe('h');
+      expect(getId()).toBe('i');
+      expect(getId()).toBe('j');
+      expect(getId()).toBe('k');
+      expect(getId()).toBe('l');
+      expect(getId()).toBe('m');
+      expect(getId()).toBe('n');
+      expect(getId()).toBe('o');
+      expect(getId()).toBe('p');
+      expect(getId()).toBe('q');
+      expect(getId()).toBe('r');
+      expect(getId()).toBe('s');
+      expect(getId()).toBe('t');
+      expect(getId()).toBe('u');
+      expect(getId()).toBe('v');
+      expect(getId()).toBe('w');
+      expect(getId()).toBe('x');
+      expect(getId()).toBe('y');
+      expect(getId()).toBe('z');
+      expect(getId()).toBe('ba');
+      expect(getId()).toBe('bb');
+    });
+  });
+  describe('Class Node', () => {
+    it('correctly prints a node', () => {
+      let node = new Node('nodeText', '[ ]');
+      expect(node.toString()).toBe(`${node.id}[nodeText]`);
+
+      node = new Node('otherNodeText', '( )');
+      expect(node.toString()).toBe(`${node.id}(otherNodeText)`);
+    });
+  });
+  describe('Class Edge', () => {
+    it('correctly prints an edge', () => {
+      const edge = new Edge('node', 'otherNode', 'edgeText', '-->');
+      expect(edge.toString()).toBe(`node ${edge.id}@-->|edgeText| otherNode`);
+    });
+  });
+  describe('Class EdgeAttribute', () => {
+    it('correctly prints an edge attribute', () => {
+      const edgeAttribute = new EdgeAttribute('edgeId');
+      expect(edgeAttribute.toString()).toBe('edgeId@{  }');
+
+      edgeAttribute.set('attr', 'val');
+      expect(edgeAttribute.toString()).toBe('edgeId@{ attr: val }');
+
+      edgeAttribute.set('attr2', 'val2');
+      expect(edgeAttribute.toString()).toBe(
+        'edgeId@{ attr: val, attr2: val2 }',
+      );
+    });
+  });
+  describe('Class ClassDefinition', () => {
+    it('correctly prints a class definition', () => {
+      const classDefinition = new ClassDefinition('className');
+      expect(classDefinition.toString()).toBe('classDef className');
+
+      classDefinition.set('attr', 'val');
+      expect(classDefinition.toString()).toBe('classDef className attr: val');
+
+      classDefinition.set('attr2', 'val2');
+      expect(classDefinition.toString()).toBe(
+        'classDef className attr: val,attr2: val2',
+      );
+    });
+  });
+  describe('Class Assignment', () => {
+    it('correctly prints a class assignment', () => {
+      const classAssignment = new ClassAssignment('id', 'className');
+      expect(classAssignment.toString()).toBe('class id className');
+    });
+  });
+  describe('Class Graph', () => {
+    it('correctly prints a Graph', () => {
+      const graph = new Graph('title');
+      expect(graph.toString()).toBe(`---
+title: title
+---
+flowchart TB
+`);
+
+      const node1 = new Node('nodeText', '[ ]');
+      const node2 = new Node('otherNodeText', '( )');
+      graph.addNode(node1);
+      graph.addNode(node2);
+      expect(graph.toString()).toBe(`---
+title: title
+---
+flowchart TB
+\t${node1.id}[nodeText]
+\t${node2.id}(otherNodeText)`);
+
+      const edge = new Edge(node1.id, node2.id, 'edgeText', '==>');
+      graph.addEdge(edge);
+      expect(graph.toString()).toBe(`---
+title: title
+---
+flowchart TB
+\t${node1.id}[nodeText]
+\t${node2.id}(otherNodeText)
+
+\t${node1.id} ${edge.id}@==>|edgeText| ${node2.id}`);
+    });
+  });
+  it('correctly prints a Graph containing a subgraph', () => {
+    const subgraph = new Graph('subgraphTitle');
+    const node1 = new Node('nodeText', '[ ]');
+    subgraph.addNode(node1);
+    const node2 = new Node('otherNodeText', '( )');
+    subgraph.addNode(node2);
+    const edge = new Edge(node1.id, node2.id, 'edgeText', '==>');
+    subgraph.addEdge(edge);
+    expect(subgraph.toSubgraph(1)).toBe(`subgraph ${subgraph.id} [subgraphTitle]
+\tdirection TB
+\t${node1.id}[nodeText]
+\t${node2.id}(otherNodeText)
+
+\t${node1.id} ${edge.id}@==>|edgeText| ${node2.id}
+end`);
+
+    const graph = new Graph('title');
+    graph.addSubgraph(subgraph);
+    expect(graph.toString()).toBe(`---
+title: title
+---
+flowchart TB
+\tsubgraph ${subgraph.id} [subgraphTitle]
+\t\tdirection TB
+\t\t${node1.id}[nodeText]
+\t\t${node2.id}(otherNodeText)
+
+\t\t${node1.id} ${edge.id}@==>|edgeText| ${node2.id}
+\tend`);
+  });
+});

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -1,0 +1,189 @@
+import { createHash } from 'node:crypto';
+
+import { type BlockDefinition } from '@jvalue/jayvee-language-server';
+
+import { type ExecutionContext } from '../execution-context';
+
+export type Id = string;
+function generateId(obj: object): string {
+  const s = JSON.stringify(obj);
+  return createHash('sha256').update(s).digest('hex');
+}
+
+export type NodeShape =
+  | {
+      start: '[';
+      end: ']';
+    }
+  | {
+      start: '(';
+      end: ')';
+    };
+
+export class Node {
+  private readonly _id: Id = generateId(this);
+  constructor(public text: string, public shape: NodeShape) {}
+
+  get id(): Id {
+    return this._id;
+  }
+
+  toString(): string {
+    return this.id + this.shape.start + this.text + this.shape.end;
+  }
+}
+
+export type Arrow = '-->' | '---' | '-.->' | '==>' | '~~~' | '--o' | '--x';
+
+export class Edge {
+  private readonly _id: Id = generateId(this);
+  constructor(
+    public from: Id,
+    public to: Id,
+    public text: string,
+    public arrow: Arrow,
+  ) {}
+
+  get id(): Id {
+    return this._id;
+  }
+
+  toString(): string {
+    return `${this.from} ${this.id}@${this.arrow}|${this.text}| ${this.to}`;
+  }
+}
+
+export class EdgeAttribute {
+  private attributes = new Map<string, string>();
+
+  constructor(public id: Id) {}
+
+  get(name: string) {
+    this.attributes.get(name);
+  }
+
+  set(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+
+  toString(): string {
+    return `${this.id}@{ ${[...this.attributes.entries()]
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(', ')} }`;
+  }
+}
+
+export class ClassDefinition {
+  private properties = new Map<string, string>();
+
+  constructor(public className: string) {}
+
+  get(name: string) {
+    this.properties.get(name);
+  }
+
+  set(name: string, value: string) {
+    this.properties.set(name, value);
+  }
+
+  toString(): string {
+    return `classDef ${this.className} ${[...this.properties.entries()]
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(',')}`;
+  }
+}
+
+export class ClassAssignment {
+  constructor(public id: string, public className: string) {}
+
+  toString(): string {
+    return `class ${this.id} ${this.className}`;
+  }
+}
+
+export type GraphDirection = 'TD' | 'LR';
+export class Graph {
+  private readonly _id: Id = generateId(this);
+  private direction: GraphDirection = 'TD';
+  private nodes = new Map<Id, Node>();
+
+  private edges = new Map<Id, Edge>();
+  private edgeAttributes: { id: Id; attributes: string[] }[] = [];
+
+  private subgraphs = new Map<Id, Graph>();
+
+  private classDefinitions: {
+    class: string;
+    propertiesAndValues: string[];
+  }[] = [];
+  private classAssignments: { id: Id; class: string }[] = [];
+
+  private blocks = new Map<BlockDefinition, Id>();
+
+  constructor(public title: string) {}
+
+  get id(): Id {
+    return this._id;
+  }
+
+  getBlockId(block: BlockDefinition): Id | undefined {
+    return this.blocks.get(block);
+  }
+
+  public addBlock(
+    context: ExecutionContext,
+    block: BlockDefinition,
+    parents: Id[],
+  ) {
+    const executor = context.executionExtension.createBlockExecutor(block);
+
+    const block_id = executor.addToGraph(this, parents, context);
+    this.blocks.set(block, block_id);
+  }
+
+  private content(): string {
+    return [
+      this.nodes,
+      this.edges,
+      [...this.subgraphs.values()].map((sg) => sg.toSubgraph()),
+      this.edgeAttributes,
+      this.classDefinitions,
+      this.classAssignments,
+    ]
+      .map((arr) => {
+        if (Array.isArray(arr)) {
+          return arr.join('\n\t');
+        }
+        return [...arr.values()].join('\n\t');
+      })
+      .join('\n\n');
+  }
+
+  public addNode(node: Node) {
+    this.nodes.set(node.id, node);
+  }
+
+  public addSubgraph(subgraph: Graph) {
+    this.subgraphs.set(subgraph.id, subgraph);
+  }
+
+  public addEdge(edge: Edge) {
+    this.edges.set(edge.id, edge);
+  }
+
+  public toSubgraph(): string {
+    return `subgraph ${this.id} [${this.title}]
+  direction ${this.direction}
+  ${this.content()}`;
+  }
+
+  toString(): string {
+    return `
+---
+title: ${this.title}
+---
+flowchart ${this.direction}
+  ${this.content()}
+`;
+  }
+}

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -138,7 +138,7 @@ export class Graph {
 
   private blocks = new Map<BlockDefinition, Id>();
 
-  constructor(public title: string) {}
+  constructor(public title?: string) {}
 
   get id(): Id {
     return this._id;
@@ -189,15 +189,16 @@ export class Graph {
   }
 
   public toSubgraph(indents: number): string {
-    return `subgraph ${this.id} [${this.title}]
+    const title = this.title !== undefined ? ` [${this.title}]` : '';
+    return `subgraph ${this.id}${title}
 ${'\t'.repeat(indents)}direction ${this.direction}
 ${this.content(indents)}
 ${indents > 0 ? '\t'.repeat(indents - 1) : ''}end`;
   }
 
   toString(): string {
-    return `---
-title: ${this.title}
+    const title = this.title !== undefined ? `\ntitle: ${this.title}` : '';
+    return `---${title}
 ---
 flowchart ${this.direction}
 ${this.content(1)}`;

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -100,9 +100,14 @@ export class ClassDefinition {
   }
 
   toString(): string {
-    return `classDef ${this.className} ${[...this.properties.entries()]
+    const properties = [...this.properties.entries()]
       .map(([key, value]) => `${key}: ${value}`)
-      .join(',')}`;
+      .join(',');
+
+    if (properties === '') {
+      return `classDef ${this.className}`;
+    }
+    return `classDef ${this.className} ${properties}`;
   }
 }
 

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -1,13 +1,27 @@
-import { createHash } from 'node:crypto';
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
 
 import { type BlockDefinition } from '@jvalue/jayvee-language-server';
 
 import { type ExecutionContext } from '../execution-context';
 
 export type Id = string;
-function generateId(obj: object): string {
-  const s = JSON.stringify(obj);
-  return createHash('sha256').update(s).digest('hex');
+let nextIdx = 0;
+const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
+function getId(): Id {
+  let idx = nextIdx++;
+  if (idx === 0) {
+    return 'a';
+  }
+
+  let id = '';
+  while (idx > 0) {
+    const letter = ALPHABET[idx % ALPHABET.length];
+    assert(letter !== undefined);
+    id += letter;
+    idx = Math.floor(idx / ALPHABET.length);
+  }
+  return id;
 }
 
 export type NodeShape =
@@ -21,7 +35,7 @@ export type NodeShape =
     };
 
 export class Node {
-  private readonly _id: Id = generateId(this);
+  private readonly _id: Id = getId();
   constructor(public text: string, public shape: NodeShape) {}
 
   get id(): Id {
@@ -36,7 +50,7 @@ export class Node {
 export type Arrow = '-->' | '---' | '-.->' | '==>' | '~~~' | '--o' | '--x';
 
 export class Edge {
-  private readonly _id: Id = generateId(this);
+  private readonly _id: Id = getId();
   constructor(
     public from: Id,
     public to: Id,
@@ -103,7 +117,7 @@ export class ClassAssignment {
 
 export type GraphDirection = 'TD' | 'LR';
 export class Graph {
-  private readonly _id: Id = generateId(this);
+  private readonly _id: Id = getId();
   private direction: GraphDirection = 'TD';
   private nodes = new Map<Id, Node>();
 

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -188,12 +188,12 @@ export class Graph {
   public toSubgraph(): string {
     return `subgraph ${this.id} [${this.title}]
   direction ${this.direction}
-  ${this.content()}`;
+    ${this.content()}
+  end`;
   }
 
   toString(): string {
-    return `
----
+    return `---
 title: ${this.title}
 ---
 flowchart ${this.direction}

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -12,19 +12,17 @@ import { type ExecutionContext } from '../execution-context';
 export type Id = string;
 let nextIdx = 0;
 const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
-function getId(): Id {
-  let idx = nextIdx++;
-  if (idx === 0) {
-    return 'a';
-  }
-
+export function getId(): Id {
+  let remaining = nextIdx++;
   let id = '';
-  while (idx > 0) {
-    const letter = ALPHABET[idx % ALPHABET.length];
+
+  do {
+    const letter = ALPHABET[remaining % ALPHABET.length];
     assert(letter !== undefined);
-    id += letter;
-    idx = Math.floor(idx / ALPHABET.length);
-  }
+    id = letter + id;
+    remaining = Math.floor(remaining / ALPHABET.length);
+  } while (remaining > 0);
+
   return id;
 }
 

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import assert from 'assert';
 

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -192,7 +192,7 @@ export class Graph {
     return `subgraph ${this.id} [${this.title}]
 ${'\t'.repeat(indents)}direction ${this.direction}
 ${this.content(indents)}
-end`;
+${indents > 0 ? '\t'.repeat(indents - 1) : ''}end`;
   }
 
   toString(): string {

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -24,15 +24,8 @@ function getId(): Id {
   return id;
 }
 
-export type NodeShape =
-  | {
-      start: '[';
-      end: ']';
-    }
-  | {
-      start: '(';
-      end: ')';
-    };
+// NOTE: The space is required, as it's a placeholder for the node's text
+export type NodeShape = '[ ]' | '( )';
 
 export class Node {
   private readonly _id: Id = getId();
@@ -43,7 +36,11 @@ export class Node {
   }
 
   toString(): string {
-    return this.id + this.shape.start + this.text + this.shape.end;
+    const [start, end, ...rem] = this.shape.split(' ');
+    assert(start !== undefined);
+    assert(end !== undefined);
+    assert(rem.length === 0);
+    return this.id + start + this.text + end;
   }
 }
 

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -166,11 +166,10 @@ export class Graph {
       this.classDefinitions,
       this.classAssignments,
     ]
-      .map((arr) => {
+      .flatMap((arr) => {
         const ar = Array.isArray(arr) ? arr : [...arr.values()];
-        return indent + ar.join(`\n${indent}`);
+        return ar.length > 0 ? [indent + ar.join(`\n${indent}`)] : [];
       })
-      .filter((s) => s !== '')
       .join('\n\n');
   }
 
@@ -198,7 +197,6 @@ end`;
 title: ${this.title}
 ---
 flowchart ${this.direction}
-${this.content(1)}
-`;
+${this.content(1)}`;
   }
 }

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -155,8 +155,8 @@ export class Graph {
   ) {
     const executor = context.executionExtension.createBlockExecutor(block);
 
-    const block_id = executor.addToGraph(this, parents, context);
-    this.blocks.set(block, block_id);
+    const blockId = executor.addToGraph(this, parents, context);
+    this.blocks.set(block, blockId);
   }
 
   private content(indents: number): string {

--- a/libs/execution/src/lib/util/mermaid-util.ts
+++ b/libs/execution/src/lib/util/mermaid-util.ts
@@ -116,10 +116,10 @@ export class ClassAssignment {
   }
 }
 
-export type GraphDirection = 'TD' | 'LR';
+export type GraphDirection = 'TB' | 'BT' | 'RL' | 'LR';
 export class Graph {
   private readonly _id: Id = getId();
-  private direction: GraphDirection = 'TD';
+  private direction: GraphDirection = 'TB';
   private nodes = new Map<Id, Node>();
 
   private edges = new Map<Id, Edge>();
@@ -156,21 +156,21 @@ export class Graph {
     this.blocks.set(block, block_id);
   }
 
-  private content(): string {
+  private content(indents: number): string {
+    const indent = '\t'.repeat(indents);
     return [
       this.nodes,
       this.edges,
-      [...this.subgraphs.values()].map((sg) => sg.toSubgraph()),
+      [...this.subgraphs.values()].map((sg) => sg.toSubgraph(indents + 1)),
       this.edgeAttributes,
       this.classDefinitions,
       this.classAssignments,
     ]
       .map((arr) => {
-        if (Array.isArray(arr)) {
-          return arr.join('\n\t');
-        }
-        return [...arr.values()].join('\n\t');
+        const ar = Array.isArray(arr) ? arr : [...arr.values()];
+        return indent + ar.join(`\n${indent}`);
       })
+      .filter((s) => s !== '')
       .join('\n\n');
   }
 
@@ -186,11 +186,11 @@ export class Graph {
     this.edges.set(edge.id, edge);
   }
 
-  public toSubgraph(): string {
+  public toSubgraph(indents: number): string {
     return `subgraph ${this.id} [${this.title}]
-  direction ${this.direction}
-    ${this.content()}
-  end`;
+${'\t'.repeat(indents)}direction ${this.direction}
+${this.content(indents)}
+end`;
   }
 
   toString(): string {
@@ -198,7 +198,7 @@ export class Graph {
 title: ${this.title}
 ---
 flowchart ${this.direction}
-  ${this.content()}
+${this.content(1)}
 `;
   }
 }

--- a/libs/interpreter-lib/src/interpreter.spec.ts
+++ b/libs/interpreter-lib/src/interpreter.spec.ts
@@ -336,8 +336,6 @@ flowchart TB
       expect(graph).not.toBe('No pipelines to graph');
       assert(graph !== 'No pipelines to graph');
 
-      console.log(graph);
-
       expect(graph.toString()).toBe(`---
 title: CarsPipeline
 ---
@@ -358,6 +356,67 @@ flowchart TB
 
 \t\to q@-->|File| p
 \t\tp s@-->|TextFile| r
+\tend`);
+    });
+    it('should graph models with two contained pipelines', async () => {
+      const assetPath =
+        'libs/interpreter-lib/test/assets/graph/two-pipelines.jv';
+      const model = readJvTestAsset(assetPath);
+
+      const interpreter = new DefaultJayveeInterpreter({
+        pipelineMatcher: () => true,
+        debug: true,
+        debugGranularity: 'peek',
+        debugTarget: 'all',
+        env: new Map(),
+      });
+
+      const program = await interpreter.parseModel((services, loggerFactory) =>
+        extractAstNodeFromString<JayveeModel>(
+          model,
+          services,
+          loggerFactory.createLogger(),
+        ),
+      );
+      expect(program).toBeDefined();
+      assert(program !== undefined);
+
+      const graph = interpreter.graphProgram(program);
+      expect(graph).not.toBe('No pipelines to graph');
+      assert(graph !== 'No pipelines to graph');
+
+      expect(graph.toString()).toBe(`---
+---
+flowchart TB
+\tsubgraph ba [CarsPipeline]
+\t\tdirection TB
+\t\tbb[CarsExtractor]
+\t\tbc[CarsTextFileInterpreter]
+\t\tbe[CarsCSVInterpreter]
+\t\tbg[NameHeaderWriter]
+\t\tbi[CarsTableInterpreter]
+\t\tbk[CarsLoader]
+
+\t\tbb bd@-->|File| bc
+\t\tbc bf@-->|TextFile| be
+\t\tbe bh@-->|Sheet| bg
+\t\tbg bj@-->|Sheet| bi
+\t\tbi bl@-->|Table| bk
+\tend
+\tsubgraph bm [ElectricVehiclesPipeline]
+\t\tdirection TB
+\t\tbn[ElectricVehiclesHttpExtractor]
+\t\tbo[ElectricVehiclesTextFileInterpreter]
+\t\tbq[ElectricVehiclesCSVInterpreter]
+\t\tbs[ElectricVehiclesTableInterpreter]
+\t\tbu[ElectricRangeTransformer]
+\t\tbw[ElectricVehiclesSQLiteLoader]
+
+\t\tbn bp@-->|File| bo
+\t\tbo br@-->|TextFile| bq
+\t\tbq bt@-->|Sheet| bs
+\t\tbs bv@-->|Table| bu
+\t\tbu bx@-->|Table| bw
 \tend`);
     });
   });

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -153,7 +153,7 @@ export interface JayveeInterpreter {
    * @returns a list of pipeline durations
    * {@link PipelineMeasure}
    */
-  listMeasures(): PipelineMeasurement[];
+  listMeasurements(): PipelineMeasurement[];
 
   /**
    * Clear all existing measurements.
@@ -274,7 +274,7 @@ export class DefaultJayveeInterpreter implements JayveeInterpreter {
     }
   }
 
-  listMeasures(): PipelineMeasurement[] {
+  listMeasurements(): PipelineMeasurement[] {
     return listMeasurements();
   }
 

--- a/libs/interpreter-lib/src/interpreter.ts
+++ b/libs/interpreter-lib/src/interpreter.ts
@@ -380,9 +380,11 @@ export class DefaultJayveeInterpreter implements JayveeInterpreter {
       );
     }
 
-    const name = path.basename(
-      program.model.$document?.uri.path ?? 'Unknown model',
-    );
+    const name =
+      program.model.$document !== undefined &&
+      program.model.$document.uri.path !== ''
+        ? path.basename(program.model.$document.uri.path)
+        : undefined;
     const graph = new Graph(name);
 
     for (const pipeline of selectedPipelines) {

--- a/libs/interpreter-lib/test/assets/graph/composite-block.jv
+++ b/libs/interpreter-lib/test/assets/graph/composite-block.jv
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline CarsPipeline {
+
+	Extractor
+		-> CarsTableInterpreter
+		-> CarsTableTransformer
+		-> CarsLoader;
+
+
+	block Extractor oftype CSVExtractor {
+		url: "https://gist.githubusercontent.com/noamross/e5d3e859aa0c794be10b/raw/b999fb4425b54c63cab088c0ce2c0d6ce961a563/cars.csv";
+		enclosing: '"';
+	}
+
+	block CarsTableInterpreter oftype TableInterpreter {
+		header: true;
+		columns: [
+			"name" oftype text,
+		];
+	}
+
+	transform copy {
+		from s oftype text;
+		to t oftype text;
+
+		t: s;
+	}
+
+	block CarsTableTransformer oftype TableTransformer {
+		inputColumns: [
+			"name",
+		];
+
+		outputColumn: "nameCopy";
+
+		uses: copy;
+	}
+
+	block CarsLoader oftype SQLiteLoader {
+		table: "Cars";
+		file: "./cars.sqlite";
+	}
+}
+
+composite blocktype CSVExtractor {
+	// Properties of the CSVExtractor, some with default values
+	property url oftype text;
+	property delimiter oftype text: ',';
+	property enclosing oftype text: '';
+	property enclosingEscape oftype text: '';
+
+	// Input and outputs
+	input inputName oftype None;
+	output outputName oftype Sheet;
+
+	// Pipeline definition from input, over blocks defined later, to output
+	inputName
+		->FileExtractor
+		->FileTextInterpreter
+		->FileCSVInterpreter
+		->outputName;
+
+	// Block definitions using values from properties by name
+	block FileExtractor oftype HttpExtractor {
+		url: url;
+	}
+	block FileTextInterpreter oftype TextFileInterpreter { }
+
+	block FileCSVInterpreter oftype CSVInterpreter {
+		delimiter: delimiter;
+		enclosing: enclosing;
+		enclosingEscape: enclosingEscape;
+	}
+}

--- a/libs/interpreter-lib/test/assets/graph/two-pipelines.jv
+++ b/libs/interpreter-lib/test/assets/graph/two-pipelines.jv
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pipeline CarsPipeline {
+
+	CarsExtractor
+		-> CarsTextFileInterpreter;
+
+	CarsTextFileInterpreter
+		-> CarsCSVInterpreter
+		-> NameHeaderWriter
+		-> CarsTableInterpreter
+		-> CarsLoader;
+
+	block CarsExtractor oftype HttpExtractor {
+		url: "https://gist.githubusercontent.com/noamross/e5d3e859aa0c794be10b/raw/b999fb4425b54c63cab088c0ce2c0d6ce961a563/cars.csv";
+	}
+
+	block CarsTextFileInterpreter oftype TextFileInterpreter { }
+
+	block CarsCSVInterpreter oftype CSVInterpreter {
+		enclosing: '"';
+	}
+
+	block NameHeaderWriter oftype CellWriter {
+		at: cell A1;
+
+		write: [
+			"name"
+		];
+	}
+
+	block CarsTableInterpreter oftype TableInterpreter {
+		header: true;
+		columns: [
+			"name" oftype text,
+			"mpg" oftype decimal,
+			"cyl" oftype integer,
+			"disp" oftype decimal,
+			"hp" oftype integer,
+			"drat" oftype decimal,
+			"wt" oftype decimal,
+			"qsec" oftype decimal,
+			"vs" oftype integer,
+			"am" oftype integer,
+			"gear" oftype integer,
+			"carb" oftype integer
+		];
+	}
+
+	block CarsLoader oftype SQLiteLoader {
+		table: "Cars";
+		file: "./cars.sqlite";
+	}
+}
+
+pipeline ElectricVehiclesPipeline {
+	// See here for meta-data of the data source
+	// https://catalog.data.gov/dataset/electric-vehicle-population-data/resource/fa51be35-691f-45d2-9f3e-535877965e69
+
+	// 2. At the top of a pipeline, we describe the
+	// structure of the pipeline. The first part until 
+	// the ElectricRangeTransformer is a linear sequence
+	// of blocks. From there we can see a split into two
+	// parallel sequences that load the data in to two
+	// different sinks.
+	ElectricVehiclesHttpExtractor
+		-> ElectricVehiclesTextFileInterpreter
+		-> ElectricVehiclesCSVInterpreter
+		-> ElectricVehiclesTableInterpreter
+		-> ElectricRangeTransformer;
+
+	ElectricRangeTransformer
+		-> ElectricVehiclesSQLiteLoader;
+
+	// 3. After the pipeline structure, we define the blocks used.
+	block ElectricVehiclesHttpExtractor oftype HttpExtractor {
+		url: "https://data.wa.gov/api/views/f6w7-q2d2/rows.csv?accessType=DOWNLOAD";
+	}
+
+	block ElectricVehiclesTextFileInterpreter oftype TextFileInterpreter { }
+
+	block ElectricVehiclesCSVInterpreter oftype CSVInterpreter { }
+
+	block ElectricVehiclesTableInterpreter oftype TableInterpreter {
+		header: true;
+		columns: [
+			"VIN (1-10)" oftype VehicleIdentificationNumber10,
+			"County" oftype text,
+			"City" oftype text,
+			"State" oftype text,
+			"Postal Code" oftype text,
+			"Model Year" oftype integer,
+			"Make" oftype text,
+			"Model" oftype text,
+			"Electric Vehicle Type" oftype text,
+			"Clean Alternative Fuel Vehicle (CAFV) Eligibility" oftype text,
+			"Electric Range" oftype integer,
+			"Base MSRP" oftype integer,
+			"Legislative District" oftype text,
+			"DOL Vehicle ID" oftype integer,
+			"Vehicle Location" oftype text,
+			"Electric Utility" oftype text,
+			"2020 Census Tract" oftype text,
+		];
+	}
+
+	block ElectricRangeTransformer oftype TableTransformer {
+		inputColumns: [
+			"Electric Range"
+		];
+		outputColumn: "Electric Range (km)";
+		uses: MilesToKilometers;
+	}
+
+	transform MilesToKilometers {
+		from miles oftype decimal;
+		to kilometers oftype integer;
+
+		kilometers: round (miles * 1.609344);
+	}
+
+	block ElectricVehiclesSQLiteLoader oftype SQLiteLoader {
+		table: "ElectricVehiclePopulationData";
+		file: "./electric-vehicles.sqlite";
+	}
+}
+
+valuetype VehicleIdentificationNumber10 oftype text {
+	constraints: [
+		OnlyCapitalLettersAndDigits,
+		ExactlyTenCharacters,
+	];
+}
+
+constraint OnlyCapitalLettersAndDigits on text: value matches /^[A-Z0-9]*$/;
+
+constraint ExactlyTenCharacters on text: value.length == 10;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "reproduce": "nx run interpreter:run -d repro.jv -dg exhaustive",
     "benchmark": "nx run benchmark:run",
     "example:cars": "nx run interpreter:run -d example/cars.jv -dg peek",
+    "graph:cars": "nx run interpreter:run -g example/cars.jv -d -dg peek",
     "example:gtfs": "nx run interpreter:run -d example/gtfs-static.jv -dg peek",
     "example:gtfs-rt": "nx run interpreter:run -d example/gtfs-rt.jv -dg peek",
     "example:workbooks": "nx run interpreter:run -d example/workbooks-xlsx.jv -dg peek",


### PR DESCRIPTION
Continues #517

This PR adds a new flag for the Jayvee interpreter `-g`/`--graph`. With this flag, the interpreter parses the model and generates a mermaid.js flowchart.

TODO:
- [x] Resolve `FIXME`s
- [x] ~~Decide how to handle edge ids~~ GitHub upgraded its mermaid version
- [x] Tests

Followup PRs:
- Implement block-specific nodes
- use class definitions
- Also display the initial input value in the graph. This means adding the parameter `initialInputValue: IOTypeImplementation | undefined = undefined` to `executionGraph()`
- Support more config options like `style` and `theme`