### PR TITLE
Update benchmark duration for cars from 30ms to 45ms

### DIFF
--- a/apps/benchmark/src/benchmark_definitions.json
+++ b/apps/benchmark/src/benchmark_definitions.json
@@ -4,7 +4,7 @@
     "modelPath": "example/cars.jv",
     "expectedMeasure": {
       "name": "cars",
-      "durationMs": 30,
+      "durationMs": 45,
       "blocks": []
     },
     "allowedDeviationFactor": 0.5


### PR DESCRIPTION
The CI fails because of the benchmarks. The execution speed hasn't changed significantly since creation, the 30ms duration was just a bit too optimistic.