### PR TITLE
Introduce .editorconfig and replace prettier's js config file with json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 # Confirms that this is the top-most EditorConfig file
 root = true
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# Confirms that this is the top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 2
+max_line_length = 80

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,0 @@
-// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
-//
-// SPDX-License-Identifier: AGPL-3.0-only
-
-module.exports = require('@jvalue/eslint-config-jvalue/.prettierrc.js');

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "all",
+  "singleQuote": true
+}

--- a/.prettierrc.json.license
+++ b/.prettierrc.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+
+SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION
This PR introduces an EditorConfig file, which allows [many editors](https://editorconfig.org/#pre-installed) to indent files correctly.
Additionally prettier's javascript config is replaced with a much simpler json.