### PR TITLE
[RFC14] Part 1: Replace valuetype inheritance with one attribute

### DIFF
--- a/apps/docs/docs/user/core-concepts.md
+++ b/apps/docs/docs/user/core-concepts.md
@@ -70,7 +70,8 @@ We differentiate the following kinds of _value types_:
 - _Compound value types_: UPCOMING.
 
 ```jayvee
-valuetype GasFillLevel oftype integer {
+valuetype GasFillLevel {
+    property level oftype integer;
     constraints: [ GasFillLevelRange ];
 }
 
@@ -125,7 +126,8 @@ use { GasFillLevelRange as FillLevelRange } './relative/path/to/file.jv'; // Ali
 
 // Then just use them as if they were defined on root level
 
-valuetype GasFillLevel oftype integer {
+valuetype GasFillLevel {
+    property level oftype integer;
     constraints: [ GasFillLevelRange ]; // GasFillLevelRange is defined in another file
 }
 ```

--- a/apps/docs/docs/user/value-types/primitive-value-types.md
+++ b/apps/docs/docs/user/value-types/primitive-value-types.md
@@ -9,7 +9,8 @@ Such _constraints_ are implicitly connected via a logical `AND` relation.
 Note that the _constraints_ need to be applicable to the base-type of the _value type_ - indicated by the identifier after the keyword `oftype`:
 
 ```jayvee
-valuetype GasFillLevel oftype integer {
+valuetype GasFillLevel {
+    property level oftype integer;
     constraints: [ GasFillLevelRange ];
 }
 ```

--- a/example/electric-vehicles.jv
+++ b/example/electric-vehicles.jv
@@ -9,19 +9,21 @@
 // - Understand the use of runtime parameters
 
 // 0. We can use elements defined in other files with the "use" syntax.
-// In this case, we use the value type UsStateCode when later specifying the table column value types. 
-use { UsStateCode } from './state-codes.jv';
+// In this case, we use the value type UsStateCode when later specifying the table column value types.
+use {
+  UsStateCode
+} from './state-codes.jv';
 
 
-// 1. This Jayvee model describes a pipeline 
-// from a CSV file in the web 
+// 1. This Jayvee model describes a pipeline
+// from a CSV file in the web
 // to a SQLite file and a PostgreSQL db sink.
 pipeline ElectricVehiclesPipeline {
   // See here for meta-data of the data source
   // https://catalog.data.gov/dataset/electric-vehicle-population-data/resource/fa51be35-691f-45d2-9f3e-535877965e69
 
   // 2. At the top of a pipeline, we describe the
-  // structure of the pipeline. The first part until 
+  // structure of the pipeline. The first part until
   // the ElectricRangeTransformer is a linear sequence
   // of blocks. From there we can see a split into two
   // parallel sequences that load the data in to two
@@ -52,7 +54,7 @@ pipeline ElectricVehiclesPipeline {
     columns: [
       // 4. Here, a user-deifned value type is used to describe this column.
       // The capital letter indicates that the value type is not built-in
-      // by convention. The value type itself is defined further below. 
+      // by convention. The value type itself is defined further below.
       "VIN (1-10)" oftype VehicleIdentificationNumber10,
       "County" oftype text,
       "City" oftype text,
@@ -75,7 +77,7 @@ pipeline ElectricVehiclesPipeline {
 
   // 5. This block describes the application of a transform function
   // taking a column as input and adding another computed column.
-  // The applied transform function is defined below and referenced 
+  // The applied transform function is defined below and referenced
   // by the "use" property.
   block ElectricRangeTransformer oftype TableTransformer {
     inputColumns: [
@@ -92,7 +94,7 @@ pipeline ElectricVehiclesPipeline {
     from miles oftype decimal;
     to kilometers oftype integer;
 
-    // 7. In order to express what the transform function does, 
+    // 7. In order to express what the transform function does,
     // we assign an expression to the output. Values from the input and output of the transform can be referred to by name.
     kilometers: round (miles * 1.609344);
   }
@@ -117,7 +119,8 @@ pipeline ElectricVehiclesPipeline {
 // 9. Below the pipeline, we model user-define value types.
 // We give them a speaking name and provide a base value type
 // that this value type builts on. User-defined value types always place additional constraints on existing value types.
-valuetype VehicleIdentificationNumber10 oftype text {
+valuetype VehicleIdentificationNumber10 {
+  property id oftype text;
   // 10. Value types can be further refined by providing constraints.
   constraints: [
     OnlyCapitalLettersAndDigits,
@@ -125,7 +128,7 @@ valuetype VehicleIdentificationNumber10 oftype text {
   ];
 }
 
-// 11. This constraint works on text value types and requires values 
+// 11. This constraint works on text value types and requires values
 // to match a given regular expression in order to be valid.
 constraint OnlyCapitalLettersAndDigits on text: value matches /^[A-Z0-9]*$/;
 

--- a/example/state-codes.jv
+++ b/example/state-codes.jv
@@ -7,7 +7,8 @@
 // - Understand how to publish elements to use them in other files
 
 // 1. The publish keyword can be used directly when defining an element.
-publish valuetype UsStateCode oftype text {
+publish valuetype UsStateCode {
+  property code oftype text;
   constraints: [
     UsStateCodeAllowlist,
   ];

--- a/libs/interpreter-lib/test/assets/graph/two-pipelines.jv
+++ b/libs/interpreter-lib/test/assets/graph/two-pipelines.jv
@@ -127,7 +127,8 @@ pipeline ElectricVehiclesPipeline {
 	}
 }
 
-valuetype VehicleIdentificationNumber10 oftype text {
+valuetype VehicleIdentificationNumber10 {
+	property attr oftype text;
 	constraints: [
 		OnlyCapitalLettersAndDigits,
 		ExactlyTenCharacters,

--- a/libs/language-server/src/grammar/value-type.langium
+++ b/libs/language-server/src/grammar/value-type.langium
@@ -13,9 +13,13 @@ BuiltinValuetypeDefinition infers ValuetypeDefinition:
 CustomValuetypeDefinition infers ValuetypeDefinition:
   'valuetype' name=ID 
     (genericDefinition=ValuetypeGenericsDefinition)?
-  'oftype' type=ValueTypeReference '{'
+  '{'
+    attribute=ValueTypeAttribute
     'constraints' ':' constraints=CollectionLiteral ';'
   '}';
+
+ValueTypeAttribute:
+  'property' name=ID 'oftype' type=ValueTypeReference ';';
 
 ValuetypeAssignmentLiteral:
   value=ValuetypeAssignment;

--- a/libs/language-server/src/lib/ast/value-definition.spec.ts
+++ b/libs/language-server/src/lib/ast/value-definition.spec.ts
@@ -33,7 +33,7 @@ describe('Parsing of ValuetypeDefinition', () => {
     const document = await parse(text);
     expect(document.parseResult.parserErrors.length).toBeGreaterThanOrEqual(1);
     expect(document.parseResult.parserErrors[0]?.message).toBe(
-      "Expecting token of type 'oftype' but found `;`.",
+      "Expecting token of type '{' but found `;`.",
     );
   });
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
@@ -90,8 +90,7 @@ export class AtomicValueType
   }
 
   protected override doGetSupertype(): ValueType | undefined {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    const supertype = this.astNode?.type;
+    const supertype = this.astNode.attribute?.type;
     return this.wrapperFactories.ValueType.wrap(supertype);
   }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
@@ -90,7 +90,8 @@ export class AtomicValueType
   }
 
   protected override doGetSupertype(): ValueType | undefined {
-    const supertype = this.astNode.attribute?.type;
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const supertype = this.astNode?.attribute?.type;
     return this.wrapperFactories.ValueType.wrap(supertype);
   }
 

--- a/libs/language-server/src/lib/validation/checks/value-type-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/value-type-definition.ts
@@ -41,11 +41,12 @@ function checkSupertypeCycle(
     )?.hasSupertypeCycle() ?? false;
   if (hasCycle) {
     assert(!valueTypeDefinition.isBuiltin);
+    assert(valueTypeDefinition.attribute?.type !== undefined);
     props.validationContext.accept(
       'error',
       'Could not construct this value type since there is a cycle in the (transitive) "oftype" relation.',
       {
-        node: valueTypeDefinition,
+        node: valueTypeDefinition.attribute,
         property: 'type',
       },
     );

--- a/libs/language-server/src/lib/validation/checks/value-type-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/value-type-definition.ts
@@ -40,8 +40,14 @@ function checkSupertypeCycle(
       valueTypeDefinition,
     )?.hasSupertypeCycle() ?? false;
   if (hasCycle) {
-    assert(!valueTypeDefinition.isBuiltin);
-    assert(valueTypeDefinition.attribute?.type !== undefined);
+    assert(
+      !valueTypeDefinition.isBuiltin,
+      "`builtin` valuetypes don't have cycles",
+    );
+    assert(
+      valueTypeDefinition.attribute?.type !== undefined,
+      '`hasCycle == true`, so `valueTypeDefinition` MUST have an attribute with a type',
+    );
     props.validationContext.accept(
       'error',
       'Could not construct this value type since there is a cycle in the (transitive) "oftype" relation.',

--- a/libs/language-server/src/lib/validation/checks/value-type-reference.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/value-type-reference.spec.ts
@@ -64,7 +64,7 @@ describe('Validation of ValueTypeReference', () => {
     for (let i = 0; i < allValueTypes.length; ++i) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const valueTypeDefinition = allValueTypes[i]!;
-      const valueTypeRef = valueTypeDefinition.type;
+      const valueTypeRef = valueTypeDefinition.attribute?.type;
       assert(valueTypeRef !== undefined);
       valueTypeReferences.push(valueTypeRef);
     }

--- a/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha2.jv
+++ b/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha2.jv
@@ -6,7 +6,7 @@
 * Alpha-2 code for countries as defined by ISO 3166.
 */
 publish valuetype CountryCodeAlpha2 {
-  property attr oftype text;
+  property code oftype text;
   constraints: [
     CountryCodeAlpha2Constraint
   ];

--- a/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha2.jv
+++ b/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha2.jv
@@ -5,7 +5,8 @@
 /**
 * Alpha-2 code for countries as defined by ISO 3166.
 */
-publish valuetype CountryCodeAlpha2 oftype text {
+publish valuetype CountryCodeAlpha2 {
+  property attr oftype text;
   constraints: [
     CountryCodeAlpha2Constraint
   ];

--- a/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha3.jv
+++ b/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha3.jv
@@ -6,7 +6,7 @@
 * Alpha-3 code for countries as defined by ISO 3166.
 */
 publish valuetype CountryCodeAlpha3 {
-  property attr oftype text;
+  property code oftype text;
   constraints: [
     CountryCodeAlpha3Constraint
   ];

--- a/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha3.jv
+++ b/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha3.jv
@@ -5,7 +5,8 @@
 /**
 * Alpha-3 code for countries as defined by ISO 3166.
 */
-publish valuetype CountryCodeAlpha3 oftype text {
+publish valuetype CountryCodeAlpha3 {
+  property attr oftype text;
   constraints: [
     CountryCodeAlpha3Constraint
   ];

--- a/libs/language-server/src/stdlib/domain/geo/CountryCodeNumeric.jv
+++ b/libs/language-server/src/stdlib/domain/geo/CountryCodeNumeric.jv
@@ -6,7 +6,7 @@
 * Numeric code for countries as defined by ISO 3166.
 */
 publish valuetype CountryCodeNumeric {
-  property attr oftype text;
+  property code oftype text;
   constraints: [
     CountryCodeNumericConstraint
   ];

--- a/libs/language-server/src/stdlib/domain/geo/CountryCodeNumeric.jv
+++ b/libs/language-server/src/stdlib/domain/geo/CountryCodeNumeric.jv
@@ -5,7 +5,8 @@
 /**
 * Numeric code for countries as defined by ISO 3166.
 */
-publish valuetype CountryCodeNumeric oftype text {
+publish valuetype CountryCodeNumeric {
+  property attr oftype text;
   constraints: [
     CountryCodeNumericConstraint
   ];

--- a/libs/language-server/src/stdlib/domain/material-science/MaterialScienceValueTypes.jv
+++ b/libs/language-server/src/stdlib/domain/material-science/MaterialScienceValueTypes.jv
@@ -8,7 +8,7 @@ constraint DOIFormat on text: value matches /\b10\.\d{4}\/[^\s]+\b/;
 * The `DOIStandardizer` block can remove common prefixes to this pattern, with the result matching this format.
 */
 publish valuetype DOI {
-	property attr oftype text;
+	property doi oftype text;
 	constraints: [
 		DOIFormat
 	];
@@ -17,7 +17,7 @@ publish valuetype DOI {
 constraint DateFormatYYYYMMDDRegex on text: value matches /\d{4}-\d{2}-\d{2}/;
 /** DateFormat as YYYY-MM-DD */
 publish valuetype DateYYYYMMDD {
-	property attr oftype text;
+	property date oftype text;
 	constraints: [
 		DateFormatYYYYMMDDRegex
 	];
@@ -26,7 +26,7 @@ publish valuetype DateYYYYMMDD {
 constraint SiUnitConstraint on text: value matches /\b((Second|Metre|Kilogram|Ampere|Kelvin|Mole|Candela)+\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constraining the Unit column to be of a specific format like "Second^(1.0)", "Ampere^(1.0)" or "Candela^(1.0)". */
 publish valuetype SiUnit {
-	property attr oftype text;
+	property unit oftype text;
 	constraints: [
 		SiUnitConstraint
 	];
@@ -35,7 +35,7 @@ publish valuetype SiUnit {
 constraint PressureUnitPascalConstraint on text: value matches /\b(Pascal\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constrains Pressure units to be Pascal^(x). */
 publish valuetype PressureUnitPascal {
-	property attr oftype text;
+	property unit oftype text;
 	constraints: [
 		PressureUnitPascalConstraint
 	];
@@ -44,7 +44,7 @@ publish valuetype PressureUnitPascal {
 constraint LengthUnitMeterConstraint on text: value matches /\b(Meter\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constrains Length units to be Meter^(x). */
 publish valuetype LengthUnitMeter {
-	property attr oftype text;
+	property unit oftype text;
 	constraints: [
 		LengthUnitMeterConstraint
 	];
@@ -54,7 +54,7 @@ publish valuetype LengthUnitMeter {
 constraint TemperatureUnitKelvinConstraint on text: value matches /\b(Kelvin\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constrains Temperature units to be Kelvin^(x). */
 publish valuetype TemperatureUnitKelvin {
-	property attr oftype text;
+	property unit oftype text;
 	constraints: [
 		TemperatureUnitKelvinConstraint
 	];

--- a/libs/language-server/src/stdlib/domain/material-science/MaterialScienceValueTypes.jv
+++ b/libs/language-server/src/stdlib/domain/material-science/MaterialScienceValueTypes.jv
@@ -7,7 +7,8 @@ constraint DOIFormat on text: value matches /\b10\.\d{4}\/[^\s]+\b/;
 * DOI Format has been constrained by a standard pattern, eg: 10.1007/xxxx
 * The `DOIStandardizer` block can remove common prefixes to this pattern, with the result matching this format.
 */
-publish valuetype DOI oftype text {
+publish valuetype DOI {
+	property attr oftype text;
 	constraints: [
 		DOIFormat
 	];
@@ -15,7 +16,8 @@ publish valuetype DOI oftype text {
 
 constraint DateFormatYYYYMMDDRegex on text: value matches /\d{4}-\d{2}-\d{2}/;
 /** DateFormat as YYYY-MM-DD */
-publish valuetype DateYYYYMMDD oftype text {
+publish valuetype DateYYYYMMDD {
+	property attr oftype text;
 	constraints: [
 		DateFormatYYYYMMDDRegex
 	];
@@ -23,7 +25,8 @@ publish valuetype DateYYYYMMDD oftype text {
 
 constraint SiUnitConstraint on text: value matches /\b((Second|Metre|Kilogram|Ampere|Kelvin|Mole|Candela)+\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constraining the Unit column to be of a specific format like "Second^(1.0)", "Ampere^(1.0)" or "Candela^(1.0)". */
-publish valuetype SiUnit oftype text {
+publish valuetype SiUnit {
+	property attr oftype text;
 	constraints: [
 		SiUnitConstraint
 	];
@@ -31,7 +34,8 @@ publish valuetype SiUnit oftype text {
 
 constraint PressureUnitPascalConstraint on text: value matches /\b(Pascal\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constrains Pressure units to be Pascal^(x). */
-publish valuetype PressureUnitPascal oftype text {
+publish valuetype PressureUnitPascal {
+	property attr oftype text;
 	constraints: [
 		PressureUnitPascalConstraint
 	];
@@ -39,7 +43,8 @@ publish valuetype PressureUnitPascal oftype text {
 
 constraint LengthUnitMeterConstraint on text: value matches /\b(Meter\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constrains Length units to be Meter^(x). */
-publish valuetype LengthUnitMeter oftype text {
+publish valuetype LengthUnitMeter {
+	property attr oftype text;
 	constraints: [
 		LengthUnitMeterConstraint
 	];
@@ -48,7 +53,8 @@ publish valuetype LengthUnitMeter oftype text {
 
 constraint TemperatureUnitKelvinConstraint on text: value matches /\b(Kelvin\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constrains Temperature units to be Kelvin^(x). */
-publish valuetype TemperatureUnitKelvin oftype text {
+publish valuetype TemperatureUnitKelvin {
+	property attr oftype text;
 	constraints: [
 		TemperatureUnitKelvinConstraint
 	];

--- a/libs/language-server/src/stdlib/domain/mobility/GTFSValueTypes.jv
+++ b/libs/language-server/src/stdlib/domain/mobility/GTFSValueTypes.jv
@@ -12,7 +12,7 @@
  */
 publish constraint GTFSColorConstraint on text: value matches /^[A-F]{6}$/;
 publish valuetype GTFSColor {
-    property attr oftype text;
+    property color oftype text;
     constraints: [GTFSColorConstraint];
 }
 
@@ -22,7 +22,7 @@ publish valuetype GTFSColor {
  */
 publish constraint DateYYYYMMDD on text: value matches /^[0-9]{4}[0-9]{2}[0-9]{2}$/;
 publish valuetype GTFSDate {
-    property attr oftype text;
+    property date oftype text;
     constraints: [DateYYYYMMDD];
 }
 
@@ -32,7 +32,7 @@ publish valuetype GTFSDate {
  */
 publish constraint CurrencyConstraint on text: value matches /^[A-Z]{3}$/;
 publish valuetype GTFSCurrency {
-    property attr oftype text;
+    property currency oftype text;
     constraints: [CurrencyConstraint];
 }
 
@@ -42,7 +42,7 @@ publish valuetype GTFSCurrency {
  */
 publish constraint TimeHHMMSS on text: value matches /^[0-9]{1,2}:{1}[0-9]{2}:{1}[0-9]{2}$/;
 publish valuetype GTFSTime {
-    property attr oftype text;
+    property time oftype text;
     constraints: [TimeHHMMSS];
 }
 
@@ -52,17 +52,17 @@ publish constraint EnumOneOrTwo on integer: value in [1, 2];
 publish constraint EnumThree on integer: value in [0, 1, 2];
 
 publish valuetype GTFSEnumTwo {
-    property attr oftype integer;
+    property number oftype integer;
     constraints: [EnumTwo];
 }
 
 publish valuetype GTFSEnumOneOrTwo {
-    property attr oftype integer;
+    property number oftype integer;
     constraints: [EnumOneOrTwo];
 }
 
 publish valuetype GTFSEnumThree {
-    property attr oftype integer;
+    property number oftype integer;
     constraints: [EnumThree];
 }
 
@@ -74,7 +74,7 @@ publish valuetype GTFSEnumThree {
  */
 publish constraint Latitude on decimal: value >= -90 and value <= 90;
 publish valuetype GTFSLatitude {
-    property attr oftype decimal;
+    property latitude oftype decimal;
     constraints: [Latitude];
 }
 
@@ -84,18 +84,18 @@ publish valuetype GTFSLatitude {
  */
 publish constraint Longitude on decimal: value >= -180 and value <= 180;
 publish valuetype GTFSLongitude {
-    property attr oftype decimal;
+    property longitude oftype decimal;
     constraints: [Longitude];
 }
 
 publish constraint NonNegativeNumber on decimal: value >= 0;
 publish valuetype GTFSNonNegativeDecimal {
-    property attr oftype decimal;
+    property number oftype decimal;
     constraints: [NonNegativeNumber];
 }
 
 publish valuetype GTFSNonNegativeInteger {
-    property attr oftype integer;
+    property number oftype integer;
     constraints: [NonNegativeNumber];
 }
 
@@ -104,6 +104,6 @@ publish valuetype GTFSNonNegativeInteger {
  */
 publish constraint URLIncludingSchema on text: value matches /^(http)s?(:\/\/)/;
 publish valuetype GTFSUrl {
-    property attr oftype text;
+    property url oftype text;
     constraints: [URLIncludingSchema];
 }

--- a/libs/language-server/src/stdlib/domain/mobility/GTFSValueTypes.jv
+++ b/libs/language-server/src/stdlib/domain/mobility/GTFSValueTypes.jv
@@ -11,7 +11,8 @@
  *      Example: FFFFFF for white, 000000 for black or 0039A6 for the A,C,E lines in NYMTA.
  */
 publish constraint GTFSColorConstraint on text: value matches /^[A-F]{6}$/;
-publish valuetype GTFSColor oftype text {
+publish valuetype GTFSColor {
+    property attr oftype text;
     constraints: [GTFSColorConstraint];
 }
 
@@ -20,7 +21,8 @@ publish valuetype GTFSColor oftype text {
  *      Example: 20180913 for September 13th, 2018.
  */
 publish constraint DateYYYYMMDD on text: value matches /^[0-9]{4}[0-9]{2}[0-9]{2}$/;
-publish valuetype GTFSDate oftype text {
+publish valuetype GTFSDate {
+    property attr oftype text;
     constraints: [DateYYYYMMDD];
 }
 
@@ -29,7 +31,8 @@ publish valuetype GTFSDate oftype text {
  *      Example: CAD for Canadian dollars, EUR for euros or JPY for Japanese yen.
  */
 publish constraint CurrencyConstraint on text: value matches /^[A-Z]{3}$/;
-publish valuetype GTFSCurrency oftype text {
+publish valuetype GTFSCurrency {
+    property attr oftype text;
     constraints: [CurrencyConstraint];
 }
 
@@ -38,7 +41,8 @@ publish valuetype GTFSCurrency oftype text {
  *      Example: 14:30:00 for 2:30PM or 25:35:00 for 1:35AM on the next day.
  */
 publish constraint TimeHHMMSS on text: value matches /^[0-9]{1,2}:{1}[0-9]{2}:{1}[0-9]{2}$/;
-publish valuetype GTFSTime oftype text {
+publish valuetype GTFSTime {
+    property attr oftype text;
     constraints: [TimeHHMMSS];
 }
 
@@ -47,15 +51,18 @@ publish constraint EnumTwo on integer: value in [0, 1];
 publish constraint EnumOneOrTwo on integer: value in [1, 2];
 publish constraint EnumThree on integer: value in [0, 1, 2];
 
-publish valuetype GTFSEnumTwo oftype integer {
+publish valuetype GTFSEnumTwo {
+    property attr oftype integer;
     constraints: [EnumTwo];
 }
 
-publish valuetype GTFSEnumOneOrTwo oftype integer {
+publish valuetype GTFSEnumOneOrTwo {
+    property attr oftype integer;
     constraints: [EnumOneOrTwo];
 }
 
-publish valuetype GTFSEnumThree oftype integer {
+publish valuetype GTFSEnumThree {
+    property attr oftype integer;
     constraints: [EnumThree];
 }
 
@@ -66,7 +73,8 @@ publish valuetype GTFSEnumThree oftype integer {
  *      Example: 41.890169 for the Colosseum in Rome.
  */
 publish constraint Latitude on decimal: value >= -90 and value <= 90;
-publish valuetype GTFSLatitude oftype decimal {
+publish valuetype GTFSLatitude {
+    property attr oftype decimal;
     constraints: [Latitude];
 }
 
@@ -75,16 +83,19 @@ publish valuetype GTFSLatitude oftype decimal {
  *      Example: 12.492269 for the Colosseum in Rome.
  */
 publish constraint Longitude on decimal: value >= -180 and value <= 180;
-publish valuetype GTFSLongitude oftype decimal {
+publish valuetype GTFSLongitude {
+    property attr oftype decimal;
     constraints: [Longitude];
 }
 
 publish constraint NonNegativeNumber on decimal: value >= 0;
-publish valuetype GTFSNonNegativeDecimal oftype decimal {
+publish valuetype GTFSNonNegativeDecimal {
+    property attr oftype decimal;
     constraints: [NonNegativeNumber];
 }
 
-publish valuetype GTFSNonNegativeInteger oftype integer {
+publish valuetype GTFSNonNegativeInteger {
+    property attr oftype integer;
     constraints: [NonNegativeNumber];
 }
 
@@ -92,6 +103,7 @@ publish valuetype GTFSNonNegativeInteger oftype integer {
  * URL - A fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See the following http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values.
  */
 publish constraint URLIncludingSchema on text: value matches /^(http)s?(:\/\/)/;
-publish valuetype GTFSUrl oftype text {
+publish valuetype GTFSUrl {
+    property attr oftype text;
     constraints: [URLIncludingSchema];
 }

--- a/libs/language-server/src/stdlib/percent.jv
+++ b/libs/language-server/src/stdlib/percent.jv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 publish valuetype Percent {
-    property attr oftype decimal;
+    property value oftype decimal;
     constraints: [ZeroToHundredDecimal];
 }
 publish constraint ZeroToHundredDecimal on decimal: value >= 0 and value <= 100;

--- a/libs/language-server/src/stdlib/percent.jv
+++ b/libs/language-server/src/stdlib/percent.jv
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-publish valuetype Percent oftype decimal {
+publish valuetype Percent {
+    property attr oftype decimal;
     constraints: [ZeroToHundredDecimal];
 }
 publish constraint ZeroToHundredDecimal on decimal: value >= 0 and value <= 100;

--- a/libs/language-server/src/test/assets/jayvee-model/invalid-duplicate-name-with-builtin-value-type.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/invalid-duplicate-name-with-builtin-value-type.jv
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype DuplicateValueTypeName oftype text {
-	constraints: [
-		Constraint,
-	];
+valuetype DuplicateValueTypeName {
+  property attr oftype text;
+  constraints: [
+    Constraint,
+  ];
 }
 
 builtin valuetype DuplicateValueTypeName;

--- a/libs/language-server/src/test/assets/jayvee-model/invalid-non-unique-different-element-types.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/invalid-non-unique-different-element-types.jv
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype DuplicateName oftype text {
-	constraints: [];
+valuetype DuplicateName {
+  property attr oftype text;
+  constraints: [ ];
 }
 
-pipeline DuplicateName {} 
+pipeline DuplicateName { } 

--- a/libs/language-server/src/test/assets/jayvee-model/invalid-non-unique-value-types.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/invalid-non-unique-value-types.jv
@@ -2,14 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype DuplicateValueTypeName oftype text {
-	constraints: [
-		Constraint,
-	];
+valuetype DuplicateValueTypeName {
+  property attr oftype text;
+  constraints: [
+    Constraint,
+  ];
 }
 
-valuetype DuplicateValueTypeName oftype text {
-	constraints: [
-		Constraint,
-	];
+valuetype DuplicateValueTypeName {
+  property attr oftype text;
+  constraints: [
+    Constraint,
+  ];
 }

--- a/libs/language-server/src/test/assets/jayvee-model/valid-duplicate-name-with-builtin.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/valid-duplicate-name-with-builtin.jv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 // File is an io type as well
-valuetype File oftype text {
-	constraints: [];
+valuetype File {
+  property attr oftype text;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/jayvee-model/valid-duplicate-name-with-pipeline-element.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/valid-duplicate-name-with-pipeline-element.jv
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype DuplicateName oftype text {
-	constraints: [];
+valuetype DuplicateName {
+  property attr oftype text;
+  constraints: [ ];
 }
 
 pipeline TestPipeline {
-  valuetype DuplicateName oftype text {
-    constraints: [];
+  valuetype DuplicateName {
+    property attr oftype text;
+    constraints: [ ];
   }
 }

--- a/libs/language-server/src/test/assets/property-body/invalid-property-validation-failed.jv
+++ b/libs/language-server/src/test/assets/property-body/invalid-property-validation-failed.jv
@@ -17,7 +17,8 @@ builtin blocktype TestProperty {
   property customValidationTextProperty oftype CustomValuetype;
 }
 
-valuetype CustomValuetype oftype text {
+valuetype CustomValuetype {
+  property attr oftype text;
   constraints: [CustomConstraint];
 }
 

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-duplicate-generic.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-duplicate-generic.jv
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType<T, T> oftype text {
-    constraints: [];
+valuetype ValueType<T, T> {
+  property attr oftype text;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-invalid-constraint-type-for-value-type.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-invalid-constraint-type-for-value-type.jv
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-constraint Constraint on integer:
-	value > 10;
+constraint Constraint on integer: value>10;
 
-valuetype ValueType oftype text {
-	constraints: [
-		Constraint
-	];
+valuetype ValueType {
+  property attr oftype text;
+  constraints: [
+    Constraint
+  ];
 }

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-invalid-constraints-item.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-invalid-constraints-item.jv
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType oftype text {
-	constraints: [
-    10 > 9
+valuetype ValueType {
+  property attr oftype text;
+  constraints: [
+    10>9
   ];
 }

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-missing-generic.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-missing-generic.jv
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType<> oftype text {
-    constraints: [];
+valuetype ValueType<> {
+  proptery attr oftype text;
+  constraints: [];
 };

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-supertype-cycle.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-supertype-cycle.jv
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType oftype ValueType {
-	constraints: [];
+valuetype ValueType {
+  property self oftype ValueType;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-definition/valid-value-type-definition.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/valid-value-type-definition.jv
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType oftype text {
-	constraints: [];
+valuetype ValueType {
+  property attr oftype text;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/invalid-reference-missing-generic.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/invalid-reference-missing-generic.jv
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType <S, T> oftype text {
-    constraints: [];
+valuetype ValueType<S, T> {
+  property attr oftype text;
+  constraints: [ ];
 }
 
-valuetype Ref oftype ValueType {
-    constraints: [];
+valuetype Ref {
+  property ref oftype ValueType;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/invalid-reference-to-non-referenceable-value-type-in-value-type.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/invalid-reference-to-non-referenceable-value-type-in-value-type.jv
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType1 oftype Constraint {
-    constraints: [];
+valuetype ValueType1 {
+  property constr oftype Constraint;
+  constraints: [ ];
 }
 
-valuetype ValueType2 oftype Regex {
-    constraints: [];
+valuetype ValueType2 {
+  property rege oftype Regex;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-few-generic-parameters.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-few-generic-parameters.jv
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType <S, T> oftype text {
-    constraints: [];
+valuetype ValueType<S, T> {
+  property attr oftype text;
+  constraints: [ ];
 }
 
-valuetype Ref oftype ValueType<text> {
-    constraints: [];
+valuetype Ref {
+  property attr oftype ValueType<text>;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-many-generic-parameters.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-many-generic-parameters.jv
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType <S, T> oftype text {
-    constraints: [];
+valuetype ValueType<S, T> {
+  property attr oftype text;
+  constraints: [ ];
 }
 
-valuetype Ref oftype ValueType<text, integer, text> {
-    constraints: [];
+valuetype Ref {
+  property ref oftype ValueType<text, integer, text>;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-non-generic-with-generic-parameters.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-non-generic-with-generic-parameters.jv
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType oftype text {
-    constraints: [];
+valuetype ValueType {
+  property attr oftype text;
+  constraints: [ ];
 }
 
-valuetype Ref oftype ValueType<text> {
-    constraints: [];
+valuetype Ref {
+  property ref oftype ValueType<text>;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-multiple-generic-value-type.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-multiple-generic-value-type.jv
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType <S, T, R, Q, P> oftype text {
-    constraints: [];
+valuetype ValueType<S, T, R, Q, P> {
+  property attr oftype text;
+  constraints: [ ];
 }
 
-valuetype Ref oftype ValueType<text, integer, decimal, text, text> {
-    constraints: [];
+valuetype Ref {
+  property ref oftype ValueType<text, integer, decimal, text, text>;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-non-generic-value-type.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-non-generic-value-type.jv
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType oftype text {
-    constraints: [];
+valuetype ValueType {
+  property attr oftype text;
+  constraints: [ ];
 }
 
-valuetype Ref oftype ValueType {
-    constraints: [];
+valuetype Ref {
+  property ref oftype ValueType;
+  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-non-referenceable-value-type-in-builtin-block-type.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-non-referenceable-value-type-in-builtin-block-type.jv
@@ -3,5 +3,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 builtin blocktype MyBlockType {
-    property x oftype Constraint;
+  property x oftype Constraint;
 }

--- a/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-single-generic-value-type.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-single-generic-value-type.jv
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-valuetype ValueType<T> oftype text {
-    constraints: [];
+valuetype ValueType<T> {
+  property attr oftype text;
+  constraints: [ ];
 }
 
-valuetype Ref oftype ValueType<text> {
-    constraints: [];
+valuetype Ref {
+  property ref oftype ValueType<text>;
+  constraints: [ ];
 }


### PR DESCRIPTION
Part 1 of implementing RFC14.

This PR replaces the valuetype's existing inheritance syntax with composition, specifically one attribute.

Example of the previous syntax:
```
valuetype SomeName oftype text {
    constraints: [
        // ...
    ];
}
```

Example of the new syntax:
```
valuetype SomeName {
    property someAttributeName oftype text;
    constraints: [
        // ...
    ];
}
```
For now, there has to be exactly one attribute, the name of which is completely irrelevant.