### PR TITLE
[RFC14] Part 2: Replace constraint array with a flat syntax

### DIFF
--- a/apps/docs/docs/user/core-concepts.md
+++ b/apps/docs/docs/user/core-concepts.md
@@ -72,7 +72,7 @@ We differentiate the following kinds of _value types_:
 ```jayvee
 valuetype GasFillLevel {
     property level oftype integer;
-    constraints: [ GasFillLevelRange ];
+    constraint levelRange: GasFillLevelRange on level;
 }
 
 constraint GasFillLevelRange on decimal:
@@ -128,7 +128,7 @@ use { GasFillLevelRange as FillLevelRange } './relative/path/to/file.jv'; // Ali
 
 valuetype GasFillLevel {
     property level oftype integer;
-    constraints: [ GasFillLevelRange ]; // GasFillLevelRange is defined in another file
+    constraint levelRange: GasFillLevelRange on level; // GasFillLevelRange is defined in another file
 }
 ```
 

--- a/apps/docs/docs/user/value-types/primitive-value-types.md
+++ b/apps/docs/docs/user/value-types/primitive-value-types.md
@@ -11,7 +11,7 @@ Note that the _constraints_ need to be applicable to the base-type of the _value
 ```jayvee
 valuetype GasFillLevel {
     property level oftype integer;
-    constraints: [ GasFillLevelRange ];
+    constraint levelRange: GasFillLevelRange on level;
 }
 ```
 

--- a/example/electric-vehicles.jv
+++ b/example/electric-vehicles.jv
@@ -122,10 +122,8 @@ pipeline ElectricVehiclesPipeline {
 valuetype VehicleIdentificationNumber10 {
   property id oftype text;
   // 10. Value types can be further refined by providing constraints.
-  constraints: [
-    OnlyCapitalLettersAndDigits,
-    ExactlyTenCharacters,
-  ];
+  constraint capitalized: OnlyCapitalLettersAndDigits on id;
+  constraint len: ExactlyTenCharacters on id;
 }
 
 // 11. This constraint works on text value types and requires values

--- a/example/state-codes.jv
+++ b/example/state-codes.jv
@@ -9,9 +9,7 @@
 // 1. The publish keyword can be used directly when defining an element.
 publish valuetype UsStateCode {
   property code oftype text;
-  constraints: [
-    UsStateCodeAllowlist,
-  ];
+  constraint allowed: UsStateCodeAllowlist on code;
 }
 
 // 2. The publish keyword can be used after a definition as well (see below).

--- a/libs/execution/src/lib/types/value-types/value-representation-validity.ts
+++ b/libs/execution/src/lib/types/value-types/value-representation-validity.ts
@@ -50,9 +50,7 @@ class ValueRepresentationValidityVisitor extends ValueTypeVisitor<boolean> {
       return false;
     }
 
-    const constraints = valueType.getConstraints(
-      this.context.evaluationContext,
-    );
+    const constraints = valueType.getConstraints();
     for (const constraint of constraints) {
       const constraintExecutor = new ConstraintExecutor(constraint);
 

--- a/libs/extensions/tabular/exec/src/lib/csv-file-loader-executor.spec.ts
+++ b/libs/extensions/tabular/exec/src/lib/csv-file-loader-executor.spec.ts
@@ -80,8 +80,10 @@ describe('Validation of CSVFileLoaderExecutor', () => {
     // NOTE: The virtual filesystem is reset before each test
     vol.reset();
   });
-  afterEach(() => {
+  afterEach(async () => {
     vi.clearAllMocks();
+    vol.reset();
+    await fsPromise.rm('test.csv');
   });
 
   it('should diagnose no error on valid loader config', async () => {

--- a/libs/interpreter-lib/test/assets/graph/two-pipelines.jv
+++ b/libs/interpreter-lib/test/assets/graph/two-pipelines.jv
@@ -4,135 +4,134 @@
 
 pipeline CarsPipeline {
 
-	CarsExtractor
-		-> CarsTextFileInterpreter;
+  CarsExtractor
+    -> CarsTextFileInterpreter;
 
-	CarsTextFileInterpreter
-		-> CarsCSVInterpreter
-		-> NameHeaderWriter
-		-> CarsTableInterpreter
-		-> CarsLoader;
+  CarsTextFileInterpreter
+    -> CarsCSVInterpreter
+    -> NameHeaderWriter
+    -> CarsTableInterpreter
+    -> CarsLoader;
 
-	block CarsExtractor oftype HttpExtractor {
-		url: "https://gist.githubusercontent.com/noamross/e5d3e859aa0c794be10b/raw/b999fb4425b54c63cab088c0ce2c0d6ce961a563/cars.csv";
-	}
+  block CarsExtractor oftype HttpExtractor {
+    url: "https://gist.githubusercontent.com/noamross/e5d3e859aa0c794be10b/raw/b999fb4425b54c63cab088c0ce2c0d6ce961a563/cars.csv";
+  }
 
-	block CarsTextFileInterpreter oftype TextFileInterpreter { }
+  block CarsTextFileInterpreter oftype TextFileInterpreter { }
 
-	block CarsCSVInterpreter oftype CSVInterpreter {
-		enclosing: '"';
-	}
+  block CarsCSVInterpreter oftype CSVInterpreter {
+    enclosing: '"';
+  }
 
-	block NameHeaderWriter oftype CellWriter {
-		at: cell A1;
+  block NameHeaderWriter oftype CellWriter {
+    at: cell A1;
 
-		write: [
-			"name"
-		];
-	}
+    write: [
+      "name"
+    ];
+  }
 
-	block CarsTableInterpreter oftype TableInterpreter {
-		header: true;
-		columns: [
-			"name" oftype text,
-			"mpg" oftype decimal,
-			"cyl" oftype integer,
-			"disp" oftype decimal,
-			"hp" oftype integer,
-			"drat" oftype decimal,
-			"wt" oftype decimal,
-			"qsec" oftype decimal,
-			"vs" oftype integer,
-			"am" oftype integer,
-			"gear" oftype integer,
-			"carb" oftype integer
-		];
-	}
+  block CarsTableInterpreter oftype TableInterpreter {
+    header: true;
+    columns: [
+      "name" oftype text,
+      "mpg" oftype decimal,
+      "cyl" oftype integer,
+      "disp" oftype decimal,
+      "hp" oftype integer,
+      "drat" oftype decimal,
+      "wt" oftype decimal,
+      "qsec" oftype decimal,
+      "vs" oftype integer,
+      "am" oftype integer,
+      "gear" oftype integer,
+      "carb" oftype integer
+    ];
+  }
 
-	block CarsLoader oftype SQLiteLoader {
-		table: "Cars";
-		file: "./cars.sqlite";
-	}
+  block CarsLoader oftype SQLiteLoader {
+    table: "Cars";
+    file: "./cars.sqlite";
+  }
 }
 
 pipeline ElectricVehiclesPipeline {
-	// See here for meta-data of the data source
-	// https://catalog.data.gov/dataset/electric-vehicle-population-data/resource/fa51be35-691f-45d2-9f3e-535877965e69
+  // See here for meta-data of the data source
+  // https://catalog.data.gov/dataset/electric-vehicle-population-data/resource/fa51be35-691f-45d2-9f3e-535877965e69
 
-	// 2. At the top of a pipeline, we describe the
-	// structure of the pipeline. The first part until 
-	// the ElectricRangeTransformer is a linear sequence
-	// of blocks. From there we can see a split into two
-	// parallel sequences that load the data in to two
-	// different sinks.
-	ElectricVehiclesHttpExtractor
-		-> ElectricVehiclesTextFileInterpreter
-		-> ElectricVehiclesCSVInterpreter
-		-> ElectricVehiclesTableInterpreter
-		-> ElectricRangeTransformer;
+  // 2. At the top of a pipeline, we describe the
+  // structure of the pipeline. The first part until 
+  // the ElectricRangeTransformer is a linear sequence
+  // of blocks. From there we can see a split into two
+  // parallel sequences that load the data in to two
+  // different sinks.
+  ElectricVehiclesHttpExtractor
+    -> ElectricVehiclesTextFileInterpreter
+    -> ElectricVehiclesCSVInterpreter
+    -> ElectricVehiclesTableInterpreter
+    -> ElectricRangeTransformer;
 
-	ElectricRangeTransformer
-		-> ElectricVehiclesSQLiteLoader;
+  ElectricRangeTransformer
+    -> ElectricVehiclesSQLiteLoader;
 
-	// 3. After the pipeline structure, we define the blocks used.
-	block ElectricVehiclesHttpExtractor oftype HttpExtractor {
-		url: "https://data.wa.gov/api/views/f6w7-q2d2/rows.csv?accessType=DOWNLOAD";
-	}
+  // 3. After the pipeline structure, we define the blocks used.
+  block ElectricVehiclesHttpExtractor oftype HttpExtractor {
+    url: "https://data.wa.gov/api/views/f6w7-q2d2/rows.csv?accessType=DOWNLOAD";
+  }
 
-	block ElectricVehiclesTextFileInterpreter oftype TextFileInterpreter { }
+  block ElectricVehiclesTextFileInterpreter oftype TextFileInterpreter { }
 
-	block ElectricVehiclesCSVInterpreter oftype CSVInterpreter { }
+  block ElectricVehiclesCSVInterpreter oftype CSVInterpreter { }
 
-	block ElectricVehiclesTableInterpreter oftype TableInterpreter {
-		header: true;
-		columns: [
-			"VIN (1-10)" oftype VehicleIdentificationNumber10,
-			"County" oftype text,
-			"City" oftype text,
-			"State" oftype text,
-			"Postal Code" oftype text,
-			"Model Year" oftype integer,
-			"Make" oftype text,
-			"Model" oftype text,
-			"Electric Vehicle Type" oftype text,
-			"Clean Alternative Fuel Vehicle (CAFV) Eligibility" oftype text,
-			"Electric Range" oftype integer,
-			"Base MSRP" oftype integer,
-			"Legislative District" oftype text,
-			"DOL Vehicle ID" oftype integer,
-			"Vehicle Location" oftype text,
-			"Electric Utility" oftype text,
-			"2020 Census Tract" oftype text,
-		];
-	}
+  block ElectricVehiclesTableInterpreter oftype TableInterpreter {
+    header: true;
+    columns: [
+      "VIN (1-10)" oftype VehicleIdentificationNumber10,
+      "County" oftype text,
+      "City" oftype text,
+      "State" oftype text,
+      "Postal Code" oftype text,
+      "Model Year" oftype integer,
+      "Make" oftype text,
+      "Model" oftype text,
+      "Electric Vehicle Type" oftype text,
+      "Clean Alternative Fuel Vehicle (CAFV) Eligibility" oftype text,
+      "Electric Range" oftype integer,
+      "Base MSRP" oftype integer,
+      "Legislative District" oftype text,
+      "DOL Vehicle ID" oftype integer,
+      "Vehicle Location" oftype text,
+      "Electric Utility" oftype text,
+      "2020 Census Tract" oftype text,
+    ];
+  }
 
-	block ElectricRangeTransformer oftype TableTransformer {
-		inputColumns: [
-			"Electric Range"
-		];
-		outputColumn: "Electric Range (km)";
-		uses: MilesToKilometers;
-	}
+  block ElectricRangeTransformer oftype TableTransformer {
+    inputColumns: [
+      "Electric Range"
+    ];
+    outputColumn: "Electric Range (km)";
+    uses: MilesToKilometers;
+  }
 
-	transform MilesToKilometers {
-		from miles oftype decimal;
-		to kilometers oftype integer;
+  transform MilesToKilometers {
+    from miles oftype decimal;
+    to kilometers oftype integer;
 
-		kilometers: round (miles * 1.609344);
-	}
+    kilometers: round (miles * 1.609344);
+  }
 
-	block ElectricVehiclesSQLiteLoader oftype SQLiteLoader {
-		table: "ElectricVehiclePopulationData";
-		file: "./electric-vehicles.sqlite";
-	}
+  block ElectricVehiclesSQLiteLoader oftype SQLiteLoader {
+    table: "ElectricVehiclePopulationData";
+    file: "./electric-vehicles.sqlite";
+  }
 }
 
 valuetype VehicleIdentificationNumber10 {
-	property attr oftype text;
-	constraints: [
-		OnlyCapitalLettersAndDigits,
-		ExactlyTenCharacters,
-	];
+  property attr oftype text;
+
+  constraint capitalized: OnlyCapitalLettersAndDigits on attr;
+  constraint len: ExactlyTenCharacters on attr;
 }
 
 constraint OnlyCapitalLettersAndDigits on text: value matches /^[A-Z0-9]*$/;

--- a/libs/language-server/src/grammar/value-type.langium
+++ b/libs/language-server/src/grammar/value-type.langium
@@ -15,11 +15,14 @@ CustomValuetypeDefinition infers ValuetypeDefinition:
     (genericDefinition=ValuetypeGenericsDefinition)?
   '{'
     attribute=ValueTypeAttribute
-    'constraints' ':' constraints=CollectionLiteral ';'
+    (constraints+=ValueTypeConstraintReference)*
   '}';
 
 ValueTypeAttribute:
   'property' name=ID 'oftype' type=ValueTypeReference ';';
+
+ValueTypeConstraintReference:
+  'constraint' name=ID ':' definition=[ConstraintDefinition] 'on' attribute=[ValueTypeAttribute] ';';
 
 ValuetypeAssignmentLiteral:
   value=ValuetypeAssignment;

--- a/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
@@ -5,8 +5,6 @@
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import { strict as assert } from 'assert';
 
-import { evaluateExpression } from '../../expressions/evaluate-expression';
-import { type EvaluationContext } from '../../expressions/evaluation-context';
 import { type InternalValueRepresentation } from '../../expressions/internal-value-representation';
 import {
   type ConstraintDefinition,
@@ -17,7 +15,6 @@ import { type WrapperFactoryProvider } from '../wrapper-factory-provider';
 
 import { AbstractValueType } from './abstract-value-type';
 import { type ValueTypeProvider } from './primitive';
-import { CollectionValueType } from './primitive/collection/collection-value-type';
 import { type ValueType, type ValueTypeVisitor } from './value-type';
 
 export class AtomicValueType
@@ -36,24 +33,18 @@ export class AtomicValueType
     return visitor.visitAtomicValueType(this);
   }
 
-  getConstraints(context: EvaluationContext): ConstraintDefinition[] {
+  getConstraints(): ConstraintDefinition[] {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    const constraintCollection = this.astNode?.constraints;
-    assert(constraintCollection !== undefined);
-    const constraintCollectionType = new CollectionValueType(
-      this.valueTypeProvider.Primitives.Constraint,
-    );
-    const constraints =
-      evaluateExpression(
-        constraintCollection,
-        context,
-        this.wrapperFactories,
-      ) ?? [];
-    if (!constraintCollectionType.isInternalValueRepresentation(constraints)) {
-      return [];
-    }
-
-    return constraints;
+    return this.astNode?.constraints?.map((constraintReference) => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      const constraintDefinition = constraintReference?.definition?.ref;
+      assert(
+        this.valueTypeProvider.Primitives.Constraint.isInternalValueRepresentation(
+          constraintDefinition,
+        ),
+      );
+      return constraintDefinition;
+    });
   }
 
   override isConvertibleTo(target: ValueType): boolean {

--- a/libs/language-server/src/lib/validation/checks/value-type-definition.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/value-type-definition.spec.ts
@@ -93,21 +93,6 @@ describe('Validation of ValuetypeDefinition', () => {
     );
   });
 
-  it('should diagnose error on invalid constraints item', async () => {
-    const text = readJvTestAsset(
-      'value-type-definition/invalid-invalid-constraints-item.jv',
-    );
-
-    await parseAndValidateValuetypeDefinition(text);
-
-    expect(validationAcceptorMock).toHaveBeenCalledTimes(1);
-    expect(validationAcceptorMock).toHaveBeenCalledWith(
-      'error',
-      `The value needs to be of type Collection<Constraint> but is of type Collection<boolean>`,
-      expect.any(Object),
-    );
-  });
-
   it('should diagnose error on invalid constraint type for value type', async () => {
     const text = readJvTestAsset(
       'value-type-definition/invalid-invalid-constraint-type-for-value-type.jv',
@@ -118,7 +103,7 @@ describe('Validation of ValuetypeDefinition', () => {
     expect(validationAcceptorMock).toHaveBeenCalledTimes(1);
     expect(validationAcceptorMock).toHaveBeenCalledWith(
       'error',
-      `This value type ValueType is not convertible to the type integer of the constraint "Constraint"`,
+      `'Constraint' cannot constrain 'attr', because 'integer' is incompatible with 'text'`,
       expect.any(Object),
     );
   });

--- a/libs/language-server/src/lib/validation/checks/value-type-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/value-type-definition.ts
@@ -97,11 +97,9 @@ function checkConstraintMatchesAttribute(
   if (!actualValuetype.isConvertibleTo(compatibleValuetype)) {
     props.validationContext.accept(
       'error',
-      `The constraint ${
-        constraint.name
-      } of type ${compatibleValuetype.getName()} cannot be applied to the property ${
+      `'${constraint.name}' cannot constrain '${
         attribute.name
-      } of type ${actualValuetype.getName()}`,
+      }', because '${compatibleValuetype.getName()}' is incompatible with '${actualValuetype.getName()}'`,
       {
         node: diagnosticNode,
         property: 'attribute',

--- a/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha2.jv
+++ b/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha2.jv
@@ -7,9 +7,7 @@
 */
 publish valuetype CountryCodeAlpha2 {
   property code oftype text;
-  constraints: [
-    CountryCodeAlpha2Constraint
-  ];
+  constraint alpha2: CountryCodeAlpha2Constraint on code;
 }
 
 publish constraint CountryCodeAlpha2Constraint on text: value in [

--- a/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha3.jv
+++ b/libs/language-server/src/stdlib/domain/geo/CountryCodeAlpha3.jv
@@ -7,9 +7,7 @@
 */
 publish valuetype CountryCodeAlpha3 {
   property code oftype text;
-  constraints: [
-    CountryCodeAlpha3Constraint
-  ];
+  constraint alpha3: CountryCodeAlpha3Constraint on code;
 }
 
 publish constraint CountryCodeAlpha3Constraint on text: value in [

--- a/libs/language-server/src/stdlib/domain/geo/CountryCodeNumeric.jv
+++ b/libs/language-server/src/stdlib/domain/geo/CountryCodeNumeric.jv
@@ -7,9 +7,7 @@
 */
 publish valuetype CountryCodeNumeric {
   property code oftype text;
-  constraints: [
-    CountryCodeNumericConstraint
-  ];
+  constraint numeric: CountryCodeNumericConstraint on code;
 }
 
 publish constraint CountryCodeNumericConstraint on text: value in [

--- a/libs/language-server/src/stdlib/domain/material-science/MaterialScienceValueTypes.jv
+++ b/libs/language-server/src/stdlib/domain/material-science/MaterialScienceValueTypes.jv
@@ -9,45 +9,35 @@ constraint DOIFormat on text: value matches /\b10\.\d{4}\/[^\s]+\b/;
 */
 publish valuetype DOI {
 	property doi oftype text;
-	constraints: [
-		DOIFormat
-	];
+  	constraint doiFormat: DOIFormat on doi;
 }
 
 constraint DateFormatYYYYMMDDRegex on text: value matches /\d{4}-\d{2}-\d{2}/;
 /** DateFormat as YYYY-MM-DD */
 publish valuetype DateYYYYMMDD {
 	property date oftype text;
-	constraints: [
-		DateFormatYYYYMMDDRegex
-	];
+  	constraint yyyymmdd: DateFormatYYYYMMDDRegex on date;
 }
 
 constraint SiUnitConstraint on text: value matches /\b((Second|Metre|Kilogram|Ampere|Kelvin|Mole|Candela)+\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constraining the Unit column to be of a specific format like "Second^(1.0)", "Ampere^(1.0)" or "Candela^(1.0)". */
 publish valuetype SiUnit {
 	property unit oftype text;
-	constraints: [
-		SiUnitConstraint
-	];
+  	constraint si: SiUnitConstraint on unit;
 }
 
 constraint PressureUnitPascalConstraint on text: value matches /\b(Pascal\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constrains Pressure units to be Pascal^(x). */
 publish valuetype PressureUnitPascal {
 	property unit oftype text;
-	constraints: [
-		PressureUnitPascalConstraint
-	];
+  	constraint pascal: PressureUnitPascalConstraint on unit;
 }
 
 constraint LengthUnitMeterConstraint on text: value matches /\b(Meter\^\(\d+(\.\d+)?\|\-\d+(\.\d+)?\)+\s)*\b/;
 /** Constrains Length units to be Meter^(x). */
 publish valuetype LengthUnitMeter {
 	property unit oftype text;
-	constraints: [
-		LengthUnitMeterConstraint
-	];
+  	constraint meter: LengthUnitMeterConstraint on unit;
 }
 
 
@@ -55,7 +45,5 @@ constraint TemperatureUnitKelvinConstraint on text: value matches /\b(Kelvin\^\(
 /** Constrains Temperature units to be Kelvin^(x). */
 publish valuetype TemperatureUnitKelvin {
 	property unit oftype text;
-	constraints: [
-		TemperatureUnitKelvinConstraint
-	];
+  	constraint kelvin: TemperatureUnitKelvinConstraint on unit;
 }

--- a/libs/language-server/src/stdlib/domain/mobility/GTFSValueTypes.jv
+++ b/libs/language-server/src/stdlib/domain/mobility/GTFSValueTypes.jv
@@ -13,7 +13,7 @@
 publish constraint GTFSColorConstraint on text: value matches /^[A-F]{6}$/;
 publish valuetype GTFSColor {
     property color oftype text;
-    constraints: [GTFSColorConstraint];
+    constraint GTFSColor: GTFSColorConstraint on color;
 }
 
 /*
@@ -23,7 +23,7 @@ publish valuetype GTFSColor {
 publish constraint DateYYYYMMDD on text: value matches /^[0-9]{4}[0-9]{2}[0-9]{2}$/;
 publish valuetype GTFSDate {
     property date oftype text;
-    constraints: [DateYYYYMMDD];
+    constraint yyyymmdd: DateYYYYMMDD on date;
 }
 
 /*
@@ -33,7 +33,7 @@ publish valuetype GTFSDate {
 publish constraint CurrencyConstraint on text: value matches /^[A-Z]{3}$/;
 publish valuetype GTFSCurrency {
     property currency oftype text;
-    constraints: [CurrencyConstraint];
+    constraint currencyConstraint: CurrencyConstraint on currency;
 }
 
 /*
@@ -43,7 +43,7 @@ publish valuetype GTFSCurrency {
 publish constraint TimeHHMMSS on text: value matches /^[0-9]{1,2}:{1}[0-9]{2}:{1}[0-9]{2}$/;
 publish valuetype GTFSTime {
     property time oftype text;
-    constraints: [TimeHHMMSS];
+    constraint hhmmss: TimeHHMMSS on time;
 }
 
 // Placeholders
@@ -53,17 +53,17 @@ publish constraint EnumThree on integer: value in [0, 1, 2];
 
 publish valuetype GTFSEnumTwo {
     property number oftype integer;
-    constraints: [EnumTwo];
+    constraint enumTwo: EnumTwo on number;
 }
 
 publish valuetype GTFSEnumOneOrTwo {
     property number oftype integer;
-    constraints: [EnumOneOrTwo];
+    constraint enumOneOrTwo: EnumOneOrTwo on number;
 }
 
 publish valuetype GTFSEnumThree {
     property number oftype integer;
-    constraints: [EnumThree];
+    constraint enumThree: EnumThree on number;
 }
 
 // Generic value types
@@ -75,7 +75,7 @@ publish valuetype GTFSEnumThree {
 publish constraint Latitude on decimal: value >= -90 and value <= 90;
 publish valuetype GTFSLatitude {
     property latitude oftype decimal;
-    constraints: [Latitude];
+    constraint lat: Latitude on latitude;
 }
 
 /*
@@ -85,18 +85,18 @@ publish valuetype GTFSLatitude {
 publish constraint Longitude on decimal: value >= -180 and value <= 180;
 publish valuetype GTFSLongitude {
     property longitude oftype decimal;
-    constraints: [Longitude];
+    constraint long: Longitude on longitude;
 }
 
 publish constraint NonNegativeNumber on decimal: value >= 0;
 publish valuetype GTFSNonNegativeDecimal {
     property number oftype decimal;
-    constraints: [NonNegativeNumber];
+    constraint nonNegative: NonNegativeNumber on number;
 }
 
 publish valuetype GTFSNonNegativeInteger {
     property number oftype integer;
-    constraints: [NonNegativeNumber];
+    constraint nonNegative: NonNegativeNumber on number;
 }
 
 /*
@@ -105,5 +105,5 @@ publish valuetype GTFSNonNegativeInteger {
 publish constraint URLIncludingSchema on text: value matches /^(http)s?(:\/\/)/;
 publish valuetype GTFSUrl {
     property url oftype text;
-    constraints: [URLIncludingSchema];
+    constraint isUrl: URLIncludingSchema on url;
 }

--- a/libs/language-server/src/stdlib/percent.jv
+++ b/libs/language-server/src/stdlib/percent.jv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 publish valuetype Percent {
-    property value oftype decimal;
-    constraints: [ZeroToHundredDecimal];
+    property number oftype decimal;
+    constraint zTo100: ZeroToHundredDecimal on number;
 }
 publish constraint ZeroToHundredDecimal on decimal: value >= 0 and value <= 100;

--- a/libs/language-server/src/test/assets/jayvee-model/invalid-duplicate-name-with-builtin-value-type.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/invalid-duplicate-name-with-builtin-value-type.jv
@@ -4,9 +4,7 @@
 
 valuetype DuplicateValueTypeName {
   property attr oftype text;
-  constraints: [
-    Constraint,
-  ];
+  constraint constraintName: Constraint on attr;
 }
 
 builtin valuetype DuplicateValueTypeName;

--- a/libs/language-server/src/test/assets/jayvee-model/invalid-non-unique-different-element-types.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/invalid-non-unique-different-element-types.jv
@@ -4,7 +4,6 @@
 
 valuetype DuplicateName {
   property attr oftype text;
-  constraints: [ ];
 }
 
 pipeline DuplicateName { } 

--- a/libs/language-server/src/test/assets/jayvee-model/invalid-non-unique-value-types.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/invalid-non-unique-value-types.jv
@@ -4,14 +4,10 @@
 
 valuetype DuplicateValueTypeName {
   property attr oftype text;
-  constraints: [
-    Constraint,
-  ];
+  constraint cons: Constraint on attr;
 }
 
 valuetype DuplicateValueTypeName {
   property attr oftype text;
-  constraints: [
-    Constraint,
-  ];
+  constraint cons: Constraint on attr;
 }

--- a/libs/language-server/src/test/assets/jayvee-model/valid-duplicate-name-with-builtin.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/valid-duplicate-name-with-builtin.jv
@@ -5,5 +5,4 @@
 // File is an io type as well
 valuetype File {
   property attr oftype text;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/jayvee-model/valid-duplicate-name-with-pipeline-element.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/valid-duplicate-name-with-pipeline-element.jv
@@ -4,12 +4,10 @@
 
 valuetype DuplicateName {
   property attr oftype text;
-  constraints: [ ];
 }
 
 pipeline TestPipeline {
   valuetype DuplicateName {
     property attr oftype text;
-    constraints: [ ];
   }
 }

--- a/libs/language-server/src/test/assets/property-body/invalid-property-validation-failed.jv
+++ b/libs/language-server/src/test/assets/property-body/invalid-property-validation-failed.jv
@@ -19,7 +19,7 @@ builtin blocktype TestProperty {
 
 valuetype CustomValuetype {
   property attr oftype text;
-  constraints: [CustomConstraint];
+  constraint cons: CustomConstraint on attr;
 }
 
 constraint CustomConstraint on text:

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-duplicate-generic.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-duplicate-generic.jv
@@ -4,5 +4,4 @@
 
 valuetype ValueType<T, T> {
   property attr oftype text;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-invalid-constraint-type-for-value-type.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-invalid-constraint-type-for-value-type.jv
@@ -6,7 +6,5 @@ constraint Constraint on integer: value>10;
 
 valuetype ValueType {
   property attr oftype text;
-  constraints: [
-    Constraint
-  ];
+  constraint cons: Constraint on attr;
 }

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-invalid-constraints-item.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-invalid-constraints-item.jv
@@ -1,8 +1,0 @@
-// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
-//
-// SPDX-License-Identifier: AGPL-3.0-only
-
-valuetype ValueType {
-  property attr oftype text;
-  constraint cons: 10>9 on attr;
-}

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-invalid-constraints-item.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-invalid-constraints-item.jv
@@ -4,7 +4,5 @@
 
 valuetype ValueType {
   property attr oftype text;
-  constraints: [
-    10>9
-  ];
+  constraint cons: 10>9 on attr;
 }

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-missing-generic.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-missing-generic.jv
@@ -4,5 +4,4 @@
 
 valuetype ValueType<> {
   proptery attr oftype text;
-  constraints: [];
 };

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-supertype-cycle.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-supertype-cycle.jv
@@ -4,5 +4,4 @@
 
 valuetype ValueType {
   property self oftype ValueType;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-definition/invalid-unallowed-builtin-body.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/invalid-unallowed-builtin-body.jv
@@ -3,5 +3,4 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 builtin valuetype ValueType {
-    constraints: [];
 };

--- a/libs/language-server/src/test/assets/value-type-definition/valid-value-type-definition.jv
+++ b/libs/language-server/src/test/assets/value-type-definition/valid-value-type-definition.jv
@@ -4,5 +4,4 @@
 
 valuetype ValueType {
   property attr oftype text;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/invalid-reference-missing-generic.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/invalid-reference-missing-generic.jv
@@ -4,10 +4,8 @@
 
 valuetype ValueType<S, T> {
   property attr oftype text;
-  constraints: [ ];
 }
 
 valuetype Ref {
   property ref oftype ValueType;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/invalid-reference-to-non-referenceable-value-type-in-value-type.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/invalid-reference-to-non-referenceable-value-type-in-value-type.jv
@@ -4,10 +4,8 @@
 
 valuetype ValueType1 {
   property constr oftype Constraint;
-  constraints: [ ];
 }
 
 valuetype ValueType2 {
   property rege oftype Regex;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-few-generic-parameters.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-few-generic-parameters.jv
@@ -4,10 +4,8 @@
 
 valuetype ValueType<S, T> {
   property attr oftype text;
-  constraints: [ ];
 }
 
 valuetype Ref {
   property attr oftype ValueType<text>;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-many-generic-parameters.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-many-generic-parameters.jv
@@ -4,10 +4,8 @@
 
 valuetype ValueType<S, T> {
   property attr oftype text;
-  constraints: [ ];
 }
 
 valuetype Ref {
   property ref oftype ValueType<text, integer, text>;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-non-generic-with-generic-parameters.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/invalid-reference-too-non-generic-with-generic-parameters.jv
@@ -4,10 +4,8 @@
 
 valuetype ValueType {
   property attr oftype text;
-  constraints: [ ];
 }
 
 valuetype Ref {
   property ref oftype ValueType<text>;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-multiple-generic-value-type.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-multiple-generic-value-type.jv
@@ -4,10 +4,8 @@
 
 valuetype ValueType<S, T, R, Q, P> {
   property attr oftype text;
-  constraints: [ ];
 }
 
 valuetype Ref {
   property ref oftype ValueType<text, integer, decimal, text, text>;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-non-generic-value-type.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-non-generic-value-type.jv
@@ -4,10 +4,8 @@
 
 valuetype ValueType {
   property attr oftype text;
-  constraints: [ ];
 }
 
 valuetype Ref {
   property ref oftype ValueType;
-  constraints: [ ];
 }

--- a/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-single-generic-value-type.jv
+++ b/libs/language-server/src/test/assets/value-type-reference/valid-reference-to-single-generic-value-type.jv
@@ -4,10 +4,8 @@
 
 valuetype ValueType<T> {
   property attr oftype text;
-  constraints: [ ];
 }
 
 valuetype Ref {
   property ref oftype ValueType<text>;
-  constraints: [ ];
 }


### PR DESCRIPTION
Part 2 of implementing RFC14.
Continues #664.

This PR replaces the previous array of constraints with a flat syntax.
 
Example of the previous syntax:
```
valuetype SomeName {
    property someAttributeName oftype text;
    constraints: [
        someConstraint,
        someOtherConstraint
    ];
}
```

Example of the new syntax:
```
valuetype SomeName {
    property someAttributeName oftype text;
    constraint nameOne: someConstraint on someAttributeName;
    constraint nameTwo: someConstraint on someAttributeName;
}
```