### PR TITLE
Replace length access with operator

### DIFF
--- a/example/electric-vehicles.jv
+++ b/example/electric-vehicles.jv
@@ -130,4 +130,4 @@ valuetype VehicleIdentificationNumber10 {
 // to match a given regular expression in order to be valid.
 constraint OnlyCapitalLettersAndDigits on text: value matches /^[A-Z0-9]*$/;
 
-constraint ExactlyTenCharacters on text: value.length == 10;
+constraint ExactlyTenCharacters on text: lengthof value == 10;

--- a/libs/interpreter-lib/test/assets/graph/two-pipelines.jv
+++ b/libs/interpreter-lib/test/assets/graph/two-pipelines.jv
@@ -136,4 +136,4 @@ valuetype VehicleIdentificationNumber10 {
 
 constraint OnlyCapitalLettersAndDigits on text: value matches /^[A-Z0-9]*$/;
 
-constraint ExactlyTenCharacters on text: value.length == 10;
+constraint ExactlyTenCharacters on text: lengthof value == 10;

--- a/libs/language-server/src/grammar/expression.langium
+++ b/libs/language-server/src/grammar/expression.langium
@@ -86,7 +86,7 @@ FreeVariableLiteral:
   ValueKeywordLiteral | ReferenceLiteral;
 
 ValueKeywordLiteral:
-  'value' ('.' lengthAccess?='length')?;
+  value='value';
 
 ReferenceLiteral:
   value=[Referencable];

--- a/libs/language-server/src/grammar/expression.langium
+++ b/libs/language-server/src/grammar/expression.langium
@@ -52,7 +52,7 @@ PrimaryExpression infers Expression:
   | ExpressionLiteral;
 
 UnaryExpression:
-  operator=('not' | '+' | '-' | 'sqrt' | 'floor' | 'ceil' | 'round' | 'lowercase' | 'uppercase' | 'asDecimal' | 'asInteger' | 'asBoolean' | 'asText') expression=PrimaryExpression;
+  operator=('not' | '+' | '-' | 'sqrt' | 'floor' | 'ceil' | 'round' | 'lowercase' | 'uppercase' | 'asDecimal' | 'asInteger' | 'asBoolean' | 'asText' | 'lengthof') expression=PrimaryExpression;
 
 ExpressionLiteral:
   ValueLiteral | FreeVariableLiteral;

--- a/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import { strict as assert } from 'assert';
-
 import { assertUnreachable } from 'langium';
 
 import { type RuntimeParameterProvider } from '../../services';
@@ -12,7 +9,6 @@ import {} from '../../validation/validation-context';
 import {
   type FreeVariableLiteral,
   type ReferenceLiteral,
-  type ValueKeywordLiteral,
   isBlockTypeProperty,
   isConstraintDefinition,
   isReferenceLiteral,
@@ -46,7 +42,7 @@ export class EvaluationContext {
     if (isReferenceLiteral(literal)) {
       return this.getValueForReference(literal);
     } else if (isValueKeywordLiteral(literal)) {
-      return this.getValueForValueKeyword(literal, this.valueTypeProvider);
+      return this.getValueForValueKeyword();
     }
     assertUnreachable(literal);
   }
@@ -105,23 +101,7 @@ export class EvaluationContext {
     this.valueKeywordValue = undefined;
   }
 
-  getValueForValueKeyword(
-    literal: ValueKeywordLiteral,
-    valueTypeProvider: ValueTypeProvider,
-  ): InternalValueRepresentation | undefined {
-    if (this.valueKeywordValue === undefined) {
-      return undefined;
-    }
-
-    if (literal.lengthAccess) {
-      assert(
-        valueTypeProvider.Primitives.Text.isInternalValueRepresentation(
-          this.valueKeywordValue,
-        ),
-      );
-      return this.valueKeywordValue.length;
-    }
-
+  getValueForValueKeyword(): InternalValueRepresentation | undefined {
     return this.valueKeywordValue;
   }
 }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/lengthof-operator-evaluator.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/lengthof-operator-evaluator.spec.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import { executeExpressionTestHelper } from '../test-utils';
+
+describe('The lengthof operator', () => {
+  it('should determine the length of a string successfully', async () => {
+    const testString = 'someString';
+    const result = await executeExpressionTestHelper(
+      'lengthof inputValue',
+      'inputValue',
+      'text',
+      testString,
+      'integer',
+    );
+
+    expect(result).toBe(testString.length);
+  });
+});

--- a/libs/language-server/src/lib/ast/expressions/evaluators/lengthof-operator-evaluator.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/lengthof-operator-evaluator.spec.ts
@@ -16,4 +16,16 @@ describe('The lengthof operator', () => {
 
     expect(result).toBe(testString.length);
   });
+
+  it('should determine the length of a collection successfully', async () => {
+    const result = await executeExpressionTestHelper(
+      `lengthof [1, 353, 23]`,
+      'inputValue',
+      'text',
+      'irrelevant',
+      'integer',
+    );
+
+    expect(result).toBe(3);
+  });
 });

--- a/libs/language-server/src/lib/ast/expressions/evaluators/lengthof-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/lengthof-operator-evaluator.ts
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
+
+import { type ValidationContext } from '../../../validation/validation-context';
+import { type UnaryExpression } from '../../generated/ast';
+import { type WrapperFactoryProvider } from '../../wrappers/wrapper-factory-provider';
+import { evaluateExpression } from '../evaluate-expression';
+import { type EvaluationContext } from '../evaluation-context';
+import { type EvaluationStrategy } from '../evaluation-strategy';
+import { type OperatorEvaluator } from '../operator-evaluator';
+import { COLLECTION_TYPEGUARD, STRING_TYPEGUARD } from '../typeguards';
+
+export class LengthofOperatorEvaluator
+  implements OperatorEvaluator<UnaryExpression>
+{
+  readonly operator = 'lengthof' as const;
+
+  evaluate(
+    expression: UnaryExpression,
+    evaluationContext: EvaluationContext,
+    wrapperFactories: WrapperFactoryProvider,
+    strategy: EvaluationStrategy,
+    validationContext: ValidationContext | undefined,
+  ): number | undefined {
+    assert(expression.operator === this.operator);
+    const operandValue = evaluateExpression(
+      expression.expression,
+      evaluationContext,
+      wrapperFactories,
+      validationContext,
+      strategy,
+    );
+    if (operandValue === undefined) {
+      return undefined;
+    }
+
+    if (STRING_TYPEGUARD(operandValue)) {
+      return operandValue.length;
+    } else if (COLLECTION_TYPEGUARD(operandValue)) {
+      return operandValue.length;
+    }
+
+    return undefined;
+  }
+}

--- a/libs/language-server/src/lib/ast/expressions/operator-registry.ts
+++ b/libs/language-server/src/lib/ast/expressions/operator-registry.ts
@@ -22,6 +22,7 @@ import { GreaterEqualOperatorEvaluator } from './evaluators/greater-equal-operat
 import { GreaterThanOperatorEvaluator } from './evaluators/greater-than-operator-evaluator';
 import { InOperatorEvaluator } from './evaluators/in-operator-evaluator';
 import { InequalityOperatorEvaluator } from './evaluators/inequality-operator-evaluator';
+import { LengthofOperatorEvaluator } from './evaluators/lengthof-operator-evaluator';
 import { LessEqualOperatorEvaluator } from './evaluators/less-equal-operator-evaluator';
 import { LessThanOperatorEvaluator } from './evaluators/less-than-operator-evaluator';
 import { LowercaseOperatorEvaluator } from './evaluators/lowercase-operator-evaluator';
@@ -63,6 +64,7 @@ import { EqualityOperatorTypeComputer } from './type-computers/equality-operator
 import { ExponentialOperatorTypeComputer } from './type-computers/exponential-operator-type-computer';
 import { InOperatorTypeComputer } from './type-computers/in-operator-type-computer';
 import { IntegerConversionOperatorTypeComputer } from './type-computers/integer-conversion-operator-type-computer';
+import { LengthofOperatorTypeComputer } from './type-computers/lengthof-operator-type-computer';
 import { LogicalOperatorTypeComputer } from './type-computers/logical-operator-type-computer';
 import { MatchesOperatorTypeComputer } from './type-computers/matches-operator-type-computer';
 import { NotOperatorTypeComputer } from './type-computers/not-operator-type-computer';
@@ -110,6 +112,7 @@ export class DefaultOperatorEvaluatorRegistry
     asInteger: new AsIntegerOperatorEvaluator(this.valueTypeProvider),
     asBoolean: new AsBooleanOperatorEvaluator(this.valueTypeProvider),
     asText: new AsTextOperatorEvaluator(this.valueTypeProvider),
+    lengthof: new LengthofOperatorEvaluator(),
   };
   binary = {
     pow: new PowOperatorEvaluator(),
@@ -155,6 +158,7 @@ export class DefaultOperatorTypeComputerRegistry
     asInteger: new AsIntegerOperatorTypeComputer(this.valueTypeProvider),
     asBoolean: new AsBooleanOperatorTypeComputer(this.valueTypeProvider),
     asText: new AsTextOperatorTypeComputer(this.valueTypeProvider),
+    lengthof: new LengthofOperatorTypeComputer(this.valueTypeProvider),
   };
   binary = {
     pow: new ExponentialOperatorTypeComputer(this.valueTypeProvider),

--- a/libs/language-server/src/lib/ast/expressions/test-utils.ts
+++ b/libs/language-server/src/lib/ast/expressions/test-utils.ts
@@ -32,7 +32,7 @@ export async function executeExpressionTestHelper(
   inputValueName: string,
   inputValueType: 'text',
   inputValueValue: InternalValueRepresentation,
-  outputValueType: 'text',
+  outputValueType: 'text' | 'integer',
 ): Promise<InternalValueRepresentation | undefined> {
   const services = createJayveeServices(NodeFileSystem).Jayvee;
   const parse = parseHelper(services);

--- a/libs/language-server/src/lib/ast/expressions/type-computers/lengthof-operator-type-computer.ts
+++ b/libs/language-server/src/lib/ast/expressions/type-computers/lengthof-operator-type-computer.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2023 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { type ValidationContext } from '../../../validation/validation-context';
+import { type UnaryExpression } from '../../generated/ast';
+import {
+  type ValueType,
+  type ValueTypeProvider,
+} from '../../wrappers/value-type';
+import { type UnaryOperatorTypeComputer } from '../operator-type-computer';
+
+export class LengthofOperatorTypeComputer implements UnaryOperatorTypeComputer {
+  constructor(protected readonly valueTypeProvider: ValueTypeProvider) {}
+
+  computeType(
+    operandType: ValueType,
+    expression: UnaryExpression,
+    context: ValidationContext | undefined,
+  ): ValueType | undefined {
+    if (
+      !operandType.isConvertibleTo(this.valueTypeProvider.EmptyCollection) &&
+      this.valueTypeProvider.Primitives.getAll().every(
+        (vt) =>
+          !operandType.isConvertibleTo(
+            this.valueTypeProvider.createCollectionValueTypeOf(vt),
+          ),
+      ) &&
+      !operandType.isConvertibleTo(this.valueTypeProvider.Primitives.Text)
+    ) {
+      context?.accept(
+        'error',
+        `The operand needs to be of type ${this.valueTypeProvider.Primitives.Text.getName()} or ${this.valueTypeProvider.EmptyCollection.getName()} but is of type ${operandType.getName()}`,
+        {
+          node: expression.expression,
+        },
+      );
+      return undefined;
+    }
+    return this.valueTypeProvider.Primitives.Integer;
+  }
+}

--- a/libs/language-server/src/lib/ast/expressions/type-inference.ts
+++ b/libs/language-server/src/lib/ast/expressions/type-inference.ts
@@ -182,7 +182,6 @@ function inferTypeFromExpressionLiteral(
       return inferTypeFromValueKeyword(
         expression,
         validationContext,
-        valueTypeProvider,
         wrapperFactories,
       );
     } else if (isReferenceLiteral(expression)) {
@@ -289,7 +288,6 @@ function inferCollectionElementTypes(
 function inferTypeFromValueKeyword(
   expression: ValueKeywordLiteral,
   validationContext: ValidationContext,
-  valueTypeProvider: ValueTypeProvider,
   wrapperFactories: WrapperFactoryProvider,
 ): ValueType | undefined {
   const constraintContainer = getNextAstNodeContainer(
@@ -315,20 +313,6 @@ function inferTypeFromValueKeyword(
     return undefined;
   }
 
-  if (expression.lengthAccess) {
-    if (!valueType.isConvertibleTo(valueTypeProvider.Primitives.Text)) {
-      validationContext.accept(
-        'error',
-        'The length can only be accessed from text values ',
-        {
-          node: expression,
-          keyword: 'length',
-        },
-      );
-      return undefined;
-    }
-    return valueTypeProvider.Primitives.Integer;
-  }
   return valueType;
 }
 

--- a/libs/language-server/src/lib/ast/expressions/typeguards.ts
+++ b/libs/language-server/src/lib/ast/expressions/typeguards.ts
@@ -47,6 +47,14 @@ export const VALUETYPEASSIGNMENT_TYPEGUARD: InternalValueRepresentationTypeguard
   return isValuetypeAssignment(value);
 };
 
+export const COLLECTION_TYPEGUARD: InternalValueRepresentationTypeguard<
+  InternalValueRepresentation[]
+> = (
+  value: InternalValueRepresentation,
+): value is InternalValueRepresentation[] => {
+  return Array.isArray(value);
+};
+
 export function isEveryValueDefined<T>(array: (T | undefined)[]): array is T[] {
   return array.every((value) => value !== undefined);
 }

--- a/libs/language-server/src/test/assets/constraint-definition/invalid-incompatible-type.jv
+++ b/libs/language-server/src/test/assets/constraint-definition/invalid-incompatible-type.jv
@@ -2,5 +2,4 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-constraint Constraint on text:
-	value.length + 10;
+constraint Constraint on text: lengthof value + 10;

--- a/libs/language-server/src/test/assets/constraint-definition/valid-simplify-info.jv
+++ b/libs/language-server/src/test/assets/constraint-definition/valid-simplify-info.jv
@@ -2,5 +2,4 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-constraint Constraint on text:
-	value.length == (10 + -2);
+constraint Constraint on text: lengthof value == (10 + -2);

--- a/libs/language-server/src/test/assets/constraint-definition/valid-text-constraint.jv
+++ b/libs/language-server/src/test/assets/constraint-definition/valid-text-constraint.jv
@@ -2,5 +2,4 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-constraint Constraint on text:
-	value.length == 10;
+constraint Constraint on text: lengthof value == 10;

--- a/libs/language-server/src/test/assets/jayvee-model/invalid-non-unique-constraints.jv
+++ b/libs/language-server/src/test/assets/jayvee-model/invalid-non-unique-constraints.jv
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-constraint DuplicateConstraintName on text:
-	value.length == 10;
+constraint DuplicateConstraintName on text: lengthof value == 10;
 
-constraint DuplicateConstraintName on text:
-	value.length == 10;
+constraint DuplicateConstraintName on text: lengthof value == 10;


### PR DESCRIPTION
This PR replaces the existing syntax
```
constraint ExactlyTenCharacters on text: value.length == 10;
```
with
```
constraint ExactlyTenCharacters on text: lengthof value == 10;
```
This allows lengths of any string, collection or reference to either to be calculated, not just `value`.