### PR TITLE
 [RFC14] Part 3: Define constraints inside the value type

### DIFF
--- a/example/electric-vehicles.jv
+++ b/example/electric-vehicles.jv
@@ -123,11 +123,12 @@ valuetype VehicleIdentificationNumber10 {
   property id oftype text;
   // 10. Value types can be further refined by providing constraints.
   constraint capitalized: OnlyCapitalLettersAndDigits on id;
-  constraint len: ExactlyTenCharacters on id;
+  // 11. Constraints can also be defined inside the value type. This constraint
+  // ensures that all ids have a length of 10 characters
+  constraint exactlyTenCharacters: lengthof id == 10;
 }
 
-// 11. This constraint works on text value types and requires values
+// 12. This constraint works on text value types and requires values
 // to match a given regular expression in order to be valid.
 constraint OnlyCapitalLettersAndDigits on text: value matches /^[A-Z0-9]*$/;
 
-constraint ExactlyTenCharacters on text: lengthof value == 10;

--- a/libs/execution/src/lib/execution-context.ts
+++ b/libs/execution/src/lib/execution-context.ts
@@ -15,6 +15,7 @@ import {
   type PropertyAssignment,
   type TransformDefinition,
   type ValueType,
+  type ValueTypeConstraintInlineDefinition,
   type ValueTypeProvider,
   type WrapperFactoryProvider,
   evaluatePropertyValue,
@@ -23,6 +24,7 @@ import {
   isPipelineDefinition,
   isPropertyBody,
   isTransformDefinition,
+  isValueTypeConstraintInlineDefinition,
 } from '@jvalue/jayvee-language-server';
 import { isReference } from 'langium';
 
@@ -39,7 +41,8 @@ import { type IOTypeImplementation } from './types';
 export type StackNode =
   | BlockDefinition
   | ConstraintDefinition
-  | TransformDefinition;
+  | TransformDefinition
+  | ValueTypeConstraintInlineDefinition;
 
 export class ExecutionContext {
   private readonly stack: StackNode[] = [];
@@ -115,7 +118,8 @@ export class ExecutionContext {
     const currentNode = this.getCurrentNode();
     if (
       isPipelineDefinition(currentNode) ||
-      isConstraintDefinition(currentNode)
+      isConstraintDefinition(currentNode) ||
+      isValueTypeConstraintInlineDefinition(currentNode)
     ) {
       return undefined;
     }
@@ -188,6 +192,7 @@ export class ExecutionContext {
     assert(!isPipelineDefinition(currentNode));
     assert(!isConstraintDefinition(currentNode));
     assert(!isTransformDefinition(currentNode));
+    assert(!isValueTypeConstraintInlineDefinition(currentNode));
 
     assert(isReference(currentNode.type));
     assert(isBlockDefinition(currentNode));

--- a/libs/execution/src/lib/types/value-types/value-representation-validity.ts
+++ b/libs/execution/src/lib/types/value-types/value-representation-validity.ts
@@ -21,6 +21,7 @@ import {
   type ValueType,
   ValueTypeVisitor,
   type ValuetypeAssignmentValuetype,
+  isConstraintDefinition,
 } from '@jvalue/jayvee-language-server';
 
 import { ConstraintExecutor } from '../../constraints';
@@ -52,7 +53,14 @@ class ValueRepresentationValidityVisitor extends ValueTypeVisitor<boolean> {
 
     const constraints = valueType.getConstraints();
     for (const constraint of constraints) {
-      const constraintExecutor = new ConstraintExecutor(constraint);
+      let constraintExecutor: ConstraintExecutor | undefined = undefined;
+      if (isConstraintDefinition(constraint)) {
+        constraintExecutor = new ConstraintExecutor(constraint);
+      } else {
+        const attribute = valueType.getAttribute();
+        assert(attribute !== undefined);
+        constraintExecutor = new ConstraintExecutor(constraint, attribute.name);
+      }
 
       this.context.enterNode(constraint);
       const valueFulfilledConstraint = constraintExecutor.isValid(

--- a/libs/language-server/src/grammar/expression.langium
+++ b/libs/language-server/src/grammar/expression.langium
@@ -95,4 +95,5 @@ Referencable:
   ConstraintDefinition
   | BlockTypeProperty
   | TransformDefinition
-  | TransformPortDefinition;
+  | TransformPortDefinition
+  | ValueTypeAttribute;

--- a/libs/language-server/src/grammar/value-type.langium
+++ b/libs/language-server/src/grammar/value-type.langium
@@ -19,7 +19,7 @@ CustomValuetypeDefinition infers ValuetypeDefinition:
   '}';
 
 ValueTypeAttribute:
-  'property' name=ID 'oftype' type=ValueTypeReference ';';
+  'property' name=ID 'oftype' valueType=ValueTypeReference ';';
 
 ValueTypeConstraintReference:
   'constraint' name=ID ':' definition=[ConstraintDefinition] 'on' attribute=[ValueTypeAttribute] ';';

--- a/libs/language-server/src/grammar/value-type.langium
+++ b/libs/language-server/src/grammar/value-type.langium
@@ -15,7 +15,7 @@ CustomValuetypeDefinition infers ValuetypeDefinition:
     (genericDefinition=ValuetypeGenericsDefinition)?
   '{'
     attribute=ValueTypeAttribute
-    (constraints+=ValueTypeConstraintReference)*
+    (constraints+=ValueTypeConstraintReference | constraints+=ValueTypeConstraintInlineDefinition)*
   '}';
 
 ValueTypeAttribute:
@@ -23,6 +23,9 @@ ValueTypeAttribute:
 
 ValueTypeConstraintReference:
   'constraint' name=ID ':' definition=[ConstraintDefinition] 'on' attribute=[ValueTypeAttribute] ';';
+
+ValueTypeConstraintInlineDefinition:
+  'constraint' name=ID ':' expression=Expression ';';
 
 ValuetypeAssignmentLiteral:
   value=ValuetypeAssignment;

--- a/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
@@ -15,6 +15,7 @@ import {
   isTransformDefinition,
   isTransformPortDefinition,
   isValueKeywordLiteral,
+  isValueTypeAttribute,
 } from '../generated/ast';
 import { type ValueTypeProvider } from '../wrappers';
 import { type ValueType } from '../wrappers/value-type/value-type';
@@ -77,6 +78,9 @@ export class EvaluationContext {
       return this.variableValues.get(dereferenced.name);
     }
     if (isBlockTypeProperty(dereferenced)) {
+      return this.variableValues.get(dereferenced.name);
+    }
+    if (isValueTypeAttribute(dereferenced)) {
       return this.variableValues.get(dereferenced.name);
     }
     assertUnreachable(dereferenced);

--- a/libs/language-server/src/lib/ast/expressions/type-inference.ts
+++ b/libs/language-server/src/lib/ast/expressions/type-inference.ts
@@ -30,6 +30,7 @@ import {
   isUnaryExpression,
   isValueKeywordLiteral,
   isValueLiteral,
+  isValueTypeAttribute,
   isValuetypeAssignmentLiteral,
 } from '../generated/ast';
 import { getNextAstNodeContainer } from '../model-util';
@@ -335,7 +336,8 @@ function inferTypeFromReferenceLiteral(
   }
   if (
     isTransformPortDefinition(referenced) ||
-    isBlockTypeProperty(referenced)
+    isBlockTypeProperty(referenced) ||
+    isValueTypeAttribute(referenced)
   ) {
     const valueType = referenced.valueType;
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
@@ -8,7 +8,10 @@ import { strict as assert } from 'assert';
 import { type InternalValueRepresentation } from '../../expressions/internal-value-representation';
 import {
   type ConstraintDefinition,
+  type ValueTypeAttribute,
+  type ValueTypeConstraintInlineDefinition,
   type ValuetypeDefinition,
+  isValueTypeConstraintInlineDefinition,
 } from '../../generated/ast';
 import { type AstNodeWrapper } from '../ast-node-wrapper';
 import { type WrapperFactoryProvider } from '../wrapper-factory-provider';
@@ -33,18 +36,31 @@ export class AtomicValueType
     return visitor.visitAtomicValueType(this);
   }
 
-  getConstraints(): ConstraintDefinition[] {
+  getAttribute(): ValueTypeAttribute | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    return this.astNode?.attribute;
+  }
+
+  getConstraints(): (
+    | ConstraintDefinition
+    | ValueTypeConstraintInlineDefinition
+  )[] {
     return (
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      this.astNode?.constraints?.map((constraintReference) => {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        const constraintDefinition = constraintReference?.definition?.ref;
-        assert(
-          this.valueTypeProvider.Primitives.Constraint.isInternalValueRepresentation(
-            constraintDefinition,
-          ),
-        );
-        return constraintDefinition;
+      this.astNode?.constraints?.map((constraint) => {
+        if (isValueTypeConstraintInlineDefinition(constraint)) {
+          return constraint;
+          // eslint-disable-next-line no-else-return
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          const constraintDefinition = constraint?.definition?.ref;
+          assert(
+            this.valueTypeProvider.Primitives.Constraint.isInternalValueRepresentation(
+              constraintDefinition,
+            ),
+          );
+          return constraintDefinition;
+        }
       }) ?? []
     );
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
@@ -100,7 +100,7 @@ export class AtomicValueType
 
   protected override doGetSupertype(): ValueType | undefined {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    const supertype = this.astNode?.attribute?.type;
+    const supertype = this.astNode?.attribute?.valueType;
     return this.wrapperFactories.ValueType.wrap(supertype);
   }
 

--- a/libs/language-server/src/lib/validation/checks/value-type-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/value-type-definition.ts
@@ -45,7 +45,7 @@ function checkSupertypeCycle(
       "`builtin` valuetypes don't have cycles",
     );
     assert(
-      valueTypeDefinition.attribute?.type !== undefined,
+      valueTypeDefinition.attribute?.valueType !== undefined,
       '`hasCycle == true`, so `valueTypeDefinition` MUST have an attribute with a type',
     );
     props.validationContext.accept(
@@ -53,7 +53,7 @@ function checkSupertypeCycle(
       'Could not construct this value type since there is a cycle in the (transitive) "oftype" relation.',
       {
         node: valueTypeDefinition.attribute,
-        property: 'type',
+        property: 'valueType',
       },
     );
   }
@@ -106,7 +106,9 @@ function checkConstraintMatchesAttribute(
   diagnosticNode: ValueTypeConstraintReference,
   props: JayveeValidationProps,
 ): void {
-  const actualValuetype = props.wrapperFactories.ValueType.wrap(attribute.type);
+  const actualValuetype = props.wrapperFactories.ValueType.wrap(
+    attribute.valueType,
+  );
   const compatibleValuetype = props.wrapperFactories.ValueType.wrap(
     constraint?.valueType,
   );

--- a/libs/language-server/src/lib/validation/checks/value-type-reference.spec.ts
+++ b/libs/language-server/src/lib/validation/checks/value-type-reference.spec.ts
@@ -64,7 +64,7 @@ describe('Validation of ValueTypeReference', () => {
     for (let i = 0; i < allValueTypes.length; ++i) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const valueTypeDefinition = allValueTypes[i]!;
-      const valueTypeRef = valueTypeDefinition.attribute?.type;
+      const valueTypeRef = valueTypeDefinition.attribute?.valueType;
       assert(valueTypeRef !== undefined);
       valueTypeReferences.push(valueTypeRef);
     }


### PR DESCRIPTION
Final part of implementing RFC14.
Continues #665.

This PR allows for constraints to be defined inside a value type.
 
Example of the new syntax:
```
valuetype SomeName {
    property someAttributeName oftype text;
    constraint shorterThanTen: lengthof someAttributeName < 10;
    constraint isLowercaseAlphabetic: someAttributeName matches /[a-z]+/;
}
```