### PR TITLE
[RFC0017] Add `invalid` and `missing`error values

### DIFF
--- a/libs/execution/src/lib/blocks/composite-block-executor.ts
+++ b/libs/execution/src/lib/blocks/composite-block-executor.ts
@@ -13,9 +13,9 @@ import {
   ERROR_TYPEGUARD,
   type EvaluationContext,
   IOType,
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
-  MissingError,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
+  MissingValue,
   type ValueType,
   type WrapperFactoryProvider,
   evaluateExpression,
@@ -182,7 +182,7 @@ export function createCompositeBlockExecutor(
       properties: BlockTypeProperty[],
       evaluationContext: EvaluationContext,
       wrapperFactories: WrapperFactoryProvider,
-    ): InternalValueRepresentation | InternalErrorRepresentation {
+    ): InternalValidValueRepresentation | InternalErrorValueRepresentation {
       const propertyFromBlock = block.body.properties.find(
         (property) => property.name === name,
       );
@@ -205,7 +205,7 @@ export function createCompositeBlockExecutor(
       );
 
       if (propertyFromBlockType?.defaultValue === undefined) {
-        return new MissingError(
+        return new MissingValue(
           `Could not find default value for property ${name}`,
         );
       }

--- a/libs/execution/src/lib/blocks/composite-block-executor.ts
+++ b/libs/execution/src/lib/blocks/composite-block-executor.ts
@@ -10,9 +10,12 @@ import {
   type BlockTypePipeline,
   type BlockTypeProperty,
   type CompositeBlockTypeDefinition,
+  ERROR_TYPEGUARD,
   type EvaluationContext,
   IOType,
+  type InternalErrorRepresentation,
   type InternalValueRepresentation,
+  MissingError,
   type ValueType,
   type WrapperFactoryProvider,
   evaluateExpression,
@@ -165,11 +168,6 @@ export function createCompositeBlockExecutor(
           context.wrapperFactories,
         );
 
-        assert(
-          propertyValue !== undefined,
-          `Can not get value for block type property ${blockTypeProperty.name}`,
-        );
-
         context.evaluationContext.setValueForReference(
           blockTypeProperty.name,
           propertyValue,
@@ -184,7 +182,7 @@ export function createCompositeBlockExecutor(
       properties: BlockTypeProperty[],
       evaluationContext: EvaluationContext,
       wrapperFactories: WrapperFactoryProvider,
-    ): InternalValueRepresentation | undefined {
+    ): InternalValueRepresentation | InternalErrorRepresentation {
       const propertyFromBlock = block.body.properties.find(
         (property) => property.name === name,
       );
@@ -197,7 +195,7 @@ export function createCompositeBlockExecutor(
           valueType,
         );
 
-        if (value !== undefined) {
+        if (!ERROR_TYPEGUARD(value)) {
           return value;
         }
       }
@@ -207,7 +205,9 @@ export function createCompositeBlockExecutor(
       );
 
       if (propertyFromBlockType?.defaultValue === undefined) {
-        return;
+        return new MissingError(
+          `Could not find default value for property ${name}`,
+        );
       }
 
       return evaluateExpression(

--- a/libs/execution/src/lib/constraints/constraint-executor.ts
+++ b/libs/execution/src/lib/constraints/constraint-executor.ts
@@ -8,6 +8,8 @@ import { strict as assert } from 'assert';
 import {
   type AstNodeWrapper,
   type ConstraintDefinition,
+  ERROR_TYPEGUARD,
+  type InternalErrorRepresentation,
   type InternalValueRepresentation,
   type ValueTypeAttribute,
   type ValueTypeConstraintInlineDefinition,
@@ -23,7 +25,7 @@ export class ConstraintExecutor<
   constructor(public readonly astNode: T) {}
 
   isValid(
-    value: InternalValueRepresentation,
+    value: InternalValueRepresentation | InternalErrorRepresentation,
     context: ExecutionContext,
     attribute: T extends ValueTypeConstraintInlineDefinition
       ? ValueTypeAttribute
@@ -42,6 +44,10 @@ export class ConstraintExecutor<
       context.evaluationContext,
       context.wrapperFactories,
     );
+    if (ERROR_TYPEGUARD(result)) {
+      context.logger.logErr(result.toString());
+      return false;
+    }
     assert(
       context.valueTypeProvider.Primitives.Boolean.isInternalValueRepresentation(
         result,

--- a/libs/execution/src/lib/constraints/constraint-executor.ts
+++ b/libs/execution/src/lib/constraints/constraint-executor.ts
@@ -9,8 +9,8 @@ import {
   type AstNodeWrapper,
   type ConstraintDefinition,
   ERROR_TYPEGUARD,
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
   type ValueTypeAttribute,
   type ValueTypeConstraintInlineDefinition,
   evaluateExpression,
@@ -25,7 +25,7 @@ export class ConstraintExecutor<
   constructor(public readonly astNode: T) {}
 
   isValid(
-    value: InternalValueRepresentation | InternalErrorRepresentation,
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
     context: ExecutionContext,
     attribute: T extends ValueTypeConstraintInlineDefinition
       ? ValueTypeAttribute
@@ -49,7 +49,7 @@ export class ConstraintExecutor<
       return false;
     }
     assert(
-      context.valueTypeProvider.Primitives.Boolean.isInternalValueRepresentation(
+      context.valueTypeProvider.Primitives.Boolean.isInternalValidValueRepresentation(
         result,
       ),
     );

--- a/libs/execution/src/lib/debugging/debug-log-visitor.ts
+++ b/libs/execution/src/lib/debugging/debug-log-visitor.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
+  ERROR_TYPEGUARD,
   type WrapperFactoryProvider,
   internalValueToString,
 } from '@jvalue/jayvee-language-server';
@@ -57,7 +58,12 @@ export class DebugLogVisitor implements IoTypeVisitor<void> {
 
       const row = table.getRow(i);
       const rowData = [...row.values()]
-        .map((cell) => internalValueToString(cell, this.wrapperFactories))
+        .map((cell) => {
+          if (ERROR_TYPEGUARD(cell)) {
+            return cell.name;
+          }
+          return internalValueToString(cell, this.wrapperFactories);
+        })
         .join(' | ');
       this.log(`[Row ${i}] ${rowData}`);
     }

--- a/libs/execution/src/lib/execution-context.ts
+++ b/libs/execution/src/lib/execution-context.ts
@@ -9,6 +9,7 @@ import { inspect } from 'node:util';
 import {
   type BlockDefinition,
   type ConstraintDefinition,
+  ERROR_TYPEGUARD,
   type EvaluationContext,
   type InternalValueRepresentation,
   type PipelineDefinition,
@@ -110,7 +111,7 @@ export class ExecutionContext {
       this.wrapperFactories,
       valueType,
     );
-    assert(propertyValue !== undefined);
+    assert(!ERROR_TYPEGUARD(propertyValue));
     return propertyValue;
   }
 

--- a/libs/execution/src/lib/execution-context.ts
+++ b/libs/execution/src/lib/execution-context.ts
@@ -11,7 +11,7 @@ import {
   type ConstraintDefinition,
   ERROR_TYPEGUARD,
   type EvaluationContext,
-  type InternalValueRepresentation,
+  type InternalValidValueRepresentation,
   type PipelineDefinition,
   type PropertyAssignment,
   type TransformDefinition,
@@ -95,7 +95,7 @@ export class ExecutionContext {
     this.logger.setLoggingContext(this.getCurrentNode().name);
   }
 
-  public getPropertyValue<I extends InternalValueRepresentation>(
+  public getPropertyValue<I extends InternalValidValueRepresentation>(
     propertyName: string,
     valueType: ValueType<I>,
   ): I {
@@ -173,7 +173,7 @@ export class ExecutionContext {
     }
   }
 
-  private getDefaultPropertyValue<I extends InternalValueRepresentation>(
+  private getDefaultPropertyValue<I extends InternalValidValueRepresentation>(
     propertyName: string,
     valueType: ValueType<I>,
   ): I {
@@ -183,7 +183,7 @@ export class ExecutionContext {
 
     const defaultValue = propertySpec.defaultValue;
     assert(defaultValue !== undefined);
-    assert(valueType.isInternalValueRepresentation(defaultValue));
+    assert(valueType.isInternalValidValueRepresentation(defaultValue));
 
     return defaultValue;
   }

--- a/libs/execution/src/lib/transforms/transform-executor.spec.ts
+++ b/libs/execution/src/lib/transforms/transform-executor.spec.ts
@@ -8,8 +8,8 @@ import path from 'node:path';
 
 import {
   ERROR_TYPEGUARD,
-  type InternalValueRepresentation,
-  InvalidError,
+  type InternalValidValueRepresentation,
+  InvalidValue,
   type JayveeServices,
   type TransformDefinition,
   createJayveeServices,
@@ -78,7 +78,7 @@ describe('Validation of TransformExecutor', () => {
     input: string,
     inputTable: Table,
     columnNames: string[],
-  ): Promise<TableColumn<InternalValueRepresentation>> {
+  ): Promise<TableColumn<InternalValidValueRepresentation>> {
     const document = await parse(input, { validation: true });
     expectNoParserAndLexerErrors(document);
 
@@ -158,7 +158,7 @@ describe('Validation of TransformExecutor', () => {
     expect(result.values).toEqual(expect.arrayContaining([21]));
   });
 
-  it('should evaluate InvalidError on invalid value representation', async () => {
+  it('should evaluate InvalidValue on invalid value representation', async () => {
     const text = readJvTestAsset(
       'transform-executor/invalid-input-output-type-transform.jv',
     );
@@ -196,7 +196,7 @@ describe('Validation of TransformExecutor', () => {
     expect(result.values).toHaveLength(1);
     const [value] = result.values;
     assert(value !== undefined);
-    expect(value).toBeInstanceOf(InvalidError);
+    expect(value).toBeInstanceOf(InvalidValue);
   });
 
   it('should diagnose no error on valid value', async () => {
@@ -289,7 +289,7 @@ describe('Validation of TransformExecutor', () => {
     }
   });
 
-  it('should evaluate InvalidError on invalid column type', async () => {
+  it('should evaluate InvalidValue on invalid column type', async () => {
     const text = readJvTestAsset(
       'transform-executor/valid-decimal-integer-transform.jv',
     );
@@ -327,10 +327,10 @@ describe('Validation of TransformExecutor', () => {
     expect(result.values).toHaveLength(1);
     const [value] = result.values;
     assert(value !== undefined);
-    expect(value).toBeInstanceOf(InvalidError);
+    expect(value).toBeInstanceOf(InvalidValue);
   });
 
-  it('should evaluate InvalidError on invalid row value', async () => {
+  it('should evaluate InvalidValue on invalid row value', async () => {
     const text = readJvTestAsset(
       'transform-executor/valid-decimal-integer-transform.jv',
     );
@@ -369,12 +369,12 @@ describe('Validation of TransformExecutor', () => {
     const [a, b] = result.values;
     assert(a !== undefined);
     assert(b !== undefined);
-    expect(a).toBeInstanceOf(InvalidError);
+    expect(a).toBeInstanceOf(InvalidValue);
     expect(b).toBe(21);
     expect(result.values).toEqual(expect.arrayContaining([21]));
   });
 
-  it('should evaluate InvalidError on an erroneous expression', async () => {
+  it('should evaluate InvalidValue on an erroneous expression', async () => {
     const text = readJvTestAsset(
       'transform-executor/invalid-expression-evaluation-error.jv',
     );
@@ -419,6 +419,6 @@ describe('Validation of TransformExecutor', () => {
     expect(result.values).toHaveLength(1);
     const [value] = result.values;
     assert(value !== undefined);
-    expect(value).toBeInstanceOf(InvalidError);
+    expect(value).toBeInstanceOf(InvalidValue);
   });
 });

--- a/libs/execution/src/lib/transforms/transform-executor.spec.ts
+++ b/libs/execution/src/lib/transforms/transform-executor.spec.ts
@@ -7,7 +7,9 @@ import assert from 'assert';
 import path from 'node:path';
 
 import {
+  ERROR_TYPEGUARD,
   type InternalValueRepresentation,
+  InvalidError,
   type JayveeServices,
   type TransformDefinition,
   createJayveeServices,
@@ -32,6 +34,10 @@ import { constructTable, getTestExecutionContext } from '../../../test/utils';
 import { type Table, type TableColumn } from '../types/io-types/table';
 
 import { type PortDetails, TransformExecutor } from './transform-executor';
+
+function expectNoErrorsInColumn(column: TableColumn) {
+  expect(column.values.every((value) => ERROR_TYPEGUARD(value)));
+}
 
 describe('Validation of TransformExecutor', () => {
   let parse: (
@@ -72,10 +78,7 @@ describe('Validation of TransformExecutor', () => {
     input: string,
     inputTable: Table,
     columnNames: string[],
-  ): Promise<{
-    resultingColumn: TableColumn<InternalValueRepresentation>;
-    rowsToDelete: number[];
-  }> {
+  ): Promise<TableColumn<InternalValueRepresentation>> {
     const document = await parse(input, { validation: true });
     expectNoParserAndLexerErrors(document);
 
@@ -147,15 +150,15 @@ describe('Validation of TransformExecutor', () => {
       transformColumnNames,
     );
 
-    expect(result.rowsToDelete).toHaveLength(0);
-    expect(result.resultingColumn.valueType).toEqual(
+    expectNoErrorsInColumn(result);
+    expect(result.valueType).toEqual(
       services.ValueTypeProvider.Primitives.Integer,
     );
-    expect(result.resultingColumn.values).toHaveLength(1);
-    expect(result.resultingColumn.values).toEqual(expect.arrayContaining([21]));
+    expect(result.values).toHaveLength(1);
+    expect(result.values).toEqual(expect.arrayContaining([21]));
   });
 
-  it('should diagnose no error on invalid value representation', async () => {
+  it('should evaluate InvalidError on invalid value representation', async () => {
     const text = readJvTestAsset(
       'transform-executor/invalid-input-output-type-transform.jv',
     );
@@ -187,12 +190,13 @@ describe('Validation of TransformExecutor', () => {
       transformColumnNames,
     );
 
-    expect(result.rowsToDelete).toHaveLength(1);
-    expect(result.rowsToDelete).toEqual(expect.arrayContaining([0]));
-    expect(result.resultingColumn.valueType).toEqual(
+    expect(result.valueType).toEqual(
       services.ValueTypeProvider.Primitives.Text,
     );
-    expect(result.resultingColumn.values).toHaveLength(0);
+    expect(result.values).toHaveLength(1);
+    const [value] = result.values;
+    assert(value !== undefined);
+    expect(value).toBeInstanceOf(InvalidError);
   });
 
   it('should diagnose no error on valid value', async () => {
@@ -234,14 +238,12 @@ describe('Validation of TransformExecutor', () => {
       transformColumnNames,
     );
 
-    expect(result.rowsToDelete).toHaveLength(0);
-    expect(result.resultingColumn.valueType).toEqual(
+    expectNoErrorsInColumn(result);
+    expect(result.valueType).toEqual(
       services.ValueTypeProvider.Primitives.Integer,
     );
-    expect(result.resultingColumn.values).toHaveLength(1);
-    expect(result.resultingColumn.values).toEqual(
-      expect.arrayContaining([106]),
-    );
+    expect(result.values).toHaveLength(1);
+    expect(result.values).toEqual(expect.arrayContaining([106]));
   });
 
   it('should diagnose error on empty columns map', async () => {
@@ -287,7 +289,7 @@ describe('Validation of TransformExecutor', () => {
     }
   });
 
-  it('should diagnose no error on invalid column type', async () => {
+  it('should evaluate InvalidError on invalid column type', async () => {
     const text = readJvTestAsset(
       'transform-executor/valid-decimal-integer-transform.jv',
     );
@@ -319,14 +321,16 @@ describe('Validation of TransformExecutor', () => {
       transformColumnNames,
     );
 
-    expect(result.rowsToDelete).toHaveLength(1);
-    expect(result.resultingColumn.valueType).toEqual(
+    expect(result.valueType).toEqual(
       services.ValueTypeProvider.Primitives.Integer,
     );
-    expect(result.resultingColumn.values).toHaveLength(0);
+    expect(result.values).toHaveLength(1);
+    const [value] = result.values;
+    assert(value !== undefined);
+    expect(value).toBeInstanceOf(InvalidError);
   });
 
-  it('should diagnose no error on invalid row value', async () => {
+  it('should evaluate InvalidError on invalid row value', async () => {
     const text = readJvTestAsset(
       'transform-executor/valid-decimal-integer-transform.jv',
     );
@@ -358,15 +362,19 @@ describe('Validation of TransformExecutor', () => {
       transformColumnNames,
     );
 
-    expect(result.rowsToDelete).toHaveLength(1);
-    expect(result.resultingColumn.valueType).toEqual(
+    expect(result.valueType).toEqual(
       services.ValueTypeProvider.Primitives.Integer,
     );
-    expect(result.resultingColumn.values).toHaveLength(1);
-    expect(result.resultingColumn.values).toEqual(expect.arrayContaining([21]));
+    expect(result.values).toHaveLength(2);
+    const [a, b] = result.values;
+    assert(a !== undefined);
+    assert(b !== undefined);
+    expect(a).toBeInstanceOf(InvalidError);
+    expect(b).toBe(21);
+    expect(result.values).toEqual(expect.arrayContaining([21]));
   });
 
-  it('should diagnose no error on expression evaluation error', async () => {
+  it('should evaluate InvalidError on an erroneous expression', async () => {
     const text = readJvTestAsset(
       'transform-executor/invalid-expression-evaluation-error.jv',
     );
@@ -405,10 +413,12 @@ describe('Validation of TransformExecutor', () => {
       transformColumnNames,
     );
 
-    expect(result.rowsToDelete).toHaveLength(1);
-    expect(result.resultingColumn.valueType).toEqual(
+    expect(result.valueType).toEqual(
       services.ValueTypeProvider.Primitives.Decimal,
     );
-    expect(result.resultingColumn.values).toHaveLength(0);
+    expect(result.values).toHaveLength(1);
+    const [value] = result.values;
+    assert(value !== undefined);
+    expect(value).toBeInstanceOf(InvalidError);
   });
 });

--- a/libs/execution/src/lib/transforms/transform-executor.ts
+++ b/libs/execution/src/lib/transforms/transform-executor.ts
@@ -119,15 +119,6 @@ export class TransformExecutor {
         !ERROR_TYPEGUARD(newValue) &&
         !isValidValueRepresentation(newValue, outputDetails.valueType, context)
       ) {
-        if (
-          !(
-            typeof newValue === 'string' ||
-            typeof newValue === 'boolean' ||
-            typeof newValue === 'number'
-          )
-        ) {
-          console.log(newValue);
-        }
         assert(
           typeof newValue === 'string' ||
             typeof newValue === 'boolean' ||

--- a/libs/execution/src/lib/types/io-types/table.ts
+++ b/libs/execution/src/lib/types/io-types/table.ts
@@ -8,8 +8,8 @@ import { strict as assert } from 'assert';
 import {
   ERROR_TYPEGUARD,
   IOType,
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
   type TextValuetype,
   type ValueType,
   cloneInternalValue,
@@ -24,15 +24,15 @@ import {
 } from './io-type-implementation';
 
 export interface TableColumn<
-  T extends InternalValueRepresentation = InternalValueRepresentation,
+  T extends InternalValidValueRepresentation = InternalValidValueRepresentation,
 > {
-  values: (T | InternalErrorRepresentation)[];
+  values: (T | InternalErrorValueRepresentation)[];
   valueType: ValueType;
 }
 
 export type TableRow = Record<
   string,
-  InternalValueRepresentation | InternalErrorRepresentation
+  InternalValidValueRepresentation | InternalErrorValueRepresentation
 >;
 
 /**
@@ -80,7 +80,7 @@ export class Table implements IOTypeImplementation<IOType.TABLE> {
 
       assert(
         ERROR_TYPEGUARD(value) ||
-          column.valueType.isInternalValueRepresentation(value),
+          column.valueType.isInternalValidValueRepresentation(value),
       );
       column.values.push(value);
     });
@@ -110,7 +110,10 @@ export class Table implements IOTypeImplementation<IOType.TABLE> {
 
   getRow(
     rowId: number,
-  ): Map<string, InternalValueRepresentation | InternalErrorRepresentation> {
+  ): Map<
+    string,
+    InternalValidValueRepresentation | InternalErrorValueRepresentation
+  > {
     const numberOfRows = this.getNumberOfRows();
     if (rowId >= numberOfRows) {
       throw new Error(
@@ -120,7 +123,7 @@ export class Table implements IOTypeImplementation<IOType.TABLE> {
 
     const row = new Map<
       string,
-      InternalValueRepresentation | InternalErrorRepresentation
+      InternalValidValueRepresentation | InternalErrorValueRepresentation
     >();
     [...this.columns.entries()].forEach(([columnName, column]) => {
       const value = column.values[rowId];

--- a/libs/execution/src/lib/types/value-types/internal-representation-parsing.ts
+++ b/libs/execution/src/lib/types/value-types/internal-representation-parsing.ts
@@ -9,11 +9,16 @@ import {
   type AtomicValueType,
   type BooleanValuetype,
   type DecimalValuetype,
+  INVALID_TYPEGUARD,
   type IntegerValuetype,
+  type InternalErrorRepresentation,
   type InternalValueRepresentation,
+  InvalidError,
   type TextValuetype,
   type ValueType,
   ValueTypeVisitor,
+  internalValueToString,
+  isCellRangeLiteral,
 } from '@jvalue/jayvee-language-server';
 
 export interface ParseOpts {
@@ -32,20 +37,33 @@ export function parseValueToInternalRepresentation<
   value: string,
   valueType: ValueType<I>,
   parseOpts?: Partial<ParseOpts>,
-): I | undefined {
+): I | InternalErrorRepresentation {
   const visitor = new InternalRepresentationParserVisitor(value, {
     ...DEFAULT_PARSE_OPTS,
     ...parseOpts,
   });
   const result = valueType.acceptVisitor(visitor);
+  if (INVALID_TYPEGUARD(result)) {
+    return result;
+  }
+
   if (!valueType.isInternalValueRepresentation(result)) {
-    return undefined;
+    if (isCellRangeLiteral(result)) {
+      return new InvalidError(
+        `A cell range literal is not valid for ${valueType.getName()}`,
+      );
+    }
+    return new InvalidError(
+      `${internalValueToString(
+        result,
+      )} is not valid for ${valueType.getName()}`,
+    );
   }
   return result;
 }
 
 class InternalRepresentationParserVisitor extends ValueTypeVisitor<
-  InternalValueRepresentation | undefined
+  InternalValueRepresentation | InvalidError
 > {
   constructor(private value: string, private parseOpts: ParseOpts) {
     super();
@@ -64,15 +82,15 @@ class InternalRepresentationParserVisitor extends ValueTypeVisitor<
     return value;
   }
 
-  visitBoolean(vt: BooleanValuetype): boolean | undefined {
+  visitBoolean(vt: BooleanValuetype): boolean | InvalidError {
     return vt.fromString(this.applyTrimOptions(this.value));
   }
 
-  visitDecimal(vt: DecimalValuetype): number | undefined {
+  visitDecimal(vt: DecimalValuetype): number | InvalidError {
     return vt.fromString(this.applyTrimOptions(this.value));
   }
 
-  visitInteger(vt: IntegerValuetype): number | undefined {
+  visitInteger(vt: IntegerValuetype): number | InvalidError {
     return vt.fromString(this.applyTrimOptions(this.value));
   }
 
@@ -82,34 +100,36 @@ class InternalRepresentationParserVisitor extends ValueTypeVisitor<
 
   visitAtomicValueType(
     valueType: AtomicValueType,
-  ): InternalValueRepresentation | undefined {
+  ): InternalValueRepresentation | InvalidError {
     const contained = valueType.getContainedType();
     assert(contained !== undefined);
 
     return contained.acceptVisitor(this);
   }
 
-  visitCellRange(): undefined {
-    return undefined;
+  visitCellRange(): InvalidError {
+    return new InvalidError(`Cannot parse cell ranges into internal values`);
   }
 
-  visitCollection(): undefined {
-    return undefined;
+  visitCollection(): InvalidError {
+    return new InvalidError(`Cannot parse collections into internal values`);
   }
 
-  visitConstraint(): undefined {
-    return undefined;
+  visitConstraint(): InvalidError {
+    return new InvalidError(`Cannot parse constraints into internal values`);
   }
 
-  visitRegex(): undefined {
-    return undefined;
+  visitRegex(): InvalidError {
+    return new InvalidError(`Cannot parse regex into internal values`);
   }
 
-  visitTransform(): undefined {
-    return undefined;
+  visitTransform(): InvalidError {
+    return new InvalidError(`Cannot parse transforms into internal values`);
   }
 
-  visitValuetypeAssignment(): undefined {
-    return undefined;
+  visitValuetypeAssignment(): InvalidError {
+    return new InvalidError(
+      `Cannot parse valuetype assignments into internal values`,
+    );
   }
 }

--- a/libs/execution/src/lib/types/value-types/internal-representation-parsing.ts
+++ b/libs/execution/src/lib/types/value-types/internal-representation-parsing.ts
@@ -11,9 +11,9 @@ import {
   type DecimalValuetype,
   INVALID_TYPEGUARD,
   type IntegerValuetype,
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
-  InvalidError,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
+  InvalidValue,
   type TextValuetype,
   type ValueType,
   ValueTypeVisitor,
@@ -32,12 +32,12 @@ const DEFAULT_PARSE_OPTS: ParseOpts = {
 };
 
 export function parseValueToInternalRepresentation<
-  I extends InternalValueRepresentation,
+  I extends InternalValidValueRepresentation,
 >(
   value: string,
   valueType: ValueType<I>,
   parseOpts?: Partial<ParseOpts>,
-): I | InternalErrorRepresentation {
+): I | InternalErrorValueRepresentation {
   const visitor = new InternalRepresentationParserVisitor(value, {
     ...DEFAULT_PARSE_OPTS,
     ...parseOpts,
@@ -47,13 +47,13 @@ export function parseValueToInternalRepresentation<
     return result;
   }
 
-  if (!valueType.isInternalValueRepresentation(result)) {
+  if (!valueType.isInternalValidValueRepresentation(result)) {
     if (isCellRangeLiteral(result)) {
-      return new InvalidError(
+      return new InvalidValue(
         `A cell range literal is not valid for ${valueType.getName()}`,
       );
     }
-    return new InvalidError(
+    return new InvalidValue(
       `${internalValueToString(
         result,
       )} is not valid for ${valueType.getName()}`,
@@ -63,7 +63,7 @@ export function parseValueToInternalRepresentation<
 }
 
 class InternalRepresentationParserVisitor extends ValueTypeVisitor<
-  InternalValueRepresentation | InvalidError
+  InternalValidValueRepresentation | InvalidValue
 > {
   constructor(private value: string, private parseOpts: ParseOpts) {
     super();
@@ -82,15 +82,15 @@ class InternalRepresentationParserVisitor extends ValueTypeVisitor<
     return value;
   }
 
-  visitBoolean(vt: BooleanValuetype): boolean | InvalidError {
+  visitBoolean(vt: BooleanValuetype): boolean | InvalidValue {
     return vt.fromString(this.applyTrimOptions(this.value));
   }
 
-  visitDecimal(vt: DecimalValuetype): number | InvalidError {
+  visitDecimal(vt: DecimalValuetype): number | InvalidValue {
     return vt.fromString(this.applyTrimOptions(this.value));
   }
 
-  visitInteger(vt: IntegerValuetype): number | InvalidError {
+  visitInteger(vt: IntegerValuetype): number | InvalidValue {
     return vt.fromString(this.applyTrimOptions(this.value));
   }
 
@@ -100,35 +100,35 @@ class InternalRepresentationParserVisitor extends ValueTypeVisitor<
 
   visitAtomicValueType(
     valueType: AtomicValueType,
-  ): InternalValueRepresentation | InvalidError {
+  ): InternalValidValueRepresentation | InvalidValue {
     const contained = valueType.getContainedType();
     assert(contained !== undefined);
 
     return contained.acceptVisitor(this);
   }
 
-  visitCellRange(): InvalidError {
-    return new InvalidError(`Cannot parse cell ranges into internal values`);
+  visitCellRange(): InvalidValue {
+    return new InvalidValue(`Cannot parse cell ranges into internal values`);
   }
 
-  visitCollection(): InvalidError {
-    return new InvalidError(`Cannot parse collections into internal values`);
+  visitCollection(): InvalidValue {
+    return new InvalidValue(`Cannot parse collections into internal values`);
   }
 
-  visitConstraint(): InvalidError {
-    return new InvalidError(`Cannot parse constraints into internal values`);
+  visitConstraint(): InvalidValue {
+    return new InvalidValue(`Cannot parse constraints into internal values`);
   }
 
-  visitRegex(): InvalidError {
-    return new InvalidError(`Cannot parse regex into internal values`);
+  visitRegex(): InvalidValue {
+    return new InvalidValue(`Cannot parse regex into internal values`);
   }
 
-  visitTransform(): InvalidError {
-    return new InvalidError(`Cannot parse transforms into internal values`);
+  visitTransform(): InvalidValue {
+    return new InvalidValue(`Cannot parse transforms into internal values`);
   }
 
-  visitValuetypeAssignment(): InvalidError {
-    return new InvalidError(
+  visitValuetypeAssignment(): InvalidValue {
+    return new InvalidValue(
       `Cannot parse valuetype assignments into internal values`,
     );
   }

--- a/libs/execution/src/lib/types/value-types/value-representation-validity.ts
+++ b/libs/execution/src/lib/types/value-types/value-representation-validity.ts
@@ -13,7 +13,7 @@ import {
   type ConstraintValuetype,
   type DecimalValuetype,
   type IntegerValuetype,
-  type InternalValueRepresentation,
+  type InternalValidValueRepresentation,
   type PrimitiveValueType,
   type RegexValuetype,
   type TextValuetype,
@@ -28,7 +28,7 @@ import { ConstraintExecutor } from '../../constraints';
 import { type ExecutionContext } from '../../execution-context';
 
 export function isValidValueRepresentation(
-  value: InternalValueRepresentation,
+  value: InternalValidValueRepresentation,
   valueType: ValueType,
   context: ExecutionContext,
 ): boolean {
@@ -38,7 +38,7 @@ export function isValidValueRepresentation(
 
 class ValueRepresentationValidityVisitor extends ValueTypeVisitor<boolean> {
   constructor(
-    private value: InternalValueRepresentation,
+    private value: InternalValidValueRepresentation,
     private context: ExecutionContext,
   ) {
     super();
@@ -118,6 +118,6 @@ class ValueRepresentationValidityVisitor extends ValueTypeVisitor<boolean> {
   }
 
   private isValidForPrimitiveValuetype(valueType: PrimitiveValueType): boolean {
-    return valueType.isInternalValueRepresentation(this.value);
+    return valueType.isInternalValidValueRepresentation(this.value);
   }
 }

--- a/libs/execution/src/lib/types/value-types/visitors/sql-value-representation-visitor.ts
+++ b/libs/execution/src/lib/types/value-types/visitors/sql-value-representation-visitor.ts
@@ -9,93 +9,112 @@ import {
   type AtomicValueType,
   type BooleanValuetype,
   type DecimalValuetype,
+  ERROR_TYPEGUARD,
   type IntegerValuetype,
+  type InternalErrorRepresentation,
   type InternalValueRepresentation,
   type TextValuetype,
   ValueTypeVisitor,
 } from '@jvalue/jayvee-language-server';
 
+// HACK: This is a temporary solution until errors have their own valuetype
+// See "Future changes" in RFC0017
+function wrap<T extends InternalValueRepresentation>(
+  f: (value: T) => string,
+): (value: T | InternalErrorRepresentation) => string {
+  return (value: T | InternalErrorRepresentation) => {
+    if (ERROR_TYPEGUARD(value)) {
+      return 'NULL';
+    }
+    return f(value);
+  };
+}
+
 export class SQLValueRepresentationVisitor extends ValueTypeVisitor<
-  (value: InternalValueRepresentation) => string
+  (value: InternalValueRepresentation | InternalErrorRepresentation) => string
 > {
-  visitBoolean(
-    valueType: BooleanValuetype,
-  ): (value: InternalValueRepresentation) => string {
-    return (value: InternalValueRepresentation) => {
+  override visitBoolean(valueType: BooleanValuetype) {
+    return wrap((value: InternalValueRepresentation) => {
       assert(valueType.isInternalValueRepresentation(value));
       return value ? `'true'` : `'false'`;
-    };
+    });
   }
 
-  visitDecimal(
-    valueType: DecimalValuetype,
-  ): (value: InternalValueRepresentation) => string {
-    return (value: InternalValueRepresentation) => {
+  override visitDecimal(valueType: DecimalValuetype) {
+    return wrap((value: InternalValueRepresentation) => {
       assert(valueType.isInternalValueRepresentation(value));
       return value.toString();
-    };
+    });
   }
 
-  visitInteger(
-    valueType: IntegerValuetype,
-  ): (value: InternalValueRepresentation) => string {
-    return (value: InternalValueRepresentation) => {
+  override visitInteger(valueType: IntegerValuetype) {
+    return wrap((value: InternalValueRepresentation) => {
       assert(valueType.isInternalValueRepresentation(value));
       return value.toString();
-    };
+    });
   }
 
-  visitText(
-    valueType: TextValuetype,
-  ): (value: InternalValueRepresentation) => string {
-    return (value: InternalValueRepresentation) => {
+  override visitText(valueType: TextValuetype) {
+    return wrap((value: InternalValueRepresentation) => {
       assert(valueType.isInternalValueRepresentation(value));
       const escapedValue = escapeSingleQuotes(value);
       return `'${escapedValue}'`;
-    };
+    });
   }
 
   override visitAtomicValueType(
     valueType: AtomicValueType,
-  ): (value: InternalValueRepresentation) => string {
+  ): (
+    value: InternalValueRepresentation | InternalErrorRepresentation,
+  ) => string {
     const contained = valueType.getContainedType();
     assert(contained !== undefined);
     return contained.acceptVisitor(this);
   }
 
-  override visitRegex(): (value: InternalValueRepresentation) => string {
+  override visitRegex(): (
+    value: InternalValueRepresentation | InternalErrorRepresentation,
+  ) => string {
     throw new Error(
       'No visit implementation given for regex. Cannot be the type of a column.',
     );
   }
 
-  override visitCellRange(): (value: InternalValueRepresentation) => string {
+  override visitCellRange(): (
+    value: InternalValueRepresentation | InternalErrorRepresentation,
+  ) => string {
     throw new Error(
       'No visit implementation given for cell ranges. Cannot be the type of a column.',
     );
   }
 
-  override visitConstraint(): (value: InternalValueRepresentation) => string {
+  override visitConstraint(): (
+    value: InternalValueRepresentation | InternalErrorRepresentation,
+  ) => string {
     throw new Error(
       'No visit implementation given for constraints. Cannot be the type of a column.',
     );
   }
 
   override visitValuetypeAssignment(): (
-    value: InternalValueRepresentation,
+    value: InternalValueRepresentation | InternalErrorRepresentation,
   ) => string {
     throw new Error(
       'No visit implementation given for value type assignments. Cannot be the type of a column.',
     );
   }
 
-  override visitCollection(): (value: InternalValueRepresentation) => string {
+  override visitCollection(): (
+    value: InternalValueRepresentation | InternalErrorRepresentation,
+  ) => string {
     throw new Error(
       'No visit implementation given for collections. Cannot be the type of a column.',
     );
   }
 
-  override visitTransform(): (value: InternalValueRepresentation) => string {
+  override visitTransform(): (
+    value: InternalValueRepresentation | InternalErrorRepresentation,
+  ) => string {
     throw new Error(
       'No visit implementation given for transforms. Cannot be the type of a column.',
     );

--- a/libs/execution/src/lib/types/value-types/visitors/sql-value-representation-visitor.ts
+++ b/libs/execution/src/lib/types/value-types/visitors/sql-value-representation-visitor.ts
@@ -11,18 +11,18 @@ import {
   type DecimalValuetype,
   ERROR_TYPEGUARD,
   type IntegerValuetype,
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
   type TextValuetype,
   ValueTypeVisitor,
 } from '@jvalue/jayvee-language-server';
 
 // HACK: This is a temporary solution until errors have their own valuetype
 // See "Future changes" in RFC0017
-function wrap<T extends InternalValueRepresentation>(
+function wrap<T extends InternalValidValueRepresentation>(
   f: (value: T) => string,
-): (value: T | InternalErrorRepresentation) => string {
-  return (value: T | InternalErrorRepresentation) => {
+): (value: T | InternalErrorValueRepresentation) => string {
+  return (value: T | InternalErrorValueRepresentation) => {
     if (ERROR_TYPEGUARD(value)) {
       return 'NULL';
     }
@@ -31,32 +31,34 @@ function wrap<T extends InternalValueRepresentation>(
 }
 
 export class SQLValueRepresentationVisitor extends ValueTypeVisitor<
-  (value: InternalValueRepresentation | InternalErrorRepresentation) => string
+  (
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
+  ) => string
 > {
   override visitBoolean(valueType: BooleanValuetype) {
-    return wrap((value: InternalValueRepresentation) => {
-      assert(valueType.isInternalValueRepresentation(value));
+    return wrap((value: InternalValidValueRepresentation) => {
+      assert(valueType.isInternalValidValueRepresentation(value));
       return value ? `'true'` : `'false'`;
     });
   }
 
   override visitDecimal(valueType: DecimalValuetype) {
-    return wrap((value: InternalValueRepresentation) => {
-      assert(valueType.isInternalValueRepresentation(value));
+    return wrap((value: InternalValidValueRepresentation) => {
+      assert(valueType.isInternalValidValueRepresentation(value));
       return value.toString();
     });
   }
 
   override visitInteger(valueType: IntegerValuetype) {
-    return wrap((value: InternalValueRepresentation) => {
-      assert(valueType.isInternalValueRepresentation(value));
+    return wrap((value: InternalValidValueRepresentation) => {
+      assert(valueType.isInternalValidValueRepresentation(value));
       return value.toString();
     });
   }
 
   override visitText(valueType: TextValuetype) {
-    return wrap((value: InternalValueRepresentation) => {
-      assert(valueType.isInternalValueRepresentation(value));
+    return wrap((value: InternalValidValueRepresentation) => {
+      assert(valueType.isInternalValidValueRepresentation(value));
       const escapedValue = escapeSingleQuotes(value);
       return `'${escapedValue}'`;
     });
@@ -65,7 +67,7 @@ export class SQLValueRepresentationVisitor extends ValueTypeVisitor<
   override visitAtomicValueType(
     valueType: AtomicValueType,
   ): (
-    value: InternalValueRepresentation | InternalErrorRepresentation,
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
   ) => string {
     const contained = valueType.getContainedType();
     assert(contained !== undefined);
@@ -73,7 +75,7 @@ export class SQLValueRepresentationVisitor extends ValueTypeVisitor<
   }
 
   override visitRegex(): (
-    value: InternalValueRepresentation | InternalErrorRepresentation,
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
   ) => string {
     throw new Error(
       'No visit implementation given for regex. Cannot be the type of a column.',
@@ -81,7 +83,7 @@ export class SQLValueRepresentationVisitor extends ValueTypeVisitor<
   }
 
   override visitCellRange(): (
-    value: InternalValueRepresentation | InternalErrorRepresentation,
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
   ) => string {
     throw new Error(
       'No visit implementation given for cell ranges. Cannot be the type of a column.',
@@ -89,7 +91,7 @@ export class SQLValueRepresentationVisitor extends ValueTypeVisitor<
   }
 
   override visitConstraint(): (
-    value: InternalValueRepresentation | InternalErrorRepresentation,
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
   ) => string {
     throw new Error(
       'No visit implementation given for constraints. Cannot be the type of a column.',
@@ -97,7 +99,7 @@ export class SQLValueRepresentationVisitor extends ValueTypeVisitor<
   }
 
   override visitValuetypeAssignment(): (
-    value: InternalValueRepresentation | InternalErrorRepresentation,
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
   ) => string {
     throw new Error(
       'No visit implementation given for value type assignments. Cannot be the type of a column.',
@@ -105,7 +107,7 @@ export class SQLValueRepresentationVisitor extends ValueTypeVisitor<
   }
 
   override visitCollection(): (
-    value: InternalValueRepresentation | InternalErrorRepresentation,
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
   ) => string {
     throw new Error(
       'No visit implementation given for collections. Cannot be the type of a column.',
@@ -113,7 +115,7 @@ export class SQLValueRepresentationVisitor extends ValueTypeVisitor<
   }
 
   override visitTransform(): (
-    value: InternalValueRepresentation | InternalErrorRepresentation,
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
   ) => string {
     throw new Error(
       'No visit implementation given for transforms. Cannot be the type of a column.',

--- a/libs/extensions/rdbms/exec/src/lib/postgres-loader-executor.spec.ts
+++ b/libs/extensions/rdbms/exec/src/lib/postgres-loader-executor.spec.ts
@@ -174,7 +174,7 @@ describe('Validation of PostgresLoaderExecutor', () => {
     expect(R.isOk(result)).toEqual(false);
     if (R.isErr(result)) {
       expect(result.left.message).toEqual(
-        'Could not write to postgres database: Connection error',
+        'Could not connect to postgres database: Connection error',
       );
       expect(databaseConnectMock).toBeCalledTimes(1);
       expect(databaseQueryMock).toBeCalledTimes(0);

--- a/libs/extensions/tabular/exec/src/lib/csv-file-loader-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/csv-file-loader-executor.ts
@@ -21,6 +21,7 @@ import {
 } from '@jvalue/jayvee-execution';
 import {
   IOType,
+  InternalErrorRepresentation,
   type InternalValueRepresentation,
 } from '@jvalue/jayvee-language-server';
 
@@ -81,9 +82,10 @@ function getHeaders(table: Table): string[] {
 }
 
 function toRows(table: Table): Row[] {
-  const columns: InternalValueRepresentation[][] = [
-    ...table.getColumns().entries(),
-  ].map((column) => column[1].values);
+  const columns: (
+    | InternalValueRepresentation
+    | InternalErrorRepresentation
+  )[][] = [...table.getColumns().entries()].map((column) => column[1].values);
 
   return transposeArray(columns);
 }

--- a/libs/extensions/tabular/exec/src/lib/csv-file-loader-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/csv-file-loader-executor.ts
@@ -21,8 +21,8 @@ import {
 } from '@jvalue/jayvee-execution';
 import {
   IOType,
-  InternalErrorRepresentation,
-  type InternalValueRepresentation,
+  InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
 } from '@jvalue/jayvee-language-server';
 
 @implementsStatic<BlockExecutorClass>()
@@ -83,8 +83,8 @@ function getHeaders(table: Table): string[] {
 
 function toRows(table: Table): Row[] {
   const columns: (
-    | InternalValueRepresentation
-    | InternalErrorRepresentation
+    | InternalValidValueRepresentation
+    | InternalErrorValueRepresentation
   )[][] = [...table.getColumns().entries()].map((column) => column[1].values);
 
   return transposeArray(columns);

--- a/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.spec.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.spec.ts
@@ -9,6 +9,7 @@ import { getTestExecutionContext } from '@jvalue/jayvee-execution/test';
 import {
   type BlockDefinition,
   IOType,
+  InvalidError,
   type JayveeServices,
   createJayveeServices,
 } from '@jvalue/jayvee-language-server';
@@ -166,7 +167,7 @@ describe('Validation of TableInterpreterExecutor', () => {
       }
     });
 
-    it('should diagnose skipping row on wrong cell value type', async () => {
+    it('should diagnose InvalidError on wrong cell value type', async () => {
       const text = readJvTestAsset('valid-wrong-value-type-with-header.jv');
 
       const testWorkbook = await readTestWorkbook('test-with-header.xlsx');
@@ -179,7 +180,13 @@ describe('Validation of TableInterpreterExecutor', () => {
       if (R.isOk(result)) {
         expect(result.right.ioType).toEqual(IOType.TABLE);
         expect(result.right.getNumberOfColumns()).toEqual(3);
-        expect(result.right.getNumberOfRows()).toEqual(0);
+        expect(result.right.getNumberOfRows()).toEqual(16);
+        const flagColumn = result.right.getColumn('flag');
+        expect(flagColumn).toBeDefined();
+        assert(flagColumn !== undefined);
+        for (const cell of flagColumn.values) {
+          expect(cell).toBeInstanceOf(InvalidError);
+        }
       }
     });
   });
@@ -230,7 +237,7 @@ describe('Validation of TableInterpreterExecutor', () => {
       if (R.isOk(result)) {
         expect(result.right.ioType).toEqual(IOType.TABLE);
         expect(result.right.getNumberOfColumns()).toEqual(3);
-        expect(result.right.getNumberOfRows()).toEqual(16);
+        expect(result.right.getNumberOfRows()).toEqual(17);
         expect(result.right.getColumn('index')).toEqual(
           expect.objectContaining({
             values: expect.arrayContaining([0, 1, 2, 15]) as number[],
@@ -246,6 +253,12 @@ describe('Validation of TableInterpreterExecutor', () => {
             values: expect.arrayContaining([true, false]) as boolean[],
           }),
         );
+        for (const value of result.right.getRow(0).values()) {
+          if (value === 'name') {
+            continue;
+          }
+          expect(value).toBeInstanceOf(InvalidError);
+        }
       }
     });
 
@@ -283,7 +296,7 @@ describe('Validation of TableInterpreterExecutor', () => {
       }
     });
 
-    it('should diagnose skipping row on wrong cell value type', async () => {
+    it('should insert InvalidError on wrong cell value type', async () => {
       const text = readJvTestAsset('valid-wrong-value-type-without-header.jv');
 
       const testWorkbook = await readTestWorkbook('test-without-header.xlsx');
@@ -296,7 +309,13 @@ describe('Validation of TableInterpreterExecutor', () => {
       if (R.isOk(result)) {
         expect(result.right.ioType).toEqual(IOType.TABLE);
         expect(result.right.getNumberOfColumns()).toEqual(3);
-        expect(result.right.getNumberOfRows()).toEqual(0);
+        expect(result.right.getNumberOfRows()).toEqual(16);
+        const flagColumn = result.right.getColumn('flag');
+        expect(flagColumn).toBeDefined();
+        assert(flagColumn !== undefined);
+        for (const cell of flagColumn.values) {
+          expect(cell).toBeInstanceOf(InvalidError);
+        }
       }
     });
 
@@ -348,7 +367,13 @@ describe('Validation of TableInterpreterExecutor', () => {
       if (R.isOk(result)) {
         expect(result.right.ioType).toEqual(IOType.TABLE);
         expect(result.right.getNumberOfColumns()).toEqual(3);
-        expect(result.right.getNumberOfRows()).toEqual(0);
+        expect(result.right.getNumberOfRows()).toEqual(3);
+        const indexColumn = result.right.getColumn('index')?.values;
+        expect(indexColumn).toBeDefined();
+        assert(indexColumn !== undefined);
+        indexColumn.forEach((cell) =>
+          expect(cell).toBeInstanceOf(InvalidError),
+        );
       }
     });
   });

--- a/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.spec.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.spec.ts
@@ -9,7 +9,7 @@ import { getTestExecutionContext } from '@jvalue/jayvee-execution/test';
 import {
   type BlockDefinition,
   IOType,
-  InvalidError,
+  InvalidValue,
   type JayveeServices,
   createJayveeServices,
 } from '@jvalue/jayvee-language-server';
@@ -167,7 +167,7 @@ describe('Validation of TableInterpreterExecutor', () => {
       }
     });
 
-    it('should diagnose InvalidError on wrong cell value type', async () => {
+    it('should diagnose InvalidValue on wrong cell value type', async () => {
       const text = readJvTestAsset('valid-wrong-value-type-with-header.jv');
 
       const testWorkbook = await readTestWorkbook('test-with-header.xlsx');
@@ -185,7 +185,7 @@ describe('Validation of TableInterpreterExecutor', () => {
         expect(flagColumn).toBeDefined();
         assert(flagColumn !== undefined);
         for (const cell of flagColumn.values) {
-          expect(cell).toBeInstanceOf(InvalidError);
+          expect(cell).toBeInstanceOf(InvalidValue);
         }
       }
     });
@@ -257,7 +257,7 @@ describe('Validation of TableInterpreterExecutor', () => {
           if (value === 'name') {
             continue;
           }
-          expect(value).toBeInstanceOf(InvalidError);
+          expect(value).toBeInstanceOf(InvalidValue);
         }
       }
     });
@@ -296,7 +296,7 @@ describe('Validation of TableInterpreterExecutor', () => {
       }
     });
 
-    it('should insert InvalidError on wrong cell value type', async () => {
+    it('should insert InvalidValue on wrong cell value type', async () => {
       const text = readJvTestAsset('valid-wrong-value-type-without-header.jv');
 
       const testWorkbook = await readTestWorkbook('test-without-header.xlsx');
@@ -314,7 +314,7 @@ describe('Validation of TableInterpreterExecutor', () => {
         expect(flagColumn).toBeDefined();
         assert(flagColumn !== undefined);
         for (const cell of flagColumn.values) {
-          expect(cell).toBeInstanceOf(InvalidError);
+          expect(cell).toBeInstanceOf(InvalidValue);
         }
       }
     });
@@ -372,7 +372,7 @@ describe('Validation of TableInterpreterExecutor', () => {
         expect(indexColumn).toBeDefined();
         assert(indexColumn !== undefined);
         indexColumn.forEach((cell) =>
-          expect(cell).toBeInstanceOf(InvalidError),
+          expect(cell).toBeInstanceOf(InvalidValue),
         );
       }
     });

--- a/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-interpreter-executor.ts
@@ -20,10 +20,10 @@ import {
   CellIndex,
   ERROR_TYPEGUARD,
   IOType,
-  InternalErrorRepresentation,
-  type InternalValueRepresentation,
-  InvalidError,
-  MissingError,
+  InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
+  InvalidValue,
+  MissingValue,
   type ValueType,
   type ValuetypeAssignment,
   internalValueToString,
@@ -189,7 +189,7 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
               skipTrailingWhitespace,
               context,
             )
-          : new MissingError(
+          : new MissingValue(
               `The sheet row did not contain a value at index ${sheetColumnIndex}`,
             );
       if (ERROR_TYPEGUARD(parsedValue)) {
@@ -212,7 +212,7 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
     skipLeadingWhitespace: boolean,
     skipTrailingWhitespace: boolean,
     context: ExecutionContext,
-  ): InternalValueRepresentation | InternalErrorRepresentation {
+  ): InternalValidValueRepresentation | InternalErrorValueRepresentation {
     const parsedValue = parseValueToInternalRepresentation(value, valueType, {
       skipLeadingWhitespace,
       skipTrailingWhitespace,
@@ -222,7 +222,7 @@ export class TableInterpreterExecutor extends AbstractBlockExecutor<
       !ERROR_TYPEGUARD(parsedValue) &&
       !isValidValueRepresentation(parsedValue, valueType, context)
     ) {
-      return new InvalidError(
+      return new InvalidValue(
         `The following value was not valid for valuetype ${valueType.getName()}: ${internalValueToString(
           parsedValue,
           context.wrapperFactories,

--- a/libs/extensions/tabular/exec/src/lib/table-transformer-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-transformer-executor.ts
@@ -17,7 +17,7 @@ import {
 } from '@jvalue/jayvee-execution';
 import {
   IOType,
-  type InternalValueRepresentation,
+  type InternalValidValueRepresentation,
 } from '@jvalue/jayvee-language-server';
 
 @implementsStatic<BlockExecutorClass>()
@@ -158,7 +158,7 @@ export class TableTransformerExecutor extends AbstractBlockExecutor<
 
   private createOutputTable(
     inputTable: R.Table,
-    transformResult: R.TableColumn<InternalValueRepresentation>,
+    transformResult: R.TableColumn<InternalValidValueRepresentation>,
     outputColumnName: string,
   ) {
     const outputTable = inputTable.clone();

--- a/libs/extensions/tabular/exec/src/lib/table-transformer-executor.ts
+++ b/libs/extensions/tabular/exec/src/lib/table-transformer-executor.ts
@@ -158,15 +158,11 @@ export class TableTransformerExecutor extends AbstractBlockExecutor<
 
   private createOutputTable(
     inputTable: R.Table,
-    transformResult: {
-      resultingColumn: R.TableColumn<InternalValueRepresentation>;
-      rowsToDelete: number[];
-    },
+    transformResult: R.TableColumn<InternalValueRepresentation>,
     outputColumnName: string,
   ) {
     const outputTable = inputTable.clone();
-    outputTable.dropRows(transformResult.rowsToDelete);
-    outputTable.addColumn(outputColumnName, transformResult.resultingColumn);
+    outputTable.addColumn(outputColumnName, transformResult);
     return outputTable;
   }
 

--- a/libs/extensions/tabular/exec/test/util.ts
+++ b/libs/extensions/tabular/exec/test/util.ts
@@ -11,8 +11,8 @@ import {
   parseValueToInternalRepresentation,
 } from '@jvalue/jayvee-execution';
 import {
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
   type ValueType,
 } from '@jvalue/jayvee-language-server';
 import * as exceljs from 'exceljs';
@@ -113,6 +113,6 @@ function constructTableRow(
 function parseAndValidatePrimitiveValue(
   value: string,
   valueType: ValueType,
-): InternalValueRepresentation | InternalErrorRepresentation {
+): InternalValidValueRepresentation | InternalErrorValueRepresentation {
   return parseValueToInternalRepresentation(value, valueType);
 }

--- a/libs/extensions/tabular/exec/test/util.ts
+++ b/libs/extensions/tabular/exec/test/util.ts
@@ -11,6 +11,7 @@ import {
   parseValueToInternalRepresentation,
 } from '@jvalue/jayvee-execution';
 import {
+  type InternalErrorRepresentation,
   type InternalValueRepresentation,
   type ValueType,
 } from '@jvalue/jayvee-language-server';
@@ -101,12 +102,10 @@ function constructTableRow(
       const value = cell.text;
       const valueType = columnDefinition.valueType;
 
-      const parsedValue = parseAndValidatePrimitiveValue(value, valueType);
-      if (parsedValue === undefined) {
-        return;
-      }
-
-      tableRow[columnDefinition.columnName] = parsedValue;
+      tableRow[columnDefinition.columnName] = parseAndValidatePrimitiveValue(
+        value,
+        valueType,
+      );
     },
   );
   return tableRow;
@@ -114,11 +113,6 @@ function constructTableRow(
 function parseAndValidatePrimitiveValue(
   value: string,
   valueType: ValueType,
-): InternalValueRepresentation | undefined {
-  const parsedValue = parseValueToInternalRepresentation(value, valueType);
-  if (parsedValue === undefined) {
-    return undefined;
-  }
-
-  return parsedValue;
+): InternalValueRepresentation | InternalErrorRepresentation {
+  return parseValueToInternalRepresentation(value, valueType);
 }

--- a/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.spec.ts
+++ b/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.spec.ts
@@ -128,7 +128,7 @@ describe('Validation of validateRuntimeParameterLiteral', () => {
     expect(validationAcceptorMock).toHaveBeenCalledTimes(1);
     expect(validationAcceptorMock).toHaveBeenLastCalledWith(
       'error',
-      'InvalidError: "Value 1" is not a number',
+      'InvalidValue: "Value 1" is not a number',
       expect.any(Object),
     );
   });

--- a/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.spec.ts
+++ b/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.spec.ts
@@ -128,7 +128,7 @@ describe('Validation of validateRuntimeParameterLiteral', () => {
     expect(validationAcceptorMock).toHaveBeenCalledTimes(1);
     expect(validationAcceptorMock).toHaveBeenLastCalledWith(
       'error',
-      `Unable to parse the value "Value 1" as integer.`,
+      'InvalidError: "Value 1" is not a number',
       expect.any(Object),
     );
   });

--- a/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.ts
+++ b/libs/interpreter-lib/src/validation-checks/runtime-parameter-literal.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
+  ERROR_TYPEGUARD,
   type JayveeValidationProps,
   type PropertyBody,
   type ReferenceableBlockTypeDefinition,
@@ -83,18 +84,10 @@ function checkRuntimeParameterValueParsing(
       runtimeParameterName,
       valueType,
     );
-  if (runtimeParameterValue === undefined) {
-    const rawValue =
-      props.evaluationContext.runtimeParameterProvider.getRawValue(
-        runtimeParameterName,
-      );
-    props.validationContext.accept(
-      'error',
-      `Unable to parse the value "${
-        rawValue ?? ''
-      }" as ${valueType.getName()}.`,
-      { node: runtimeParameter },
-    );
+  if (ERROR_TYPEGUARD(runtimeParameterValue)) {
+    props.validationContext.accept('error', runtimeParameterValue.toString(), {
+      node: runtimeParameter,
+    });
   }
 }
 

--- a/libs/language-server/src/grammar/expression.langium
+++ b/libs/language-server/src/grammar/expression.langium
@@ -64,7 +64,8 @@ ValueLiteral:
   | RegexLiteral
   | CellRangeLiteral
   | ValuetypeAssignmentLiteral
-  | CollectionLiteral;
+  | CollectionLiteral
+  | ErrorLiteral;
 
 TextLiteral:
   value=STRING;
@@ -81,6 +82,9 @@ RegexLiteral:
 
 CollectionLiteral:
   '[' (values+=(Expression) (',' values+=(Expression))*)? ','? ']';
+
+ErrorLiteral:
+  error= "invalid" | "missing";
 
 FreeVariableLiteral:
   ValueKeywordLiteral | ReferenceLiteral;

--- a/libs/language-server/src/lib/ast/expressions/evaluate-expression.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluate-expression.ts
@@ -16,6 +16,7 @@ import {
   isBlockTypeProperty,
   isCellRangeLiteral,
   isCollectionLiteral,
+  isErrorLiteral,
   isExpression,
   isExpressionLiteral,
   isFreeVariableLiteral,
@@ -29,39 +30,37 @@ import { type ValueType, type WrapperFactoryProvider } from '../wrappers';
 
 import { type EvaluationContext } from './evaluation-context';
 import { EvaluationStrategy } from './evaluation-strategy';
-import { type InternalValueRepresentation } from './internal-value-representation';
-import { isEveryValueDefined } from './typeguards';
+import {
+  type InternalErrorRepresentation,
+  type InternalValueRepresentation,
+  InvalidError,
+  MissingError,
+  internalValueToString,
+} from './internal-value-representation';
+import { ERROR_TYPEGUARD } from './typeguards';
 
 export function evaluatePropertyValue<T extends InternalValueRepresentation>(
   property: PropertyAssignment,
   evaluationContext: EvaluationContext,
   wrapperFactories: WrapperFactoryProvider,
   valueType: ValueType<T>,
-): T | undefined {
+): T | InternalErrorRepresentation {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const propertyValue = property?.value;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   assert(propertyValue !== undefined);
 
-  if (isBlockTypeProperty(propertyValue)) {
-    // Properties of block types are always undefined
-    // because they are set in the block that instantiates the block type
-    return undefined;
-  }
+  // Properties of block types are always undefined
+  // because they are set in the block that instantiates the block type
+  assert(!isBlockTypeProperty(propertyValue));
 
-  let result: InternalValueRepresentation | undefined;
+  let result: InternalValueRepresentation | InternalErrorRepresentation;
   if (isRuntimeParameterLiteral(propertyValue)) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    const runtimeParameterName = propertyValue?.name;
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (runtimeParameterName === undefined) {
-      result = undefined;
-    } else {
-      result = evaluationContext.getValueForRuntimeParameter(
-        runtimeParameterName,
-        valueType,
-      );
-    }
+    const runtimeParameterName = propertyValue.name;
+    result = evaluationContext.getValueForRuntimeParameter(
+      runtimeParameterName,
+      valueType,
+    );
   } else if (isExpression(propertyValue)) {
     result = evaluateExpression(
       propertyValue,
@@ -73,24 +72,23 @@ export function evaluatePropertyValue<T extends InternalValueRepresentation>(
   }
 
   assert(
-    result === undefined || valueType.isInternalValueRepresentation(result),
+    ERROR_TYPEGUARD(result) || valueType.isInternalValueRepresentation(result),
     `Evaluation result ${
-      result?.toString() ?? 'undefined'
-    } is not valid: Neither undefined, nor of type ${valueType.getName()}`,
+      ERROR_TYPEGUARD(result)
+        ? result.name
+        : internalValueToString(result, wrapperFactories)
+    } is not of type ${valueType.getName()}`,
   );
   return result;
 }
 
 export function evaluateExpression(
-  expression: Expression | undefined,
+  expression: Expression,
   evaluationContext: EvaluationContext,
   wrapperFactories: WrapperFactoryProvider,
   context: ValidationContext | undefined = undefined,
   strategy: EvaluationStrategy = EvaluationStrategy.LAZY,
-): InternalValueRepresentation | undefined {
-  if (expression === undefined) {
-    return undefined;
-  }
+): InternalValueRepresentation | InternalErrorRepresentation {
   if (isExpressionLiteral(expression)) {
     if (isFreeVariableLiteral(expression)) {
       return evaluationContext.getValueFor(expression);
@@ -147,35 +145,42 @@ function evaluateValueLiteral(
   wrapperFactories: WrapperFactoryProvider,
   validationContext: ValidationContext | undefined = undefined,
   strategy: EvaluationStrategy = EvaluationStrategy.LAZY,
-): InternalValueRepresentation | undefined {
+): InternalValueRepresentation | InternalErrorRepresentation {
+  if (isErrorLiteral(expression)) {
+    return expression.error === 'invalid'
+      ? new InvalidError('Created by user')
+      : new MissingError('Created by user');
+  }
   if (isCollectionLiteral(expression)) {
-    const evaluatedCollection = expression.values.map((v) =>
-      evaluateExpression(
-        v,
+    const evaluatedCollection: InternalValueRepresentation[] = [];
+    for (const value of expression.values) {
+      const result = evaluateExpression(
+        value,
         evaluationContext,
         wrapperFactories,
         validationContext,
         strategy,
-      ),
-    );
-    if (!isEveryValueDefined(evaluatedCollection)) {
-      return undefined;
+      );
+      if (ERROR_TYPEGUARD(result)) {
+        return result;
+      }
+      evaluatedCollection.push(result);
     }
     return evaluatedCollection;
   }
   if (isCellRangeLiteral(expression)) {
     if (!wrapperFactories.CellRange.canWrap(expression)) {
-      return undefined;
+      return new InvalidError(
+        `${internalValueToString(
+          expression,
+          wrapperFactories,
+        )} is not a valid cell range`,
+      );
     }
     return expression;
   }
   if (isRegexLiteral(expression)) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (expression?.value === undefined) {
-      return undefined;
-    }
     return new RegExp(expression.value);
   }
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  return expression?.value;
+  return expression.value;
 }

--- a/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
@@ -78,7 +78,7 @@ export class EvaluationContext {
     if (dereferenced === undefined) {
       const error = referenceLiteral.value.error;
       assert(error !== undefined);
-      return new MissingError(`Could not resolve reverence: ${error.message}`);
+      return new MissingError(`Could not resolve reference: ${error.message}`);
     }
 
     if (isConstraintDefinition(dereferenced)) {

--- a/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
@@ -90,19 +90,25 @@ export class EvaluationContext {
     if (isTransformPortDefinition(dereferenced)) {
       return (
         this.variableValues.get(dereferenced.name) ??
-        new MissingValue(`Could not find value for ${dereferenced.name}`)
+        new MissingValue(
+          `Could not find value for transform port ${dereferenced.name}`,
+        )
       );
     }
     if (isBlockTypeProperty(dereferenced)) {
       return (
         this.variableValues.get(dereferenced.name) ??
-        new MissingValue(`Could not find value for ${dereferenced.name}`)
+        new MissingValue(
+          `Could not find value for block type property ${dereferenced.name}`,
+        )
       );
     }
     if (isValueTypeAttribute(dereferenced)) {
       return (
         this.variableValues.get(dereferenced.name) ??
-        new MissingValue(`Could not find value for ${dereferenced.name}`)
+        new MissingValue(
+          `Could not find value for value type attribute ${dereferenced.name}`,
+        )
       );
     }
     assertUnreachable(dereferenced);

--- a/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluation-context.ts
@@ -24,24 +24,24 @@ import { type ValueTypeProvider } from '../wrappers';
 import { type ValueType } from '../wrappers/value-type/value-type';
 
 import {
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
-  MissingError,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
+  MissingValue,
 } from './internal-value-representation';
 import { type OperatorEvaluatorRegistry } from './operator-registry';
 
-const NO_KEYWORD_ERROR: MissingError = new MissingError(
+const NO_KEYWORD_ERROR: MissingValue = new MissingValue(
   'No value keyword literal',
 );
 
 export class EvaluationContext {
   private readonly variableValues = new Map<
     string,
-    InternalValueRepresentation | InternalErrorRepresentation
+    InternalValidValueRepresentation | InternalErrorValueRepresentation
   >();
   private valueKeywordValue:
-    | InternalValueRepresentation
-    | InternalErrorRepresentation = NO_KEYWORD_ERROR;
+    | InternalValidValueRepresentation
+    | InternalErrorValueRepresentation = NO_KEYWORD_ERROR;
 
   constructor(
     public readonly runtimeParameterProvider: RuntimeParameterProvider,
@@ -51,7 +51,7 @@ export class EvaluationContext {
 
   getValueFor(
     literal: FreeVariableLiteral,
-  ): InternalValueRepresentation | InternalErrorRepresentation {
+  ): InternalValidValueRepresentation | InternalErrorValueRepresentation {
     if (isReferenceLiteral(literal)) {
       return this.getValueForReference(literal);
     } else if (isValueKeywordLiteral(literal)) {
@@ -62,7 +62,7 @@ export class EvaluationContext {
 
   setValueForReference(
     refText: string,
-    value: InternalValueRepresentation | InternalErrorRepresentation,
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
   ): void {
     this.variableValues.set(refText, value);
   }
@@ -73,12 +73,12 @@ export class EvaluationContext {
 
   getValueForReference(
     referenceLiteral: ReferenceLiteral,
-  ): InternalValueRepresentation | InternalErrorRepresentation {
+  ): InternalValidValueRepresentation | InternalErrorValueRepresentation {
     const dereferenced = referenceLiteral.value.ref;
     if (dereferenced === undefined) {
       const error = referenceLiteral.value.error;
       assert(error !== undefined);
-      return new MissingError(`Could not resolve reference: ${error.message}`);
+      return new MissingValue(`Could not resolve reference: ${error.message}`);
     }
 
     if (isConstraintDefinition(dereferenced)) {
@@ -90,19 +90,19 @@ export class EvaluationContext {
     if (isTransformPortDefinition(dereferenced)) {
       return (
         this.variableValues.get(dereferenced.name) ??
-        new MissingError(`Could not find value for ${dereferenced.name}`)
+        new MissingValue(`Could not find value for ${dereferenced.name}`)
       );
     }
     if (isBlockTypeProperty(dereferenced)) {
       return (
         this.variableValues.get(dereferenced.name) ??
-        new MissingError(`Could not find value for ${dereferenced.name}`)
+        new MissingValue(`Could not find value for ${dereferenced.name}`)
       );
     }
     if (isValueTypeAttribute(dereferenced)) {
       return (
         this.variableValues.get(dereferenced.name) ??
-        new MissingError(`Could not find value for ${dereferenced.name}`)
+        new MissingValue(`Could not find value for ${dereferenced.name}`)
       );
     }
     assertUnreachable(dereferenced);
@@ -112,15 +112,15 @@ export class EvaluationContext {
     return this.runtimeParameterProvider.hasValue(key);
   }
 
-  getValueForRuntimeParameter<I extends InternalValueRepresentation>(
+  getValueForRuntimeParameter<I extends InternalValidValueRepresentation>(
     key: string,
     valueType: ValueType<I>,
-  ): I | InternalErrorRepresentation {
+  ): I | InternalErrorValueRepresentation {
     return this.runtimeParameterProvider.getParsedValue(key, valueType);
   }
 
   setValueForValueKeyword(
-    value: InternalValueRepresentation | InternalErrorRepresentation,
+    value: InternalValidValueRepresentation | InternalErrorValueRepresentation,
   ) {
     this.valueKeywordValue = value;
   }
@@ -130,8 +130,8 @@ export class EvaluationContext {
   }
 
   getValueForValueKeyword():
-    | InternalValueRepresentation
-    | InternalErrorRepresentation {
+    | InternalValidValueRepresentation
+    | InternalErrorValueRepresentation {
     return this.valueKeywordValue;
   }
 }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/division-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/division-operator-evaluator.ts
@@ -7,7 +7,7 @@ import { strict as assert } from 'assert';
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type BinaryExpression } from '../../generated/ast';
-import { InvalidError } from '../internal-value-representation';
+import { InvalidValue } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD } from '../typeguards';
 
@@ -25,7 +25,7 @@ export class DivisionOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
     rightValue: number,
     expression: BinaryExpression,
     context: ValidationContext | undefined,
-  ): number | InvalidError {
+  ): number | InvalidValue {
     const resultingValue = leftValue / rightValue;
 
     if (!isFinite(resultingValue)) {
@@ -33,7 +33,7 @@ export class DivisionOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
       context?.accept('error', 'Arithmetic error: division by zero', {
         node: expression,
       });
-      return new InvalidError('Cannot divide by zero!');
+      return new InvalidValue('Cannot divide by zero!');
     }
     return resultingValue;
   }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/division-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/division-operator-evaluator.ts
@@ -7,6 +7,7 @@ import { strict as assert } from 'assert';
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type BinaryExpression } from '../../generated/ast';
+import { InvalidError } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD } from '../typeguards';
 
@@ -24,7 +25,7 @@ export class DivisionOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
     rightValue: number,
     expression: BinaryExpression,
     context: ValidationContext | undefined,
-  ): number | undefined {
+  ): number | InvalidError {
     const resultingValue = leftValue / rightValue;
 
     if (!isFinite(resultingValue)) {
@@ -32,7 +33,7 @@ export class DivisionOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
       context?.accept('error', 'Arithmetic error: division by zero', {
         node: expression,
       });
-      return undefined;
+      return new InvalidError('Cannot divide by zero!');
     }
     return resultingValue;
   }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/equality-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/equality-operator-evaluator.ts
@@ -2,25 +2,25 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../internal-value-representation';
+import { type InternalValidValueRepresentation } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
-import { INTERNAL_VALUE_REPRESENTATION_TYPEGUARD } from '../typeguards';
+import { INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD } from '../typeguards';
 
 export class EqualityOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
-  InternalValueRepresentation,
-  InternalValueRepresentation,
+  InternalValidValueRepresentation,
+  InternalValidValueRepresentation,
   boolean
 > {
   constructor() {
     super(
       '==',
-      INTERNAL_VALUE_REPRESENTATION_TYPEGUARD,
-      INTERNAL_VALUE_REPRESENTATION_TYPEGUARD,
+      INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD,
+      INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD,
     );
   }
   override doEvaluate(
-    left: InternalValueRepresentation,
-    right: InternalValueRepresentation,
+    left: InternalValidValueRepresentation,
+    right: InternalValidValueRepresentation,
   ): boolean {
     return left === right;
   }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/in-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/in-operator-evaluator.ts
@@ -3,15 +3,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
-  type InternalValueRepresentation,
-  type InternalValueRepresentationTypeguard,
+  type InternalValidValueRepresentation,
+  type InternalValidValueRepresentationTypeguard,
 } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD, STRING_TYPEGUARD } from '../typeguards';
 
 export class InOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
-  InternalValueRepresentation,
-  InternalValueRepresentation[],
+  InternalValidValueRepresentation,
+  InternalValidValueRepresentation[],
   boolean
 > {
   constructor() {
@@ -29,13 +29,13 @@ export class InOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
   }
 }
 
-const isLeftOperandMatchingValueRepresentationTypeguard: InternalValueRepresentationTypeguard<
+const isLeftOperandMatchingValueRepresentationTypeguard: InternalValidValueRepresentationTypeguard<
   string | number
 > = (value) => {
   return STRING_TYPEGUARD(value) || NUMBER_TYPEGUARD(value);
 };
 
-const isRightOperandMatchingValueRepresentationTypeguard: InternalValueRepresentationTypeguard<
+const isRightOperandMatchingValueRepresentationTypeguard: InternalValidValueRepresentationTypeguard<
   (string | number)[]
 > = (value) => {
   return (

--- a/libs/language-server/src/lib/ast/expressions/evaluators/inequality-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/inequality-operator-evaluator.ts
@@ -2,25 +2,25 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../internal-value-representation';
+import { type InternalValidValueRepresentation } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
-import { INTERNAL_VALUE_REPRESENTATION_TYPEGUARD } from '../typeguards';
+import { INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD } from '../typeguards';
 
 export class InequalityOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
-  InternalValueRepresentation,
-  InternalValueRepresentation,
+  InternalValidValueRepresentation,
+  InternalValidValueRepresentation,
   boolean
 > {
   constructor() {
     super(
       '!=',
-      INTERNAL_VALUE_REPRESENTATION_TYPEGUARD,
-      INTERNAL_VALUE_REPRESENTATION_TYPEGUARD,
+      INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD,
+      INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD,
     );
   }
   override doEvaluate(
-    left: InternalValueRepresentation,
-    right: InternalValueRepresentation,
+    left: InternalValidValueRepresentation,
+    right: InternalValidValueRepresentation,
   ): boolean {
     return left !== right;
   }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/lengthof-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/lengthof-operator-evaluator.ts
@@ -11,8 +11,13 @@ import { type WrapperFactoryProvider } from '../../wrappers/wrapper-factory-prov
 import { evaluateExpression } from '../evaluate-expression';
 import { type EvaluationContext } from '../evaluation-context';
 import { type EvaluationStrategy } from '../evaluation-strategy';
+import { type InternalErrorRepresentation } from '../internal-value-representation';
 import { type OperatorEvaluator } from '../operator-evaluator';
-import { COLLECTION_TYPEGUARD, STRING_TYPEGUARD } from '../typeguards';
+import {
+  COLLECTION_TYPEGUARD,
+  ERROR_TYPEGUARD,
+  STRING_TYPEGUARD,
+} from '../typeguards';
 
 export class LengthofOperatorEvaluator
   implements OperatorEvaluator<UnaryExpression>
@@ -25,7 +30,7 @@ export class LengthofOperatorEvaluator
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): number | undefined {
+  ): number | InternalErrorRepresentation {
     assert(expression.operator === this.operator);
     const operandValue = evaluateExpression(
       expression.expression,
@@ -34,16 +39,14 @@ export class LengthofOperatorEvaluator
       validationContext,
       strategy,
     );
-    if (operandValue === undefined) {
-      return undefined;
+    if (ERROR_TYPEGUARD(operandValue)) {
+      return operandValue;
     }
 
-    if (STRING_TYPEGUARD(operandValue)) {
-      return operandValue.length;
-    } else if (COLLECTION_TYPEGUARD(operandValue)) {
-      return operandValue.length;
-    }
+    assert(
+      STRING_TYPEGUARD(operandValue) || COLLECTION_TYPEGUARD(operandValue),
+    );
 
-    return undefined;
+    return operandValue.length;
   }
 }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/lengthof-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/lengthof-operator-evaluator.ts
@@ -11,7 +11,7 @@ import { type WrapperFactoryProvider } from '../../wrappers/wrapper-factory-prov
 import { evaluateExpression } from '../evaluate-expression';
 import { type EvaluationContext } from '../evaluation-context';
 import { type EvaluationStrategy } from '../evaluation-strategy';
-import { type InternalErrorRepresentation } from '../internal-value-representation';
+import { type InternalErrorValueRepresentation } from '../internal-value-representation';
 import { type OperatorEvaluator } from '../operator-evaluator';
 import {
   COLLECTION_TYPEGUARD,
@@ -30,7 +30,7 @@ export class LengthofOperatorEvaluator
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): number | InternalErrorRepresentation {
+  ): number | InternalErrorValueRepresentation {
     assert(expression.operator === this.operator);
     const operandValue = evaluateExpression(
       expression.expression,

--- a/libs/language-server/src/lib/ast/expressions/evaluators/modulo-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/modulo-operator-evaluator.ts
@@ -4,6 +4,7 @@
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type BinaryExpression } from '../../generated/ast';
+import { InvalidError } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD } from '../typeguards';
 
@@ -21,7 +22,7 @@ export class ModuloOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
     rightValue: number,
     expression: BinaryExpression,
     context: ValidationContext | undefined,
-  ): number | undefined {
+  ): number | InvalidError {
     const resultingValue = leftValue % rightValue;
 
     if (!isFinite(resultingValue)) {
@@ -29,12 +30,14 @@ export class ModuloOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
         context?.accept('error', 'Arithmetic error: modulo by zero', {
           node: expression,
         });
-      } else {
-        context?.accept('error', 'Unknown arithmetic error', {
-          node: expression,
-        });
+        return new InvalidError('Cannot compute modulo by zero');
       }
-      return undefined;
+      context?.accept('error', 'Unknown arithmetic error', {
+        node: expression,
+      });
+      return new InvalidError(
+        `Failed to compute ${leftValue} modulo ${rightValue}`,
+      );
     }
     return resultingValue;
   }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/modulo-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/modulo-operator-evaluator.ts
@@ -4,7 +4,7 @@
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type BinaryExpression } from '../../generated/ast';
-import { InvalidError } from '../internal-value-representation';
+import { InvalidValue } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD } from '../typeguards';
 
@@ -22,7 +22,7 @@ export class ModuloOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
     rightValue: number,
     expression: BinaryExpression,
     context: ValidationContext | undefined,
-  ): number | InvalidError {
+  ): number | InvalidValue {
     const resultingValue = leftValue % rightValue;
 
     if (!isFinite(resultingValue)) {
@@ -30,12 +30,12 @@ export class ModuloOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
         context?.accept('error', 'Arithmetic error: modulo by zero', {
           node: expression,
         });
-        return new InvalidError('Cannot compute modulo by zero');
+        return new InvalidValue('Cannot compute modulo by zero');
       }
       context?.accept('error', 'Unknown arithmetic error', {
         node: expression,
       });
-      return new InvalidError(
+      return new InvalidValue(
         `Failed to compute ${leftValue} modulo ${rightValue}`,
       );
     }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/parse-operators-evaluators.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/parse-operators-evaluators.spec.ts
@@ -33,20 +33,20 @@ async function expectResult(
     `${op} inputValue`,
     input,
   );
-  if (ERROR_TYPEGUARD(expected)) {
-    if (INVALID_TYPEGUARD(expected)) {
-      expect(result).toBeInstanceOf(InvalidValue);
-      assert(result instanceof InvalidValue);
-      expect(result.message).toBe(expected.message);
-    } else if (MISSING_TYPEGUARD(expected)) {
-      expect(result).toBeInstanceOf(MissingValue);
-      assert(result instanceof MissingValue);
-      expect(result.message).toBe(expected.message);
-    } else {
-      assertUnreachable(expected);
-    }
-  } else {
+  if (!ERROR_TYPEGUARD(expected)) {
     expect(result).toStrictEqual(expected);
+    return;
+  }
+  if (INVALID_TYPEGUARD(expected)) {
+    expect(result).toBeInstanceOf(InvalidValue);
+    assert(result instanceof InvalidValue);
+    expect(result.message).toBe(expected.message);
+  } else if (MISSING_TYPEGUARD(expected)) {
+    expect(result).toBeInstanceOf(MissingValue);
+    assert(result instanceof MissingValue);
+    expect(result.message).toBe(expected.message);
+  } else {
+    assertUnreachable(expected);
   }
 }
 

--- a/libs/language-server/src/lib/ast/expressions/evaluators/parse-operators-evaluators.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/parse-operators-evaluators.spec.ts
@@ -6,28 +6,28 @@ import { assertUnreachable } from 'langium';
 import {
   ERROR_TYPEGUARD,
   INVALID_TYPEGUARD,
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
-  InvalidError,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
+  InvalidValue,
   MISSING_TYPEGUARD,
-  MissingError,
+  MissingValue,
 } from '..';
 import { executeDefaultTextToTextExpression } from '../test-utils';
 
 async function expectResult(
   op: string,
   input: string,
-  expected: InternalValueRepresentation,
+  expected: InternalValidValueRepresentation,
 ): Promise<void>;
 async function expectResult(
   op: string,
   input: string,
-  expected: InternalErrorRepresentation,
+  expected: InternalErrorValueRepresentation,
 ): Promise<void>;
 async function expectResult(
   op: string,
   input: string,
-  expected: InternalValueRepresentation | InternalErrorRepresentation,
+  expected: InternalValidValueRepresentation | InternalErrorValueRepresentation,
 ) {
   const result = await executeDefaultTextToTextExpression(
     `${op} inputValue`,
@@ -35,12 +35,12 @@ async function expectResult(
   );
   if (ERROR_TYPEGUARD(expected)) {
     if (INVALID_TYPEGUARD(expected)) {
-      expect(result).toBeInstanceOf(InvalidError);
-      assert(result instanceof InvalidError);
+      expect(result).toBeInstanceOf(InvalidValue);
+      assert(result instanceof InvalidValue);
       expect(result.message).toBe(expected.message);
     } else if (MISSING_TYPEGUARD(expected)) {
-      expect(result).toBeInstanceOf(MissingError);
-      assert(result instanceof MissingError);
+      expect(result).toBeInstanceOf(MissingValue);
+      assert(result instanceof MissingValue);
       expect(result.message).toBe(expected.message);
     } else {
       assertUnreachable(expected);
@@ -83,7 +83,7 @@ describe('The asInteger operator', () => {
     await expectResult(
       'asInteger',
       '32.5',
-      new InvalidError('32.5 is a decimal, not an integer'),
+      new InvalidValue('32.5 is a decimal, not an integer'),
     );
   });
 });
@@ -103,12 +103,12 @@ describe('The asBoolean operator', () => {
     await expectResult(
       'asBoolean',
       '0',
-      new InvalidError('"0" is not a boolean'),
+      new InvalidValue('"0" is not a boolean'),
     );
     await expectResult(
       'asBoolean',
       '1',
-      new InvalidError('"1" is not a boolean'),
+      new InvalidValue('"1" is not a boolean'),
     );
   });
 
@@ -116,7 +116,7 @@ describe('The asBoolean operator', () => {
     await expectResult(
       'asBoolean',
       'notABoolean',
-      new InvalidError('"notABoolean" is not a boolean'),
+      new InvalidValue('"notABoolean" is not a boolean'),
     );
   });
 });

--- a/libs/language-server/src/lib/ast/expressions/evaluators/parse-operators-evaluators.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/parse-operators-evaluators.spec.ts
@@ -1,90 +1,122 @@
 // SPDX-FileCopyrightText: 2024 Friedrich-Alexander-Universitat Erlangen-Nurnberg
 //
 // SPDX-License-Identifier: AGPL-3.0-only
-import { type InternalValueRepresentation } from '..';
+import { assertUnreachable } from 'langium';
+
+import {
+  ERROR_TYPEGUARD,
+  INVALID_TYPEGUARD,
+  type InternalErrorRepresentation,
+  type InternalValueRepresentation,
+  InvalidError,
+  MISSING_TYPEGUARD,
+  MissingError,
+} from '..';
 import { executeDefaultTextToTextExpression } from '../test-utils';
 
-async function expectSuccess<I extends InternalValueRepresentation>(
+async function expectResult(
   op: string,
   input: string,
-  expected: I,
+  expected: InternalValueRepresentation,
+): Promise<void>;
+async function expectResult(
+  op: string,
+  input: string,
+  expected: InternalErrorRepresentation,
+): Promise<void>;
+async function expectResult(
+  op: string,
+  input: string,
+  expected: InternalValueRepresentation | InternalErrorRepresentation,
 ) {
-  let result: InternalValueRepresentation | undefined = undefined;
-  try {
-    result = await executeDefaultTextToTextExpression(
-      `${op} inputValue`,
-      input,
-    );
-  } finally {
-    expect(result).toEqual(expected);
-  }
-}
-
-async function expectError(op: string, input: string) {
-  let result: InternalValueRepresentation | undefined = undefined;
-  try {
-    result = await executeDefaultTextToTextExpression(
-      `${op} inputValue`,
-      input,
-    );
-  } catch {
-    result = undefined;
-  } finally {
-    expect(result).toBeUndefined();
+  const result = await executeDefaultTextToTextExpression(
+    `${op} inputValue`,
+    input,
+  );
+  if (ERROR_TYPEGUARD(expected)) {
+    if (INVALID_TYPEGUARD(expected)) {
+      expect(result).toBeInstanceOf(InvalidError);
+      assert(result instanceof InvalidError);
+      expect(result.message).toBe(expected.message);
+    } else if (MISSING_TYPEGUARD(expected)) {
+      expect(result).toBeInstanceOf(MissingError);
+      assert(result instanceof MissingError);
+      expect(result.message).toBe(expected.message);
+    } else {
+      assertUnreachable(expected);
+    }
+  } else {
+    expect(result).toStrictEqual(expected);
   }
 }
 
 describe('The asText operator', () => {
   it('should parse text successfully', async () => {
-    await expectSuccess('asText', 'someText', 'someText');
+    await expectResult('asText', 'someText', 'someText');
   });
 });
 
 describe('The asDecimal operator', () => {
   it('should parse positive decimals successfully', async () => {
-    await expectSuccess('asDecimal', '1.6', 1.6);
+    await expectResult('asDecimal', '1.6', 1.6);
   });
 
   it('should parse decimals with commas successfully', async () => {
-    await expectSuccess('asDecimal', '1,6', 1.6);
+    await expectResult('asDecimal', '1,6', 1.6);
   });
 
   it('should parse negative decimals with commas successfully', async () => {
-    await expectSuccess('asDecimal', '-1,6', -1.6);
+    await expectResult('asDecimal', '-1,6', -1.6);
   });
 });
 
 describe('The asInteger operator', () => {
   it('should parse positive integers successfully', async () => {
-    await expectSuccess('asInteger', '32', 32);
+    await expectResult('asInteger', '32', 32);
   });
 
   it('should parse negative integers successfully', async () => {
-    await expectSuccess('asInteger', '-1', -1);
+    await expectResult('asInteger', '-1', -1);
   });
 
   it('should fail with decimal values', async () => {
-    await expectError('asInteger', '32.5');
+    await expectResult(
+      'asInteger',
+      '32.5',
+      new InvalidError('32.5 is a decimal, not an integer'),
+    );
   });
 });
 
 describe('The asBoolean operator', () => {
   it('should parse true and True successfully', async () => {
-    await expectSuccess('asBoolean', 'true', true);
-    await expectSuccess('asBoolean', 'True', true);
+    await expectResult('asBoolean', 'true', true);
+    await expectResult('asBoolean', 'True', true);
   });
 
   it('should parse false and False successfully', async () => {
-    await expectSuccess('asBoolean', 'false', false);
-    await expectSuccess('asBoolean', 'False', false);
+    await expectResult('asBoolean', 'false', false);
+    await expectResult('asBoolean', 'False', false);
   });
 
   it('should fail with 0 and 1', async () => {
-    await expectError('asBoolean', '0');
-    await expectError('asBoolean', '1');
+    await expectResult(
+      'asBoolean',
+      '0',
+      new InvalidError('"0" is not a boolean'),
+    );
+    await expectResult(
+      'asBoolean',
+      '1',
+      new InvalidError('"1" is not a boolean'),
+    );
   });
 
   it('should fail on a arbitrary string', async () => {
-    await expectError('asBoolean', 'notABoolean');
+    await expectResult(
+      'asBoolean',
+      'notABoolean',
+      new InvalidError('"notABoolean" is not a boolean'),
+    );
   });
 });

--- a/libs/language-server/src/lib/ast/expressions/evaluators/parse-operators-evaluators.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/parse-operators-evaluators.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { type ValueTypeProvider } from '../../wrappers';
-import { type InvalidError } from '../internal-value-representation';
+import { type InvalidValue } from '../internal-value-representation';
 import { DefaultUnaryOperatorEvaluator } from '../operator-evaluator';
 import { STRING_TYPEGUARD } from '../typeguards';
 
@@ -26,7 +26,7 @@ export class AsDecimalOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
   constructor(private readonly valueTypeProvider: ValueTypeProvider) {
     super('asDecimal', STRING_TYPEGUARD);
   }
-  override doEvaluate(operandValue: string): number | InvalidError {
+  override doEvaluate(operandValue: string): number | InvalidValue {
     return this.valueTypeProvider.Primitives.Decimal.fromString(operandValue);
   }
 }
@@ -38,7 +38,7 @@ export class AsIntegerOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
   constructor(private readonly valueTypeProvider: ValueTypeProvider) {
     super('asInteger', STRING_TYPEGUARD);
   }
-  override doEvaluate(operandValue: string): number | InvalidError {
+  override doEvaluate(operandValue: string): number | InvalidValue {
     return this.valueTypeProvider.Primitives.Integer.fromString(operandValue);
   }
 }
@@ -50,7 +50,7 @@ export class AsBooleanOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
   constructor(private readonly valueTypeProvider: ValueTypeProvider) {
     super('asBoolean', STRING_TYPEGUARD);
   }
-  override doEvaluate(operandValue: string): boolean | InvalidError {
+  override doEvaluate(operandValue: string): boolean | InvalidValue {
     return this.valueTypeProvider.Primitives.Boolean.fromString(operandValue);
   }
 }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/parse-operators-evaluators.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/parse-operators-evaluators.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { type ValueTypeProvider } from '../../wrappers';
+import { type InvalidError } from '../internal-value-representation';
 import { DefaultUnaryOperatorEvaluator } from '../operator-evaluator';
 import { STRING_TYPEGUARD } from '../typeguards';
 
@@ -25,13 +26,8 @@ export class AsDecimalOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
   constructor(private readonly valueTypeProvider: ValueTypeProvider) {
     super('asDecimal', STRING_TYPEGUARD);
   }
-  override doEvaluate(operandValue: string): number {
-    const dec =
-      this.valueTypeProvider.Primitives.Decimal.fromString(operandValue);
-    if (dec === undefined) {
-      throw new Error(`Could not parse "${operandValue}" into a Decimal`);
-    }
-    return dec;
+  override doEvaluate(operandValue: string): number | InvalidError {
+    return this.valueTypeProvider.Primitives.Decimal.fromString(operandValue);
   }
 }
 
@@ -42,13 +38,8 @@ export class AsIntegerOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
   constructor(private readonly valueTypeProvider: ValueTypeProvider) {
     super('asInteger', STRING_TYPEGUARD);
   }
-  override doEvaluate(operandValue: string): number {
-    const int =
-      this.valueTypeProvider.Primitives.Integer.fromString(operandValue);
-    if (int === undefined) {
-      throw new Error(`Could not parse "${operandValue}" into an Integer`);
-    }
-    return int;
+  override doEvaluate(operandValue: string): number | InvalidError {
+    return this.valueTypeProvider.Primitives.Integer.fromString(operandValue);
   }
 }
 
@@ -59,12 +50,7 @@ export class AsBooleanOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
   constructor(private readonly valueTypeProvider: ValueTypeProvider) {
     super('asBoolean', STRING_TYPEGUARD);
   }
-  override doEvaluate(operandValue: string): boolean {
-    const bool =
-      this.valueTypeProvider.Primitives.Boolean.fromString(operandValue);
-    if (bool === undefined) {
-      throw new Error(`Could not parse "${operandValue}" into a Boolean`);
-    }
-    return bool;
+  override doEvaluate(operandValue: string): boolean | InvalidError {
+    return this.valueTypeProvider.Primitives.Boolean.fromString(operandValue);
   }
 }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/pow-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/pow-operator-evaluator.ts
@@ -4,6 +4,7 @@
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type BinaryExpression } from '../../generated/ast';
+import { InvalidError } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD } from '../typeguards';
 
@@ -21,7 +22,7 @@ export class PowOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
     rightValue: number,
     expression: BinaryExpression,
     context: ValidationContext | undefined,
-  ): number | undefined {
+  ): number | InvalidError {
     const resultingValue = leftValue ** rightValue;
 
     if (!isFinite(resultingValue)) {
@@ -31,12 +32,16 @@ export class PowOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
           'Arithmetic error: zero raised to a negative number',
           { node: expression },
         );
-      } else {
-        context?.accept('error', 'Unknown arithmetic error', {
-          node: expression,
-        });
+        return new InvalidError(
+          'Cannot compute zero raised to a negative number',
+        );
       }
-      return undefined;
+      context?.accept('error', 'Unknown arithmetic error', {
+        node: expression,
+      });
+      return new InvalidError(
+        `Cannot compute ${leftValue} raised to ${rightValue}`,
+      );
     }
     return resultingValue;
   }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/pow-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/pow-operator-evaluator.ts
@@ -4,7 +4,7 @@
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type BinaryExpression } from '../../generated/ast';
-import { InvalidError } from '../internal-value-representation';
+import { InvalidValue } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD } from '../typeguards';
 
@@ -22,7 +22,7 @@ export class PowOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
     rightValue: number,
     expression: BinaryExpression,
     context: ValidationContext | undefined,
-  ): number | InvalidError {
+  ): number | InvalidValue {
     const resultingValue = leftValue ** rightValue;
 
     if (!isFinite(resultingValue)) {
@@ -32,14 +32,14 @@ export class PowOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
           'Arithmetic error: zero raised to a negative number',
           { node: expression },
         );
-        return new InvalidError(
+        return new InvalidValue(
           'Cannot compute zero raised to a negative number',
         );
       }
       context?.accept('error', 'Unknown arithmetic error', {
         node: expression,
       });
-      return new InvalidError(
+      return new InvalidValue(
         `Cannot compute ${leftValue} raised to ${rightValue}`,
       );
     }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/root-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/root-operator-evaluator.ts
@@ -4,7 +4,7 @@
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type BinaryExpression } from '../../generated/ast';
-import { InvalidError } from '../internal-value-representation';
+import { InvalidValue } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD } from '../typeguards';
 
@@ -22,7 +22,7 @@ export class RootOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
     rightValue: number,
     expression: BinaryExpression,
     context: ValidationContext | undefined,
-  ): number | InvalidError {
+  ): number | InvalidValue {
     const resultingValue = leftValue ** (1 / rightValue);
 
     if (!isFinite(resultingValue)) {
@@ -32,19 +32,19 @@ export class RootOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
           'Arithmetic error: root of zero with negative degree',
           { node: expression },
         );
-        return new InvalidError(
+        return new InvalidValue(
           'Cannot compute the root of zero with negative degree',
         );
       } else if (rightValue === 0) {
         context?.accept('error', 'Arithmetic error: root of degree zero', {
           node: expression,
         });
-        return new InvalidError('Cannot compute the root of degree zero');
+        return new InvalidValue('Cannot compute the root of degree zero');
       }
       context?.accept('error', 'Unknown arithmetic error', {
         node: expression,
       });
-      return new InvalidError(
+      return new InvalidValue(
         `Failed to compute the ${rightValue}th root of ${leftValue}`,
       );
     }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/root-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/root-operator-evaluator.ts
@@ -4,6 +4,7 @@
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type BinaryExpression } from '../../generated/ast';
+import { InvalidError } from '../internal-value-representation';
 import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD } from '../typeguards';
 
@@ -21,7 +22,7 @@ export class RootOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
     rightValue: number,
     expression: BinaryExpression,
     context: ValidationContext | undefined,
-  ): number | undefined {
+  ): number | InvalidError {
     const resultingValue = leftValue ** (1 / rightValue);
 
     if (!isFinite(resultingValue)) {
@@ -31,16 +32,21 @@ export class RootOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
           'Arithmetic error: root of zero with negative degree',
           { node: expression },
         );
+        return new InvalidError(
+          'Cannot compute the root of zero with negative degree',
+        );
       } else if (rightValue === 0) {
         context?.accept('error', 'Arithmetic error: root of degree zero', {
           node: expression,
         });
-      } else {
-        context?.accept('error', 'Unknown arithmetic error', {
-          node: expression,
-        });
+        return new InvalidError('Cannot compute the root of degree zero');
       }
-      return undefined;
+      context?.accept('error', 'Unknown arithmetic error', {
+        node: expression,
+      });
+      return new InvalidError(
+        `Failed to compute the ${rightValue}th root of ${leftValue}`,
+      );
     }
     return resultingValue;
   }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/sqrt-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/sqrt-operator-evaluator.ts
@@ -7,6 +7,7 @@ import { strict as assert } from 'assert';
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type UnaryExpression } from '../../generated/ast';
+import { InvalidError } from '../internal-value-representation';
 import { DefaultUnaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD } from '../typeguards';
 
@@ -21,7 +22,7 @@ export class SqrtOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
     operandValue: number,
     expression: UnaryExpression,
     context: ValidationContext | undefined,
-  ): number | undefined {
+  ): number | InvalidError {
     const resultingValue = Math.sqrt(operandValue);
 
     if (!isFinite(resultingValue)) {
@@ -31,7 +32,9 @@ export class SqrtOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
         'Arithmetic error: square root of negative number',
         { node: expression },
       );
-      return undefined;
+      return new InvalidError(
+        `Cannot compute the square root of the negative number ${operandValue}`,
+      );
     }
     return resultingValue;
   }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/sqrt-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/sqrt-operator-evaluator.ts
@@ -7,7 +7,7 @@ import { strict as assert } from 'assert';
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type UnaryExpression } from '../../generated/ast';
-import { InvalidError } from '../internal-value-representation';
+import { InvalidValue } from '../internal-value-representation';
 import { DefaultUnaryOperatorEvaluator } from '../operator-evaluator';
 import { NUMBER_TYPEGUARD } from '../typeguards';
 
@@ -22,7 +22,7 @@ export class SqrtOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
     operandValue: number,
     expression: UnaryExpression,
     context: ValidationContext | undefined,
-  ): number | InvalidError {
+  ): number | InvalidValue {
     const resultingValue = Math.sqrt(operandValue);
 
     if (!isFinite(resultingValue)) {
@@ -32,7 +32,7 @@ export class SqrtOperatorEvaluator extends DefaultUnaryOperatorEvaluator<
         'Arithmetic error: square root of negative number',
         { node: expression },
       );
-      return new InvalidError(
+      return new InvalidValue(
         `Cannot compute the square root of the negative number ${operandValue}`,
       );
     }

--- a/libs/language-server/src/lib/ast/expressions/internal-value-representation.ts
+++ b/libs/language-server/src/lib/ast/expressions/internal-value-representation.ts
@@ -23,6 +23,9 @@ import { type WrapperFactoryProvider } from '../wrappers';
 
 import { COLLECTION_TYPEGUARD, ERROR_TYPEGUARD } from './typeguards';
 
+// INFO: `ErroneousValue` extends `Error` in order to make use of the `stack`
+// property.
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack
 abstract class ErroneousValue extends Error {
   abstract override name: string;
 

--- a/libs/language-server/src/lib/ast/expressions/internal-value-representation.ts
+++ b/libs/language-server/src/lib/ast/expressions/internal-value-representation.ts
@@ -21,7 +21,7 @@ import {
 } from '../generated/ast';
 import { type WrapperFactoryProvider } from '../wrappers';
 
-import { COLLECTION_TYPEGUARD } from './typeguards';
+import { COLLECTION_TYPEGUARD, ERROR_TYPEGUARD } from './typeguards';
 
 abstract class JayveeError extends Error {
   abstract override name: string;
@@ -153,11 +153,15 @@ export function internalValueToString(
   assertUnreachable(valueRepresentation);
 }
 
-export function cloneInternalValue<T extends InternalValueRepresentation>(
-  valueRepresentation: T,
-): T {
+export function cloneInternalValue<
+  T extends InternalValueRepresentation | InternalErrorRepresentation,
+>(valueRepresentation: T): T {
   if (COLLECTION_TYPEGUARD(valueRepresentation)) {
     return valueRepresentation.map(cloneInternalValue) as T;
+  }
+
+  if (ERROR_TYPEGUARD(valueRepresentation)) {
+    return valueRepresentation.clone() as T;
   }
 
   if (

--- a/libs/language-server/src/lib/ast/expressions/internal-value-representation.ts
+++ b/libs/language-server/src/lib/ast/expressions/internal-value-representation.ts
@@ -16,7 +16,50 @@ import {
   isTransformDefinition,
   isValuetypeAssignment,
 } from '../generated/ast';
-import type { WrapperFactoryProvider } from '../wrappers';
+import { type WrapperFactoryProvider } from '../wrappers';
+
+abstract class JayveeError extends Error {
+  abstract override name: string;
+
+  constructor(message: string) {
+    super(message);
+  }
+
+  override toString(): string {
+    return `${this.name}: ${this.message}`;
+  }
+
+  abstract clone(): JayveeError;
+}
+
+export class InvalidError extends JayveeError {
+  public override name = 'InvalidError' as const;
+
+  constructor(message: string, stack?: string) {
+    super(message);
+    if (stack !== undefined) {
+      this.stack = stack;
+    }
+  }
+
+  override clone(): InvalidError {
+    return new InvalidError(this.message, this.stack);
+  }
+}
+
+export class MissingError extends JayveeError {
+  override name = 'MissingError' as const;
+
+  override clone(): MissingError {
+    const cloned = new MissingError(this.message);
+    if (this.stack !== undefined) {
+      cloned.stack = this.stack;
+    }
+    return cloned;
+  }
+}
+
+export type InternalErrorRepresentation = InvalidError | MissingError;
 
 import { COLLECTION_TYPEGUARD } from './typeguards';
 

--- a/libs/language-server/src/lib/ast/expressions/operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/operator-evaluator.ts
@@ -17,9 +17,9 @@ import { evaluateExpression } from './evaluate-expression';
 import { type EvaluationContext } from './evaluation-context';
 import { EvaluationStrategy } from './evaluation-strategy';
 import {
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
-  type InternalValueRepresentationTypeguard,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
+  type InternalValidValueRepresentationTypeguard,
 } from './internal-value-representation';
 import {
   type BinaryExpressionOperator,
@@ -46,24 +46,24 @@ export interface OperatorEvaluator<
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): InternalValueRepresentation | InternalErrorRepresentation;
+  ): InternalValidValueRepresentation | InternalErrorValueRepresentation;
 }
 
 export abstract class DefaultUnaryOperatorEvaluator<
-  O extends InternalValueRepresentation,
-  T extends InternalValueRepresentation,
+  O extends InternalValidValueRepresentation,
+  T extends InternalValidValueRepresentation,
 > implements OperatorEvaluator<UnaryExpression>
 {
   constructor(
     public readonly operator: UnaryExpressionOperator,
-    private readonly operandValueTypeguard: InternalValueRepresentationTypeguard<O>,
+    private readonly operandValueTypeguard: InternalValidValueRepresentationTypeguard<O>,
   ) {}
 
   protected abstract doEvaluate(
     operandValue: O,
     expression: UnaryExpression,
     context: ValidationContext | undefined,
-  ): T | InternalErrorRepresentation;
+  ): T | InternalErrorValueRepresentation;
 
   evaluate(
     expression: UnaryExpression,
@@ -71,7 +71,7 @@ export abstract class DefaultUnaryOperatorEvaluator<
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): T | InternalErrorRepresentation {
+  ): T | InternalErrorValueRepresentation {
     assert(expression.operator === this.operator);
     const operandValue = evaluateExpression(
       expression.expression,
@@ -91,15 +91,15 @@ export abstract class DefaultUnaryOperatorEvaluator<
 }
 
 export abstract class DefaultBinaryOperatorEvaluator<
-  L extends InternalValueRepresentation,
-  R extends InternalValueRepresentation,
-  T extends InternalValueRepresentation,
+  L extends InternalValidValueRepresentation,
+  R extends InternalValidValueRepresentation,
+  T extends InternalValidValueRepresentation,
 > implements OperatorEvaluator<BinaryExpression>
 {
   constructor(
     public readonly operator: BinaryExpressionOperator,
-    private readonly leftValueTypeguard: InternalValueRepresentationTypeguard<L>,
-    private readonly rightValueTypeguard: InternalValueRepresentationTypeguard<R>,
+    private readonly leftValueTypeguard: InternalValidValueRepresentationTypeguard<L>,
+    private readonly rightValueTypeguard: InternalValidValueRepresentationTypeguard<R>,
   ) {}
 
   protected abstract doEvaluate(
@@ -107,7 +107,7 @@ export abstract class DefaultBinaryOperatorEvaluator<
     rightValue: R,
     expression: BinaryExpression,
     context: ValidationContext | undefined,
-  ): T | InternalErrorRepresentation;
+  ): T | InternalErrorValueRepresentation;
 
   evaluate(
     expression: BinaryExpression,
@@ -115,7 +115,7 @@ export abstract class DefaultBinaryOperatorEvaluator<
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): T | InternalErrorRepresentation {
+  ): T | InternalErrorValueRepresentation {
     assert(expression.operator === this.operator);
     const leftValue = evaluateExpression(
       expression.left,
@@ -183,7 +183,7 @@ export abstract class BooleanShortCircuitOperatorEvaluator
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): boolean | InternalErrorRepresentation {
+  ): boolean | InternalErrorValueRepresentation {
     assert(expression.operator === this.operator);
     const leftValue = evaluateExpression(
       expression.left,
@@ -228,17 +228,17 @@ export abstract class BooleanShortCircuitOperatorEvaluator
 }
 
 export abstract class DefaultTernaryOperatorEvaluator<
-  FirstValue extends InternalValueRepresentation,
-  SecondValue extends InternalValueRepresentation,
-  ThirdValue extends InternalValueRepresentation,
-  ReturnValue extends InternalValueRepresentation,
+  FirstValue extends InternalValidValueRepresentation,
+  SecondValue extends InternalValidValueRepresentation,
+  ThirdValue extends InternalValidValueRepresentation,
+  ReturnValue extends InternalValidValueRepresentation,
 > implements OperatorEvaluator<TernaryExpression>
 {
   constructor(
     public readonly operator: TernaryExpressionOperator,
-    private readonly firstValueTypeguard: InternalValueRepresentationTypeguard<FirstValue>,
-    private readonly secondValueTypeguard: InternalValueRepresentationTypeguard<SecondValue>,
-    private readonly thirdValueTypeguard: InternalValueRepresentationTypeguard<ThirdValue>,
+    private readonly firstValueTypeguard: InternalValidValueRepresentationTypeguard<FirstValue>,
+    private readonly secondValueTypeguard: InternalValidValueRepresentationTypeguard<SecondValue>,
+    private readonly thirdValueTypeguard: InternalValidValueRepresentationTypeguard<ThirdValue>,
   ) {}
 
   protected abstract doEvaluate(
@@ -247,7 +247,7 @@ export abstract class DefaultTernaryOperatorEvaluator<
     thirdValue: ThirdValue,
     expression: TernaryExpression,
     context: ValidationContext | undefined,
-  ): ReturnValue | InternalErrorRepresentation;
+  ): ReturnValue | InternalErrorValueRepresentation;
 
   evaluate(
     expression: TernaryExpression,
@@ -255,7 +255,7 @@ export abstract class DefaultTernaryOperatorEvaluator<
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): ReturnValue | InternalErrorRepresentation {
+  ): ReturnValue | InternalErrorValueRepresentation {
     // The following linting exception can be removed when a second ternary operator is added
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     assert(expression.operator === this.operator);

--- a/libs/language-server/src/lib/ast/expressions/operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/operator-evaluator.ts
@@ -17,6 +17,7 @@ import { evaluateExpression } from './evaluate-expression';
 import { type EvaluationContext } from './evaluation-context';
 import { EvaluationStrategy } from './evaluation-strategy';
 import {
+  type InternalErrorRepresentation,
   type InternalValueRepresentation,
   type InternalValueRepresentationTypeguard,
 } from './internal-value-representation';
@@ -25,6 +26,11 @@ import {
   type TernaryExpressionOperator,
   type UnaryExpressionOperator,
 } from './operator-types';
+import {
+  ERROR_TYPEGUARD,
+  INVALID_TYPEGUARD,
+  MISSING_TYPEGUARD,
+} from './typeguards';
 
 export interface OperatorEvaluator<
   E extends UnaryExpression | BinaryExpression | TernaryExpression,
@@ -40,7 +46,7 @@ export interface OperatorEvaluator<
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): InternalValueRepresentation | undefined;
+  ): InternalValueRepresentation | InternalErrorRepresentation;
 }
 
 export abstract class DefaultUnaryOperatorEvaluator<
@@ -57,7 +63,7 @@ export abstract class DefaultUnaryOperatorEvaluator<
     operandValue: O,
     expression: UnaryExpression,
     context: ValidationContext | undefined,
-  ): T | undefined;
+  ): T | InternalErrorRepresentation;
 
   evaluate(
     expression: UnaryExpression,
@@ -65,7 +71,7 @@ export abstract class DefaultUnaryOperatorEvaluator<
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): T | undefined {
+  ): T | InternalErrorRepresentation {
     assert(expression.operator === this.operator);
     const operandValue = evaluateExpression(
       expression.expression,
@@ -74,8 +80,8 @@ export abstract class DefaultUnaryOperatorEvaluator<
       validationContext,
       strategy,
     );
-    if (operandValue === undefined) {
-      return undefined;
+    if (ERROR_TYPEGUARD(operandValue)) {
+      return operandValue;
     }
 
     assert(this.operandValueTypeguard(operandValue));
@@ -101,7 +107,7 @@ export abstract class DefaultBinaryOperatorEvaluator<
     rightValue: R,
     expression: BinaryExpression,
     context: ValidationContext | undefined,
-  ): T | undefined;
+  ): T | InternalErrorRepresentation;
 
   evaluate(
     expression: BinaryExpression,
@@ -109,7 +115,7 @@ export abstract class DefaultBinaryOperatorEvaluator<
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): T | undefined {
+  ): T | InternalErrorRepresentation {
     assert(expression.operator === this.operator);
     const leftValue = evaluateExpression(
       expression.left,
@@ -118,8 +124,8 @@ export abstract class DefaultBinaryOperatorEvaluator<
       validationContext,
       strategy,
     );
-    if (strategy === EvaluationStrategy.LAZY && leftValue === undefined) {
-      return undefined;
+    if (strategy === EvaluationStrategy.LAZY && ERROR_TYPEGUARD(leftValue)) {
+      return leftValue;
     }
     const rightValue = evaluateExpression(
       expression.right,
@@ -128,8 +134,17 @@ export abstract class DefaultBinaryOperatorEvaluator<
       validationContext,
       strategy,
     );
-    if (leftValue === undefined || rightValue === undefined) {
-      return undefined;
+    if (INVALID_TYPEGUARD(leftValue)) {
+      return leftValue;
+    }
+    if (INVALID_TYPEGUARD(rightValue)) {
+      return rightValue;
+    }
+    if (MISSING_TYPEGUARD(leftValue)) {
+      return leftValue;
+    }
+    if (MISSING_TYPEGUARD(rightValue)) {
+      return rightValue;
     }
 
     assert(this.leftValueTypeguard(leftValue));
@@ -168,7 +183,7 @@ export abstract class BooleanShortCircuitOperatorEvaluator
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): boolean | undefined {
+  ): boolean | InternalErrorRepresentation {
     assert(expression.operator === this.operator);
     const leftValue = evaluateExpression(
       expression.left,
@@ -177,10 +192,10 @@ export abstract class BooleanShortCircuitOperatorEvaluator
       validationContext,
       strategy,
     );
-    assert(leftValue === undefined || typeof leftValue === 'boolean');
+    assert(ERROR_TYPEGUARD(leftValue) || typeof leftValue === 'boolean');
     if (strategy === EvaluationStrategy.LAZY) {
-      if (leftValue === undefined) {
-        return undefined;
+      if (ERROR_TYPEGUARD(leftValue)) {
+        return leftValue;
       }
       if (this.canSkipRightOperandEvaluation(leftValue)) {
         return this.getShortCircuitValue();
@@ -194,8 +209,17 @@ export abstract class BooleanShortCircuitOperatorEvaluator
       validationContext,
       strategy,
     );
-    if (leftValue === undefined || rightValue === undefined) {
-      return undefined;
+    if (INVALID_TYPEGUARD(leftValue)) {
+      return leftValue;
+    }
+    if (INVALID_TYPEGUARD(rightValue)) {
+      return rightValue;
+    }
+    if (MISSING_TYPEGUARD(leftValue)) {
+      return leftValue;
+    }
+    if (MISSING_TYPEGUARD(rightValue)) {
+      return rightValue;
     }
     assert(typeof rightValue === 'boolean');
 
@@ -223,7 +247,7 @@ export abstract class DefaultTernaryOperatorEvaluator<
     thirdValue: ThirdValue,
     expression: TernaryExpression,
     context: ValidationContext | undefined,
-  ): ReturnValue | undefined;
+  ): ReturnValue | InternalErrorRepresentation;
 
   evaluate(
     expression: TernaryExpression,
@@ -231,7 +255,7 @@ export abstract class DefaultTernaryOperatorEvaluator<
     wrapperFactories: WrapperFactoryProvider,
     strategy: EvaluationStrategy,
     validationContext: ValidationContext | undefined,
-  ): ReturnValue | undefined {
+  ): ReturnValue | InternalErrorRepresentation {
     // The following linting exception can be removed when a second ternary operator is added
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     assert(expression.operator === this.operator);
@@ -244,8 +268,8 @@ export abstract class DefaultTernaryOperatorEvaluator<
       strategy,
     );
 
-    if (strategy === EvaluationStrategy.LAZY && firstValue === undefined) {
-      return undefined;
+    if (strategy === EvaluationStrategy.LAZY && ERROR_TYPEGUARD(firstValue)) {
+      return firstValue;
     }
 
     const secondValue = evaluateExpression(
@@ -264,12 +288,23 @@ export abstract class DefaultTernaryOperatorEvaluator<
       strategy,
     );
 
-    if (
-      firstValue === undefined ||
-      secondValue === undefined ||
-      thirdValue === undefined
-    ) {
-      return undefined;
+    if (INVALID_TYPEGUARD(firstValue)) {
+      return firstValue;
+    }
+    if (INVALID_TYPEGUARD(secondValue)) {
+      return secondValue;
+    }
+    if (INVALID_TYPEGUARD(thirdValue)) {
+      return thirdValue;
+    }
+    if (MISSING_TYPEGUARD(firstValue)) {
+      return firstValue;
+    }
+    if (MISSING_TYPEGUARD(secondValue)) {
+      return secondValue;
+    }
+    if (MISSING_TYPEGUARD(thirdValue)) {
+      return thirdValue;
     }
 
     assert(this.firstValueTypeguard(firstValue));

--- a/libs/language-server/src/lib/ast/expressions/test-utils.ts
+++ b/libs/language-server/src/lib/ast/expressions/test-utils.ts
@@ -12,7 +12,10 @@ import { isTransformDefinition } from '../generated/ast';
 
 import { evaluateExpression } from './evaluate-expression';
 import { EvaluationContext } from './evaluation-context';
-import { type InternalValueRepresentation } from './internal-value-representation';
+import {
+  type InternalErrorRepresentation,
+  type InternalValueRepresentation,
+} from './internal-value-representation';
 
 export async function executeDefaultTextToTextExpression(
   expression: string,
@@ -33,7 +36,7 @@ export async function executeExpressionTestHelper(
   inputValueType: 'text',
   inputValueValue: InternalValueRepresentation,
   outputValueType: 'text' | 'integer',
-): Promise<InternalValueRepresentation | undefined> {
+): Promise<InternalValueRepresentation | InternalErrorRepresentation> {
   const services = createJayveeServices(NodeFileSystem).Jayvee;
   const parse = parseHelper(services);
 

--- a/libs/language-server/src/lib/ast/expressions/test-utils.ts
+++ b/libs/language-server/src/lib/ast/expressions/test-utils.ts
@@ -13,13 +13,13 @@ import { isTransformDefinition } from '../generated/ast';
 import { evaluateExpression } from './evaluate-expression';
 import { EvaluationContext } from './evaluation-context';
 import {
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
 } from './internal-value-representation';
 
 export async function executeDefaultTextToTextExpression(
   expression: string,
-  input: InternalValueRepresentation,
+  input: InternalValidValueRepresentation,
 ) {
   return executeExpressionTestHelper(
     expression,
@@ -34,9 +34,11 @@ export async function executeExpressionTestHelper(
   expression: string,
   inputValueName: string,
   inputValueType: 'text',
-  inputValueValue: InternalValueRepresentation,
+  inputValueValue: InternalValidValueRepresentation,
   outputValueType: 'text' | 'integer',
-): Promise<InternalValueRepresentation | InternalErrorRepresentation> {
+): Promise<
+  InternalValidValueRepresentation | InternalErrorValueRepresentation
+> {
   const services = createJayveeServices(NodeFileSystem).Jayvee;
   const parse = parseHelper(services);
 

--- a/libs/language-server/src/lib/ast/expressions/type-inference.ts
+++ b/libs/language-server/src/lib/ast/expressions/type-inference.ts
@@ -18,6 +18,7 @@ import {
   isCellRangeLiteral,
   isCollectionLiteral,
   isConstraintDefinition,
+  isErrorLiteral,
   isExpressionLiteral,
   isFreeVariableLiteral,
   isNumericLiteral,
@@ -44,8 +45,6 @@ import {
   pickCommonAtomicValueType,
   pickCommonPrimitiveValuetype,
 } from '../wrappers/util/value-type-util';
-
-import { isEveryValueDefined } from './typeguards';
 
 export function inferExpressionType(
   expression: Expression | undefined,
@@ -176,6 +175,8 @@ function inferTypeFromExpressionLiteral(
         valueTypeProvider,
         wrapperFactories,
       );
+    } else if (isErrorLiteral(expression)) {
+      return undefined; // FIXME: make sure `undefined` means any type
     }
     assertUnreachable(expression);
   } else if (isFreeVariableLiteral(expression)) {
@@ -280,10 +281,12 @@ function inferCollectionElementTypes(
       wrapperFactories,
     ),
   );
-  if (!isEveryValueDefined(elementValuetypes)) {
-    return undefined;
+
+  if (elementValuetypes.every((value) => value !== undefined)) {
+    return elementValuetypes;
   }
-  return elementValuetypes;
+
+  return undefined;
 }
 
 function inferTypeFromValueKeyword(

--- a/libs/language-server/src/lib/ast/expressions/type-inference.ts
+++ b/libs/language-server/src/lib/ast/expressions/type-inference.ts
@@ -46,6 +46,10 @@ import {
   pickCommonPrimitiveValuetype,
 } from '../wrappers/util/value-type-util';
 
+/**
+ * @returns The inferred ValueType. `undefined` means that any type could be
+ * present here
+ * */
 export function inferExpressionType(
   expression: Expression | undefined,
   validationContext: ValidationContext,
@@ -176,7 +180,7 @@ function inferTypeFromExpressionLiteral(
         wrapperFactories,
       );
     } else if (isErrorLiteral(expression)) {
-      return undefined; // FIXME: make sure `undefined` means any type
+      return undefined;
     }
     assertUnreachable(expression);
   } else if (isFreeVariableLiteral(expression)) {

--- a/libs/language-server/src/lib/ast/expressions/typeguards.ts
+++ b/libs/language-server/src/lib/ast/expressions/typeguards.ts
@@ -16,26 +16,23 @@ import {
 } from '../generated/ast';
 
 import {
-  type AtomicInternalValueRepresentation,
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
-  type InternalValueRepresentationTypeguard,
-  type InvalidError,
-  type MissingError,
+  type AtomicInternalValidValueRepresentation,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
+  type InternalValidValueRepresentationTypeguard,
+  type InvalidValue,
+  type MissingValue,
 } from './internal-value-representation';
 
-export const INTERNAL_VALUE_REPRESENTATION_TYPEGUARD: InternalValueRepresentationTypeguard<
-  InternalValueRepresentation
-> = (value): value is InternalValueRepresentation => {
-  return (
-    ATOMIC_INTERNAL_VALUE_REPRESENTATION_TYPEGUARD(value) ||
-    COLLECTION_TYPEGUARD(value)
-  );
-};
+export const INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD: InternalValidValueRepresentationTypeguard<
+  InternalValidValueRepresentation
+> = (value): value is InternalValidValueRepresentation =>
+  ATOMIC_INTERNAL_VALUE_REPRESENTATION_TYPEGUARD(value) ||
+  COLLECTION_TYPEGUARD(value);
 
-export const ATOMIC_INTERNAL_VALUE_REPRESENTATION_TYPEGUARD: InternalValueRepresentationTypeguard<
-  AtomicInternalValueRepresentation
-> = (value): value is AtomicInternalValueRepresentation =>
+export const ATOMIC_INTERNAL_VALUE_REPRESENTATION_TYPEGUARD: InternalValidValueRepresentationTypeguard<
+  AtomicInternalValidValueRepresentation
+> = (value): value is AtomicInternalValidValueRepresentation =>
   BOOLEAN_TYPEGUARD(value) ||
   NUMBER_TYPEGUARD(value) ||
   STRING_TYPEGUARD(value) ||
@@ -45,56 +42,59 @@ export const ATOMIC_INTERNAL_VALUE_REPRESENTATION_TYPEGUARD: InternalValueRepres
   BLOCKTYPEPROPERTY_TYPEGUARD(value) ||
   TRANSFORMDEFINITION_TYPEGUARD(value);
 
-export const NUMBER_TYPEGUARD: InternalValueRepresentationTypeguard<number> = (
-  value,
-) => typeof value === 'number';
-export const BOOLEAN_TYPEGUARD: InternalValueRepresentationTypeguard<
+export const NUMBER_TYPEGUARD: InternalValidValueRepresentationTypeguard<
+  number
+> = (value) => typeof value === 'number';
+export const BOOLEAN_TYPEGUARD: InternalValidValueRepresentationTypeguard<
   boolean
 > = (value) => typeof value === 'boolean';
-export const STRING_TYPEGUARD: InternalValueRepresentationTypeguard<string> = (
-  value,
-) => typeof value === 'string';
+export const STRING_TYPEGUARD: InternalValidValueRepresentationTypeguard<
+  string
+> = (value) => typeof value === 'string';
 
-export const REGEXP_TYPEGUARD: InternalValueRepresentationTypeguard<RegExp> = (
-  value,
-) => value instanceof RegExp;
+export const REGEXP_TYPEGUARD: InternalValidValueRepresentationTypeguard<
+  RegExp
+> = (value) => value instanceof RegExp;
 
-export const CELLRANGELITERAL_TYPEGUARD: InternalValueRepresentationTypeguard<
+export const CELLRANGELITERAL_TYPEGUARD: InternalValidValueRepresentationTypeguard<
   CellRangeLiteral
 > = (value) => isCellRangeLiteral(value);
 
-export const CONSTRAINTDEFINITION_TYPEGUARD: InternalValueRepresentationTypeguard<
+export const CONSTRAINTDEFINITION_TYPEGUARD: InternalValidValueRepresentationTypeguard<
   ConstraintDefinition
 > = (value) => isConstraintDefinition(value);
 
-export const VALUETYPEASSIGNMENT_TYPEGUARD: InternalValueRepresentationTypeguard<
+export const VALUETYPEASSIGNMENT_TYPEGUARD: InternalValidValueRepresentationTypeguard<
   ValuetypeAssignment
 > = (value) => isValuetypeAssignment(value);
 
-export const BLOCKTYPEPROPERTY_TYPEGUARD: InternalValueRepresentationTypeguard<
+export const BLOCKTYPEPROPERTY_TYPEGUARD: InternalValidValueRepresentationTypeguard<
   BlockTypeProperty
 > = (value) => isBlockTypeProperty(value);
 
-export const TRANSFORMDEFINITION_TYPEGUARD: InternalValueRepresentationTypeguard<
+export const TRANSFORMDEFINITION_TYPEGUARD: InternalValidValueRepresentationTypeguard<
   TransformDefinition
 > = (value) => isTransformDefinition(value);
 
-export const COLLECTION_TYPEGUARD: InternalValueRepresentationTypeguard<
-  InternalValueRepresentation[]
+export const COLLECTION_TYPEGUARD: InternalValidValueRepresentationTypeguard<
+  (InternalValidValueRepresentation | InternalErrorValueRepresentation)[]
 > = (value) =>
   Array.isArray(value) &&
-  value.every((v) => INTERNAL_VALUE_REPRESENTATION_TYPEGUARD(v));
+  value.every(
+    (v) =>
+      INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD(v) || ERROR_TYPEGUARD(v),
+  );
 
-export const INVALID_TYPEGUARD = (value: unknown): value is InvalidError => {
-  return value instanceof Error && value.name === 'InvalidError';
+export const INVALID_TYPEGUARD = (value: unknown): value is InvalidValue => {
+  return value instanceof Error && value.name === 'InvalidValue';
 };
 
-export const MISSING_TYPEGUARD = (value: unknown): value is MissingError => {
-  return value instanceof Error && value.name === 'MissingError';
+export const MISSING_TYPEGUARD = (value: unknown): value is MissingValue => {
+  return value instanceof Error && value.name === 'MissingValue';
 };
 
 export const ERROR_TYPEGUARD = (
   value: unknown,
-): value is InternalErrorRepresentation => {
+): value is InternalErrorValueRepresentation => {
   return INVALID_TYPEGUARD(value) || MISSING_TYPEGUARD(value);
 };

--- a/libs/language-server/src/lib/ast/expressions/typeguards.ts
+++ b/libs/language-server/src/lib/ast/expressions/typeguards.ts
@@ -17,8 +17,11 @@ import {
 
 import {
   type AtomicInternalValueRepresentation,
+  type InternalErrorRepresentation,
   type InternalValueRepresentation,
   type InternalValueRepresentationTypeguard,
+  type InvalidError,
+  type MissingError,
 } from './internal-value-representation';
 
 export const INTERNAL_VALUE_REPRESENTATION_TYPEGUARD: InternalValueRepresentationTypeguard<
@@ -82,6 +85,16 @@ export const COLLECTION_TYPEGUARD: InternalValueRepresentationTypeguard<
   Array.isArray(value) &&
   value.every((v) => INTERNAL_VALUE_REPRESENTATION_TYPEGUARD(v));
 
-export function isEveryValueDefined<T>(array: (T | undefined)[]): array is T[] {
-  return array.every((value) => value !== undefined);
-}
+export const INVALID_TYPEGUARD = (value: unknown): value is InvalidError => {
+  return value instanceof Error && value.name === 'InvalidError';
+};
+
+export const MISSING_TYPEGUARD = (value: unknown): value is MissingError => {
+  return value instanceof Error && value.name === 'MissingError';
+};
+
+export const ERROR_TYPEGUARD = (
+  value: unknown,
+): value is InternalErrorRepresentation => {
+  return INVALID_TYPEGUARD(value) || MISSING_TYPEGUARD(value);
+};

--- a/libs/language-server/src/lib/ast/wrappers/typed-object/block-type-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/typed-object/block-type-wrapper.ts
@@ -9,6 +9,7 @@ import { type Reference, isReference } from 'langium';
 
 import { RuntimeParameterProvider } from '../../../services/runtime-parameter-provider';
 import {
+  ERROR_TYPEGUARD,
   EvaluationContext,
   type OperatorEvaluatorRegistry,
   evaluateExpression,
@@ -65,18 +66,20 @@ export class BlockTypeWrapper extends TypedObjectWrapper<ReferenceableBlockTypeD
         type: valueType,
       };
 
-      const defaultValue = evaluateExpression(
-        property.defaultValue,
-        new EvaluationContext(
-          new RuntimeParameterProvider(),
-          operatorEvaluatorRegistry,
-          valueTypeProvider,
-        ),
-        wrapperFactories,
-      );
-      if (defaultValue !== undefined) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        properties[property.name]!.defaultValue = defaultValue;
+      if (property.defaultValue !== undefined) {
+        const defaultValue = evaluateExpression(
+          property.defaultValue,
+          new EvaluationContext(
+            new RuntimeParameterProvider(),
+            operatorEvaluatorRegistry,
+            valueTypeProvider,
+          ),
+          wrapperFactories,
+        );
+        if (!ERROR_TYPEGUARD(defaultValue)) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          properties[property.name]!.defaultValue = defaultValue;
+        }
       }
     }
 

--- a/libs/language-server/src/lib/ast/wrappers/typed-object/block-type-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/typed-object/block-type-wrapper.ts
@@ -77,8 +77,10 @@ export class BlockTypeWrapper extends TypedObjectWrapper<ReferenceableBlockTypeD
           wrapperFactories,
         );
         if (!ERROR_TYPEGUARD(defaultValue)) {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          properties[property.name]!.defaultValue = defaultValue;
+          const propertySpec = properties[property.name];
+          assert(propertySpec !== undefined);
+          propertySpec.defaultValue = defaultValue;
+          properties[property.name] = propertySpec;
         }
       }
     }

--- a/libs/language-server/src/lib/ast/wrappers/typed-object/typed-object-wrapper.ts
+++ b/libs/language-server/src/lib/ast/wrappers/typed-object/typed-object-wrapper.ts
@@ -6,7 +6,7 @@ import { type AstNode } from 'langium';
 
 import { type ValidationContext } from '../../../validation/validation-context';
 import { type EvaluationContext } from '../../expressions/evaluation-context';
-import { type InternalValueRepresentation } from '../../expressions/internal-value-representation';
+import { type InternalValidValueRepresentation } from '../../expressions/internal-value-representation';
 import {
   type PropertyAssignment,
   type PropertyBody,
@@ -15,7 +15,7 @@ import { type AstNodeWrapper } from '../ast-node-wrapper';
 import { type ValueType } from '../value-type';
 
 export interface PropertySpecification<
-  I extends InternalValueRepresentation = InternalValueRepresentation,
+  I extends InternalValidValueRepresentation = InternalValidValueRepresentation,
 > {
   type: ValueType<I>;
   defaultValue?: I;

--- a/libs/language-server/src/lib/ast/wrappers/value-type/abstract-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/abstract-value-type.ts
@@ -3,14 +3,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
 } from '../../expressions';
 
 import { type ValueType, type ValueTypeVisitor } from './value-type';
 
-export abstract class AbstractValueType<I extends InternalValueRepresentation>
-  implements ValueType<I>
+export abstract class AbstractValueType<
+  I extends InternalValidValueRepresentation,
+> implements ValueType<I>
 {
   abstract acceptVisitor<R>(visitor: ValueTypeVisitor<R>): R;
 
@@ -33,8 +34,10 @@ export abstract class AbstractValueType<I extends InternalValueRepresentation>
     return false;
   }
 
-  abstract isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | InternalErrorRepresentation,
+  abstract isInternalValidValueRepresentation(
+    operandValue:
+      | InternalValidValueRepresentation
+      | InternalErrorValueRepresentation,
   ): operandValue is I;
 
   abstract getName(): string;

--- a/libs/language-server/src/lib/ast/wrappers/value-type/abstract-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/abstract-value-type.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../expressions';
+import {
+  type InternalErrorRepresentation,
+  type InternalValueRepresentation,
+} from '../../expressions';
 
 import { type ValueType, type ValueTypeVisitor } from './value-type';
 
@@ -31,7 +34,7 @@ export abstract class AbstractValueType<I extends InternalValueRepresentation>
   }
 
   abstract isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation | InternalErrorRepresentation,
   ): operandValue is I;
 
   abstract getName(): string;

--- a/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/atomic-value-type.ts
@@ -5,7 +5,7 @@
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import { strict as assert } from 'assert';
 
-import { type InternalValueRepresentation } from '../../expressions/internal-value-representation';
+import { type InternalValidValueRepresentation } from '../../expressions/internal-value-representation';
 import {} from '../../expressions/typeguards';
 import {
   type ConstraintDefinition,
@@ -22,7 +22,7 @@ import { type ValueTypeProvider } from './primitive';
 import { type ValueType, type ValueTypeVisitor } from './value-type';
 
 export class AtomicValueType
-  extends AbstractValueType<InternalValueRepresentation>
+  extends AbstractValueType<InternalValidValueRepresentation>
   implements AstNodeWrapper<ValuetypeDefinition>
 {
   constructor(
@@ -71,7 +71,7 @@ export class AtomicValueType
       }
 
       assert(
-        this.valueTypeProvider.Primitives.Constraint.isInternalValueRepresentation(
+        this.valueTypeProvider.Primitives.Constraint.isInternalValidValueRepresentation(
           constraintDefinition,
         ),
       );
@@ -120,14 +120,14 @@ export class AtomicValueType
     return this.wrapperFactories.ValueType.wrap(supertype);
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
-  ): operandValue is InternalValueRepresentation {
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
+  ): operandValue is InternalValidValueRepresentation {
     const supertype = this.getContainedType();
     if (supertype === undefined) {
       return false;
     }
-    return supertype.isInternalValueRepresentation(operandValue);
+    return supertype.isInternalValidValueRepresentation(operandValue);
   }
 
   override equals(target: ValueType): boolean {

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-value-type.ts
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
-  type InternalValueRepresentation,
-  InvalidError,
+  type InternalValidValueRepresentation,
+  InvalidValue,
 } from '../../../expressions/internal-value-representation';
 import { type ValueTypeVisitor } from '../value-type';
 
@@ -26,8 +26,8 @@ export class BooleanValuetype extends PrimitiveValueType<boolean> {
     return 'boolean';
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is boolean {
     return typeof operandValue === 'boolean';
   }
@@ -43,12 +43,12 @@ Examples: true, false
 `.trim();
   }
 
-  override fromString(s: string): boolean | InvalidError {
+  override fromString(s: string): boolean | InvalidValue {
     if (TRUE_REGEX.test(s)) {
       return true;
     } else if (FALSE_REGEX.test(s)) {
       return false;
     }
-    return new InvalidError(`"${s}" is not a boolean`);
+    return new InvalidValue(`"${s}" is not a boolean`);
   }
 }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/boolean-value-type.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
+import {
+  type InternalValueRepresentation,
+  InvalidError,
+} from '../../../expressions/internal-value-representation';
 import { type ValueTypeVisitor } from '../value-type';
 
 import { PrimitiveValueType } from './primitive-value-type';
@@ -24,7 +27,7 @@ export class BooleanValuetype extends PrimitiveValueType<boolean> {
   }
 
   override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation,
   ): operandValue is boolean {
     return typeof operandValue === 'boolean';
   }
@@ -40,12 +43,12 @@ Examples: true, false
 `.trim();
   }
 
-  override fromString(s: string): boolean | undefined {
+  override fromString(s: string): boolean | InvalidError {
     if (TRUE_REGEX.test(s)) {
       return true;
     } else if (FALSE_REGEX.test(s)) {
       return false;
     }
-    return undefined;
+    return new InvalidError(`"${s}" is not a boolean`);
   }
 }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/cell-range-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/cell-range-value-type.ts
@@ -25,7 +25,7 @@ export class CellRangeValuetype extends PrimitiveValueType<CellRangeLiteral> {
   }
 
   override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation,
   ): operandValue is CellRangeLiteral {
     return isCellRangeLiteral(operandValue);
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/cell-range-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/cell-range-value-type.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
+import { type InternalValidValueRepresentation } from '../../../expressions/internal-value-representation';
 import {
   type CellRangeLiteral,
   isCellRangeLiteral,
@@ -24,8 +24,8 @@ export class CellRangeValuetype extends PrimitiveValueType<CellRangeLiteral> {
     return 'CellRange';
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is CellRangeLiteral {
     return isCellRangeLiteral(operandValue);
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/abstract-collection-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/abstract-collection-value-type.ts
@@ -2,14 +2,14 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../../expressions/internal-value-representation';
+import { type InternalValidValueRepresentation } from '../../../../expressions/internal-value-representation';
 import { PrimitiveValueType } from '../primitive-value-type';
 
-export type ToArray<I extends InternalValueRepresentation | undefined> =
-  I extends InternalValueRepresentation ? I[] : [];
+export type ToArray<I extends InternalValidValueRepresentation | undefined> =
+  I extends InternalValidValueRepresentation ? I[] : [];
 
 export abstract class AbstractCollectionValueType<
-  I extends InternalValueRepresentation | undefined,
+  I extends InternalValidValueRepresentation | undefined,
 > extends PrimitiveValueType<ToArray<I>> {
   override isAllowedAsRuntimeParameter(): boolean {
     return false;

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/collection-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/collection-value-type.ts
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
-  type AtomicInternalValueRepresentation,
-  type InternalValueRepresentation,
+  type AtomicInternalValidValueRepresentation,
+  type InternalValidValueRepresentation,
 } from '../../../../expressions/internal-value-representation';
 import { type ValueType, type ValueTypeVisitor } from '../../value-type';
 
@@ -14,7 +14,7 @@ import {
 } from './abstract-collection-value-type';
 
 export class CollectionValueType<
-  I extends InternalValueRepresentation = InternalValueRepresentation,
+  I extends InternalValidValueRepresentation = InternalValidValueRepresentation,
 > extends AbstractCollectionValueType<I> {
   constructor(public readonly elementType: ValueType<I>) {
     super();
@@ -35,20 +35,20 @@ export class CollectionValueType<
     );
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is ToArray<I> {
     return (
       Array.isArray(operandValue) &&
       operandValue.every((element) =>
-        this.elementType.isInternalValueRepresentation(element),
+        this.elementType.isInternalValidValueRepresentation(element),
       )
     );
   }
 }
 
 export function isCollectionValueType<
-  I extends AtomicInternalValueRepresentation,
+  I extends AtomicInternalValidValueRepresentation,
 >(v: unknown, elementType: ValueType<I>): v is CollectionValueType<I> {
   return v instanceof CollectionValueType && v.elementType.equals(elementType);
 }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/collection-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/collection-value-type.ts
@@ -36,7 +36,7 @@ export class CollectionValueType<
   }
 
   override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation,
   ): operandValue is ToArray<I> {
     return (
       Array.isArray(operandValue) &&

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/empty-collection-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/empty-collection-value-type.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../../expressions/internal-value-representation';
+import { type InternalValidValueRepresentation } from '../../../../expressions/internal-value-representation';
 import { type ValueType, type ValueTypeVisitor } from '../../value-type';
 
 import { AbstractCollectionValueType } from './abstract-collection-value-type';
@@ -23,8 +23,8 @@ export class EmptyCollectionValueType extends AbstractCollectionValueType<undefi
     return `Collection`;
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is [] {
     return Array.isArray(operandValue) && operandValue.length === 0;
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/empty-collection-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/collection/empty-collection-value-type.ts
@@ -24,7 +24,7 @@ export class EmptyCollectionValueType extends AbstractCollectionValueType<undefi
   }
 
   override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation,
   ): operandValue is [] {
     return Array.isArray(operandValue) && operandValue.length === 0;
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/constraint-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/constraint-value-type.ts
@@ -25,7 +25,7 @@ export class ConstraintValuetype extends PrimitiveValueType<ConstraintDefinition
   }
 
   override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation,
   ): operandValue is ConstraintDefinition {
     return isConstraintDefinition(operandValue);
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/constraint-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/constraint-value-type.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
+import { type InternalValidValueRepresentation } from '../../../expressions/internal-value-representation';
 import {
   type ConstraintDefinition,
   isConstraintDefinition,
@@ -24,8 +24,8 @@ export class ConstraintValuetype extends PrimitiveValueType<ConstraintDefinition
     return 'Constraint';
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is ConstraintDefinition {
     return isConstraintDefinition(operandValue);
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-value-type.ts
@@ -2,16 +2,19 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
+import {
+  type InternalValueRepresentation,
+  InvalidError,
+} from '../../../expressions/internal-value-representation';
 import { type ValueTypeVisitor } from '../value-type';
 
 import { PrimitiveValueType } from './primitive-value-type';
 
 const NUMBER_REGEX = /^[+-]?([0-9]*[,.])?[0-9]+([eE][+-]?\d+)?$/;
 
-export function parseDecimal(s: string): number | undefined {
+export function parseDecimal(s: string): number | InvalidError {
   if (!NUMBER_REGEX.test(s)) {
-    return undefined;
+    return new InvalidError(`"${s}" is not a number`);
   }
 
   return Number.parseFloat(s.replace(',', '.'));
@@ -31,7 +34,7 @@ export class DecimalValuetype extends PrimitiveValueType<number> {
   }
 
   override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation,
   ): operandValue is number {
     return typeof operandValue === 'number' && Number.isFinite(operandValue);
   }
@@ -47,7 +50,7 @@ Example: 3.14
 `.trim();
   }
 
-  override fromString(s: string): number | undefined {
+  override fromString(s: string): number | InvalidError {
     return parseDecimal(s);
   }
 }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/decimal-value-type.ts
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
-  type InternalValueRepresentation,
-  InvalidError,
+  type InternalValidValueRepresentation,
+  InvalidValue,
 } from '../../../expressions/internal-value-representation';
 import { type ValueTypeVisitor } from '../value-type';
 
@@ -12,9 +12,9 @@ import { PrimitiveValueType } from './primitive-value-type';
 
 const NUMBER_REGEX = /^[+-]?([0-9]*[,.])?[0-9]+([eE][+-]?\d+)?$/;
 
-export function parseDecimal(s: string): number | InvalidError {
+export function parseDecimal(s: string): number | InvalidValue {
   if (!NUMBER_REGEX.test(s)) {
-    return new InvalidError(`"${s}" is not a number`);
+    return new InvalidValue(`"${s}" is not a number`);
   }
 
   return Number.parseFloat(s.replace(',', '.'));
@@ -33,8 +33,8 @@ export class DecimalValuetype extends PrimitiveValueType<number> {
     return 'decimal';
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is number {
     return typeof operandValue === 'number' && Number.isFinite(operandValue);
   }
@@ -50,7 +50,7 @@ Example: 3.14
 `.trim();
   }
 
-  override fromString(s: string): number | InvalidError {
+  override fromString(s: string): number | InvalidValue {
     return parseDecimal(s);
   }
 }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/integer-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/integer-value-type.ts
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
-  type InternalValueRepresentation,
-  InvalidError,
+  type InternalValidValueRepresentation,
+  InvalidValue,
 } from '../../../expressions/internal-value-representation';
 import { INVALID_TYPEGUARD } from '../../../expressions/typeguards';
 import { type ValueType, type ValueTypeVisitor } from '../value-type';
@@ -29,8 +29,8 @@ export class IntegerValuetype extends PrimitiveValueType<number> {
     return 'integer';
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is number {
     return typeof operandValue === 'number' && Number.isInteger(operandValue);
   }
@@ -46,7 +46,7 @@ Example: 3
 `.trim();
   }
 
-  override fromString(s: string): number | InvalidError {
+  override fromString(s: string): number | InvalidValue {
     /**
      * Reuse decimal number parsing to capture valid scientific notation
      * of integers like 5.3e3 = 5300. In contrast to decimal, if the final number
@@ -61,7 +61,7 @@ Example: 3
     const integerNumber = Math.trunc(decimalNumber);
 
     if (decimalNumber !== integerNumber) {
-      return new InvalidError(`${decimalNumber} is a decimal, not an integer`);
+      return new InvalidValue(`${decimalNumber} is a decimal, not an integer`);
     }
 
     return integerNumber;

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-value-type-provider.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-value-type-provider.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../expressions';
+import { type InternalValidValueRepresentation } from '../../../expressions';
 import { type ValueType } from '../value-type';
 
 import { BooleanValuetype } from './boolean-value-type';
@@ -26,7 +26,7 @@ export class ValueTypeProvider {
   Primitives = new PrimitiveValueTypeProvider();
   EmptyCollection = new EmptyCollectionValueType();
 
-  createCollectionValueTypeOf<I extends InternalValueRepresentation>(
+  createCollectionValueTypeOf<I extends InternalValidValueRepresentation>(
     input: ValueType<I>,
   ): CollectionValueType<I> {
     return new CollectionValueType(input);

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-value-type.ts
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
-  type InternalValueRepresentation,
-  InvalidError,
+  type InternalValidValueRepresentation,
+  InvalidValue,
 } from '../../../expressions/internal-value-representation';
 import { AbstractValueType } from '../abstract-value-type';
 import { type ValueType } from '../value-type';
 
 export abstract class PrimitiveValueType<
-  I extends InternalValueRepresentation = InternalValueRepresentation,
+  I extends InternalValidValueRepresentation = InternalValidValueRepresentation,
 > extends AbstractValueType<I> {
   constructor() {
     super();
@@ -38,8 +38,8 @@ export abstract class PrimitiveValueType<
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  fromString(_s: string): I | InvalidError {
-    return new InvalidError(`Cannot parse ${this.getName()}`);
+  fromString(_s: string): I | InvalidValue {
+    return new InvalidValue(`Cannot parse ${this.getName()}`);
   }
 }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/primitive-value-type.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
+import {
+  type InternalValueRepresentation,
+  InvalidError,
+} from '../../../expressions/internal-value-representation';
 import { AbstractValueType } from '../abstract-value-type';
 import { type ValueType } from '../value-type';
 
@@ -35,8 +38,8 @@ export abstract class PrimitiveValueType<
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  fromString(_s: string): I | undefined {
-    return undefined;
+  fromString(_s: string): I | InvalidError {
+    return new InvalidError(`Cannot parse ${this.getName()}`);
   }
 }
 

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/regex-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/regex-value-type.ts
@@ -21,7 +21,7 @@ export class RegexValuetype extends PrimitiveValueType<RegExp> {
   }
 
   override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation,
   ): operandValue is RegExp {
     return operandValue instanceof RegExp;
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/regex-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/regex-value-type.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
+import { type InternalValidValueRepresentation } from '../../../expressions/internal-value-representation';
 import { type ValueTypeVisitor } from '../value-type';
 
 import { PrimitiveValueType } from './primitive-value-type';
@@ -20,8 +20,8 @@ export class RegexValuetype extends PrimitiveValueType<RegExp> {
     return 'Regex';
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is RegExp {
     return operandValue instanceof RegExp;
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-value-type.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
+import { type InternalValidValueRepresentation } from '../../../expressions/internal-value-representation';
 import { type ValueTypeVisitor } from '../value-type';
 
 import { PrimitiveValueType } from './primitive-value-type';
@@ -20,8 +20,8 @@ export class TextValuetype extends PrimitiveValueType<string> {
     return 'text';
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is string {
     return typeof operandValue === 'string';
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/text-value-type.ts
@@ -21,7 +21,7 @@ export class TextValuetype extends PrimitiveValueType<string> {
   }
 
   override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation,
   ): operandValue is string {
     return typeof operandValue === 'string';
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/transform-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/transform-value-type.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
+import { type InternalValidValueRepresentation } from '../../../expressions/internal-value-representation';
 import {
   type TransformDefinition,
   isTransformDefinition,
@@ -24,8 +24,8 @@ export class TransformValuetype extends PrimitiveValueType<TransformDefinition> 
     return 'Transform';
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is TransformDefinition {
     return isTransformDefinition(operandValue);
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/transform-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/transform-value-type.ts
@@ -25,7 +25,7 @@ export class TransformValuetype extends PrimitiveValueType<TransformDefinition> 
   }
 
   override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation,
   ): operandValue is TransformDefinition {
     return isTransformDefinition(operandValue);
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/value-type-assignment-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/value-type-assignment-value-type.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../../expressions/internal-value-representation';
+import { type InternalValidValueRepresentation } from '../../../expressions/internal-value-representation';
 import {
   type ValuetypeAssignment as AstValuetypeAssignment,
   isValuetypeAssignment as isAstValuetypeAssignment,
@@ -24,8 +24,8 @@ export class ValuetypeAssignmentValuetype extends PrimitiveValueType<AstValuetyp
     return 'ValuetypeAssignment';
   }
 
-  override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation,
+  override isInternalValidValueRepresentation(
+    operandValue: InternalValidValueRepresentation,
   ): operandValue is AstValuetypeAssignment {
     return isAstValuetypeAssignment(operandValue);
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/primitive/value-type-assignment-value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/primitive/value-type-assignment-value-type.ts
@@ -25,7 +25,7 @@ export class ValuetypeAssignmentValuetype extends PrimitiveValueType<AstValuetyp
   }
 
   override isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation,
   ): operandValue is AstValuetypeAssignment {
     return isAstValuetypeAssignment(operandValue);
   }

--- a/libs/language-server/src/lib/ast/wrappers/value-type/value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/value-type.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValueRepresentation } from '../../expressions/internal-value-representation';
+import {
+  type InternalErrorRepresentation,
+  type InternalValueRepresentation,
+} from '../../expressions/internal-value-representation';
 
 import { type AtomicValueType } from './atomic-value-type';
 import {
@@ -54,7 +57,7 @@ export interface ValueType<
    * For example, a TextValuetype has the internal representation string.
    */
   isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | undefined,
+    operandValue: InternalValueRepresentation | InternalErrorRepresentation,
   ): operandValue is I;
 
   /**

--- a/libs/language-server/src/lib/ast/wrappers/value-type/value-type.ts
+++ b/libs/language-server/src/lib/ast/wrappers/value-type/value-type.ts
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
 } from '../../expressions/internal-value-representation';
 
 import { type AtomicValueType } from './atomic-value-type';
@@ -27,7 +27,7 @@ export interface VisitableValueType {
 }
 
 export interface ValueType<
-  I extends InternalValueRepresentation = InternalValueRepresentation,
+  I extends InternalValidValueRepresentation = InternalValidValueRepresentation,
 > extends VisitableValueType {
   acceptVisitor<R>(visitor: ValueTypeVisitor<R>): R;
 
@@ -56,8 +56,10 @@ export interface ValueType<
    * Typeguard to validate whether a given value is in the correct internal representation of this value type.
    * For example, a TextValuetype has the internal representation string.
    */
-  isInternalValueRepresentation(
-    operandValue: InternalValueRepresentation | InternalErrorRepresentation,
+  isInternalValidValueRepresentation(
+    operandValue:
+      | InternalValidValueRepresentation
+      | InternalErrorValueRepresentation,
   ): operandValue is I;
 
   /**

--- a/libs/language-server/src/lib/services/runtime-parameter-provider.ts
+++ b/libs/language-server/src/lib/services/runtime-parameter-provider.ts
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
+
 import {
   type InternalErrorRepresentation,
   type InternalValueRepresentation,
@@ -36,8 +39,7 @@ export class RuntimeParameterProvider {
       );
     }
 
-    if (this.valueParser === undefined)
-      return new MissingError(`Did not have value parser set`); // FIXME: undefined is probably better here
+    assert(this.valueParser !== undefined);
     return this.valueParser(stringValue, valueType);
   }
 

--- a/libs/language-server/src/lib/services/runtime-parameter-provider.ts
+++ b/libs/language-server/src/lib/services/runtime-parameter-provider.ts
@@ -6,35 +6,35 @@
 import assert from 'assert';
 
 import {
-  type InternalErrorRepresentation,
-  type InternalValueRepresentation,
-  MissingError,
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
+  MissingValue,
 } from '../ast/expressions/internal-value-representation';
 import { type ValueType } from '../ast/wrappers/value-type/value-type';
 
-export type InternalValueRepresentationParser = <
-  I extends InternalValueRepresentation,
+export type InternalValidValueRepresentationParser = <
+  I extends InternalValidValueRepresentation,
 >(
   value: string,
   valueType: ValueType<I>,
-) => I | InternalErrorRepresentation;
+) => I | InternalErrorValueRepresentation;
 
 export class RuntimeParameterProvider {
   private runtimeParameters = new Map<string, string>();
-  private valueParser: InternalValueRepresentationParser | undefined =
+  private valueParser: InternalValidValueRepresentationParser | undefined =
     undefined;
 
-  setValueParser(valueParser: InternalValueRepresentationParser) {
+  setValueParser(valueParser: InternalValidValueRepresentationParser) {
     this.valueParser = valueParser;
   }
 
-  getParsedValue<I extends InternalValueRepresentation>(
+  getParsedValue<I extends InternalValidValueRepresentation>(
     key: string,
     valueType: ValueType<I>,
-  ): I | InternalErrorRepresentation {
+  ): I | InternalErrorValueRepresentation {
     const stringValue = this.getRawValue(key);
     if (stringValue === undefined) {
-      return new MissingError(
+      return new MissingValue(
         `Could not find value for runtime parameter ${key}`,
       );
     }
@@ -55,7 +55,7 @@ export class RuntimeParameterProvider {
     return this.runtimeParameters.has(key);
   }
 
-  getReadonlyMap(): ReadonlyMap<string, InternalValueRepresentation> {
+  getReadonlyMap(): ReadonlyMap<string, InternalValidValueRepresentation> {
     return this.runtimeParameters;
   }
 }

--- a/libs/language-server/src/lib/validation/checks/block-type-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/block-type-definition.ts
@@ -189,7 +189,9 @@ function checkPropertyDefaultValuesHasCorrectType(
   );
   assert(expectedValuetype !== undefined);
 
-  if (!expectedValuetype.isInternalValueRepresentation(evaluatedExpression)) {
+  if (
+    !expectedValuetype.isInternalValidValueRepresentation(evaluatedExpression)
+  ) {
     props.validationContext.accept(
       'error',
       `This default value is not compatible with value type ${expectedValuetype.getName()}`,

--- a/libs/language-server/src/lib/validation/checks/block-type-definition.ts
+++ b/libs/language-server/src/lib/validation/checks/block-type-definition.ts
@@ -7,6 +7,7 @@ import { strict as assert } from 'assert';
 
 import {
   type BlockTypeProperty,
+  ERROR_TYPEGUARD,
   type ReferenceableBlockTypeDefinition,
   evaluateExpression,
 } from '../../ast';
@@ -171,10 +172,10 @@ function checkPropertyDefaultValuesHasCorrectType(
     props.wrapperFactories,
     props.validationContext,
   );
-  if (evaluatedExpression === undefined) {
+  if (ERROR_TYPEGUARD(evaluatedExpression)) {
     props.validationContext.accept(
       'error',
-      `Could not evaluate this expression.`,
+      `Could not evaluate this expression: ${evaluatedExpression.toString()}`,
       {
         node: property,
         property: 'defaultValue',

--- a/libs/language-server/src/lib/validation/checks/block-type-specific/property-assignment.ts
+++ b/libs/language-server/src/lib/validation/checks/block-type-specific/property-assignment.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import {
+  ERROR_TYPEGUARD,
   type InternalValueRepresentation,
   type PropertyAssignment,
   type PropertySpecification,
@@ -26,7 +27,7 @@ export function checkBlockTypeSpecificProperties(
     props.wrapperFactories,
     propertySpec.type,
   );
-  if (propValue === undefined) {
+  if (ERROR_TYPEGUARD(propValue)) {
     return;
   }
 
@@ -112,7 +113,7 @@ function checkCellWriterProperty(
       props.wrapperFactories,
       props.valueTypeProvider.Primitives.CellRange,
     );
-    if (cellRange === undefined) {
+    if (ERROR_TYPEGUARD(cellRange)) {
       return;
     }
 
@@ -147,8 +148,11 @@ function checkColumnDeleterProperty(
         props.valueTypeProvider.Primitives.CellRange,
       ),
     );
+    if (ERROR_TYPEGUARD(cellRanges)) {
+      return;
+    }
 
-    cellRanges?.forEach((cellRange) => {
+    cellRanges.forEach((cellRange) => {
       if (!props.wrapperFactories.CellRange.canWrap(cellRange)) {
         return;
       }
@@ -271,8 +275,11 @@ function checkRowDeleterProperty(
         props.valueTypeProvider.Primitives.CellRange,
       ),
     );
+    if (ERROR_TYPEGUARD(cellRanges)) {
+      return;
+    }
 
-    cellRanges?.forEach((cellRange) => {
+    cellRanges.forEach((cellRange) => {
       if (!props.wrapperFactories.CellRange.canWrap(cellRange)) {
         return;
       }
@@ -305,7 +312,7 @@ function checkTableInterpreterProperty(
         props.valueTypeProvider.Primitives.ValuetypeAssignment,
       ),
     );
-    if (valueTypeAssignments === undefined) {
+    if (ERROR_TYPEGUARD(valueTypeAssignments)) {
       return;
     }
 
@@ -360,7 +367,10 @@ function checkTextLineDeleterProperty(
         props.valueTypeProvider.Primitives.Integer,
       ),
     );
-    lines?.forEach((value, index) => {
+    if (ERROR_TYPEGUARD(lines)) {
+      return;
+    }
+    lines.forEach((value, index) => {
       if (value < minTextLineIndex) {
         props.validationContext.accept(
           'error',

--- a/libs/language-server/src/lib/validation/checks/block-type-specific/property-assignment.ts
+++ b/libs/language-server/src/lib/validation/checks/block-type-specific/property-assignment.ts
@@ -4,7 +4,7 @@
 
 import {
   ERROR_TYPEGUARD,
-  type InternalValueRepresentation,
+  type InternalValidValueRepresentation,
   type PropertyAssignment,
   type PropertySpecification,
   evaluatePropertyValue,
@@ -85,11 +85,11 @@ export function checkBlockTypeSpecificProperties(
 
 function checkArchiveInterpreterProperty(
   propName: string,
-  propValue: InternalValueRepresentation,
+  propValue: InternalValidValueRepresentation,
   property: PropertyAssignment,
   props: JayveeValidationProps,
 ) {
-  const allowedArchiveTypes: InternalValueRepresentation[] = ['zip', 'gz'];
+  const allowedArchiveTypes: InternalValidValueRepresentation[] = ['zip', 'gz'];
   if (propName === 'archiveType') {
     checkPropertyValueOneOf(
       propValue,
@@ -173,11 +173,11 @@ function checkColumnDeleterProperty(
 
 function checkGtfsRTInterpreterProperty(
   propName: string,
-  propValue: InternalValueRepresentation,
+  propValue: InternalValidValueRepresentation,
   property: PropertyAssignment,
   props: JayveeValidationProps,
 ) {
-  const allowedEntities: InternalValueRepresentation[] = [
+  const allowedEntities: InternalValidValueRepresentation[] = [
     'trip_update',
     'alert',
     'vehicle',
@@ -195,7 +195,7 @@ function checkGtfsRTInterpreterProperty(
 
 function checkHttpExtractorProperty(
   propName: string,
-  propValue: InternalValueRepresentation,
+  propValue: InternalValidValueRepresentation,
   property: PropertyAssignment,
   props: JayveeValidationProps,
 ) {
@@ -226,7 +226,7 @@ function checkHttpExtractorProperty(
     }
   }
   if (propName === 'retryBackoffStrategy') {
-    const allowedRetryStrategies: InternalValueRepresentation[] = [
+    const allowedRetryStrategies: InternalValidValueRepresentation[] = [
       'exponential',
       'linear',
     ];
@@ -242,7 +242,7 @@ function checkHttpExtractorProperty(
 
 function checkLocalFileExtractorProperty(
   propName: string,
-  propValue: InternalValueRepresentation,
+  propValue: InternalValidValueRepresentation,
   property: PropertyAssignment,
   props: JayveeValidationProps,
 ) {
@@ -322,12 +322,12 @@ function checkTableInterpreterProperty(
 
 function checkTextFileInterpreterProperty(
   propName: string,
-  propValue: InternalValueRepresentation,
+  propValue: InternalValidValueRepresentation,
   property: PropertyAssignment,
   props: JayveeValidationProps,
 ) {
   // https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API/Encodings
-  const allowedEncodings: InternalValueRepresentation[] = [
+  const allowedEncodings: InternalValidValueRepresentation[] = [
     'utf8',
     'ibm866',
     'latin2',
@@ -388,7 +388,7 @@ function checkTextLineDeleterProperty(
 
 function checkTextRangeSelectorProperty(
   propName: string,
-  propValue: InternalValueRepresentation,
+  propValue: InternalValidValueRepresentation,
   property: PropertyAssignment,
   props: JayveeValidationProps,
 ) {
@@ -408,8 +408,8 @@ function checkTextRangeSelectorProperty(
 }
 
 function checkPropertyValueOneOf(
-  propValue: InternalValueRepresentation,
-  allowedValues: InternalValueRepresentation[],
+  propValue: InternalValidValueRepresentation,
+  allowedValues: InternalValidValueRepresentation[],
   propName: string,
   property: PropertyAssignment,
   props: JayveeValidationProps,

--- a/libs/language-server/src/lib/validation/checks/block-type-specific/property-body.ts
+++ b/libs/language-server/src/lib/validation/checks/block-type-specific/property-body.ts
@@ -2,7 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type PropertyBody, evaluatePropertyValue } from '../../../ast';
+import {
+  ERROR_TYPEGUARD,
+  type PropertyBody,
+  evaluatePropertyValue,
+} from '../../../ast';
 import { type JayveeValidationProps } from '../../validation-registry';
 
 export function checkBlockTypeSpecificPropertyBody(
@@ -47,7 +51,7 @@ function checkTextRangeSelectorPropertyBody(
     props.wrapperFactories,
     props.valueTypeProvider.Primitives.Integer,
   );
-  if (lineFrom === undefined || lineTo === undefined) {
+  if (ERROR_TYPEGUARD(lineFrom) || ERROR_TYPEGUARD(lineTo)) {
     return;
   }
 
@@ -89,7 +93,7 @@ function checkCellWriterPropertyBody(
     props.valueTypeProvider.Primitives.CellRange,
   );
 
-  if (writeValues === undefined || atValue === undefined) {
+  if (ERROR_TYPEGUARD(writeValues) || ERROR_TYPEGUARD(atValue)) {
     return;
   }
 
@@ -147,7 +151,7 @@ function checkInputColumnsMatchTransformationPorts(
     ),
   );
 
-  if (transform === undefined || inputColumns === undefined) {
+  if (ERROR_TYPEGUARD(transform) || ERROR_TYPEGUARD(inputColumns)) {
     return;
   }
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/libs/language-server/src/lib/validation/validation-util.ts
+++ b/libs/language-server/src/lib/validation/validation-util.ts
@@ -8,6 +8,7 @@ import { strict as assert } from 'assert';
 import { type AstNode, MultiMap, assertUnreachable } from 'langium';
 
 import {
+  ERROR_TYPEGUARD,
   EvaluationStrategy,
   type Expression,
   evaluateExpression,
@@ -88,7 +89,7 @@ export function checkExpressionSimplification(
       props.validationContext,
       EvaluationStrategy.EXHAUSTIVE,
     );
-    assert(evaluatedExpression !== undefined);
+    assert(!ERROR_TYPEGUARD(evaluatedExpression));
 
     props.validationContext.accept(
       'info',


### PR DESCRIPTION
Depends on #674.

This PR implements RFC0017, accepted in #670.

Also included is a restructuring of `PostgresLoaderExecutor` with a more granular `try/catch`.

Reason for the draft status: The RFC states that a log message must be emitted every time an error is assigned to a variable. I still need to make sure that is actually the case in the implementation

Edit: sorry for the large diff