### PR TITLE
RFC0018: Multi-attribute value types

### DIFF
--- a/rfc/0018-multi-attribute-value-types/README.md
+++ b/rfc/0018-multi-attribute-value-types/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 | | |
 |---|---|
 | Feature Tag | `multi-attribute value types` |
-| Status | `DISCUSSION` | <!-- Possible values: DRAFT, DISCUSSION, ACCEPTED, REJECTED -->
+| Status | `ACCEPTED` | <!-- Possible values: DRAFT, DISCUSSION, ACCEPTED, REJECTED -->
 | Responsible | `jrentlez` |
 <!-- 
   Status Overview:


### PR DESCRIPTION
This RFC allows value types to have multiple attributes.
~~Value types are used to define tables, replacing the existing syntax.~~