### PR TITLE
Correct comparison for error values

### DIFF
--- a/libs/language-server/src/lib/ast/expressions/evaluators/equality-operator-evaluator.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/equality-operator-evaluator.spec.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import {
+  InvalidValue,
+  MissingValue,
+  type InternalErrorValueRepresentation,
+} from '../internal-value-representation';
+import { executeExpressionTestHelper } from '../test-utils';
+
+async function executeErrorValueComparison(
+  a: InternalErrorValueRepresentation,
+  b: 'invalid' | 'missing',
+) {
+  return executeExpressionTestHelper(
+    `inputValue == ${b}`,
+    'inputValue',
+    'text',
+    a,
+    'boolean',
+  );
+}
+
+describe('The equality operator', () => {
+  it('should compare invalid values correctly', async () => {
+    let result = await executeErrorValueComparison(
+      new InvalidValue(''),
+      'invalid',
+    );
+    expect(result).toBe(true);
+
+    result = await executeErrorValueComparison(new MissingValue(''), 'invalid');
+    expect(result).toBe(false);
+  });
+
+  it('should compare missing values correctly', async () => {
+    let result = await executeErrorValueComparison(
+      new MissingValue(''),
+      'missing',
+    );
+    expect(result).toBe(true);
+
+    result = await executeErrorValueComparison(new InvalidValue(''), 'missing');
+    expect(result).toBe(false);
+  });
+});

--- a/libs/language-server/src/lib/ast/expressions/evaluators/equality-operator-evaluator.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/equality-operator-evaluator.ts
@@ -2,26 +2,57 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { type InternalValidValueRepresentation } from '../internal-value-representation';
-import { DefaultBinaryOperatorEvaluator } from '../operator-evaluator';
-import { INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD } from '../typeguards';
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import assert from 'assert';
 
-export class EqualityOperatorEvaluator extends DefaultBinaryOperatorEvaluator<
-  InternalValidValueRepresentation,
-  InternalValidValueRepresentation,
-  boolean
-> {
-  constructor() {
-    super(
-      '==',
-      INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD,
-      INTERNAL_VALID_VALUE_REPRESENTATION_TYPEGUARD,
+import { type ValidationContext } from '../../../validation';
+import { type BinaryExpression } from '../../generated/ast';
+import { type WrapperFactoryProvider } from '../../wrappers';
+import { evaluateExpression } from '../evaluate-expression';
+import { type EvaluationContext } from '../evaluation-context';
+import { type EvaluationStrategy } from '../evaluation-strategy';
+import {
+  type InternalErrorValueRepresentation,
+  type InternalValidValueRepresentation,
+} from '../internal-value-representation';
+import { type OperatorEvaluator } from '../operator-evaluator';
+import { INVALID_TYPEGUARD, MISSING_TYPEGUARD } from '../typeguards';
+
+export class EqualityOperatorEvaluator
+  implements OperatorEvaluator<BinaryExpression>
+{
+  public readonly operator = '==' as const;
+
+  evaluate(
+    expression: BinaryExpression,
+    evaluationContext: EvaluationContext,
+    wrapperFactories: WrapperFactoryProvider,
+    strategy: EvaluationStrategy,
+    validationContext: ValidationContext | undefined,
+  ): InternalValidValueRepresentation | InternalErrorValueRepresentation {
+    assert(expression.operator === this.operator);
+    const leftValue = evaluateExpression(
+      expression.left,
+      evaluationContext,
+      wrapperFactories,
+      validationContext,
+      strategy,
     );
-  }
-  override doEvaluate(
-    left: InternalValidValueRepresentation,
-    right: InternalValidValueRepresentation,
-  ): boolean {
-    return left === right;
+    const rightValue = evaluateExpression(
+      expression.right,
+      evaluationContext,
+      wrapperFactories,
+      validationContext,
+      strategy,
+    );
+
+    if (INVALID_TYPEGUARD(leftValue)) {
+      return INVALID_TYPEGUARD(rightValue);
+    }
+    if (MISSING_TYPEGUARD(leftValue)) {
+      return MISSING_TYPEGUARD(rightValue);
+    }
+
+    return leftValue === rightValue;
   }
 }

--- a/libs/language-server/src/lib/ast/expressions/evaluators/inequality-operator-evaluator.spec.ts
+++ b/libs/language-server/src/lib/ast/expressions/evaluators/inequality-operator-evaluator.spec.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 Friedrich-Alexander-Universitat Erlangen-Nurnberg
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+import {
+  InvalidValue,
+  MissingValue,
+  type InternalErrorValueRepresentation,
+} from '../internal-value-representation';
+import { executeExpressionTestHelper } from '../test-utils';
+
+async function executeErrorValueComparison(
+  a: InternalErrorValueRepresentation,
+  b: 'invalid' | 'missing',
+) {
+  return executeExpressionTestHelper(
+    `inputValue != ${b}`,
+    'inputValue',
+    'text',
+    a,
+    'boolean',
+  );
+}
+
+describe('The inequality operator', () => {
+  it('should compare invalid values correctly', async () => {
+    let result = await executeErrorValueComparison(
+      new InvalidValue(''),
+      'invalid',
+    );
+    expect(result).toBe(false);
+
+    result = await executeErrorValueComparison(new MissingValue(''), 'invalid');
+    expect(result).toBe(true);
+  });
+
+  it('should compare missing values correctly', async () => {
+    let result = await executeErrorValueComparison(
+      new MissingValue(''),
+      'missing',
+    );
+    expect(result).toBe(false);
+
+    result = await executeErrorValueComparison(new InvalidValue(''), 'missing');
+    expect(result).toBe(true);
+  });
+});

--- a/libs/language-server/src/lib/ast/expressions/test-utils.ts
+++ b/libs/language-server/src/lib/ast/expressions/test-utils.ts
@@ -34,8 +34,10 @@ export async function executeExpressionTestHelper(
   expression: string,
   inputValueName: string,
   inputValueType: 'text',
-  inputValueValue: InternalValidValueRepresentation,
-  outputValueType: 'text' | 'integer',
+  inputValueValue:
+    | InternalValidValueRepresentation
+    | InternalErrorValueRepresentation,
+  outputValueType: 'text' | 'integer' | 'boolean',
 ): Promise<
   InternalValidValueRepresentation | InternalErrorValueRepresentation
 > {


### PR DESCRIPTION
Problem: Comparing an erroneous values with `invalid` returns false, when it should return true

Solution: Update implementations of `EqualityOperatorEvaluator` and `InequalityOperatorEvaluator`