### PR TITLE
fix(ci): fix publishing dry run by correcting version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jayvee",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jayvee",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "dependencies": {
         "@docusaurus/core": "3.4.0",
         "@docusaurus/preset-classic": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jayvee",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "scripts": {
     "nx": "nx",
     "format": "nx format:write",


### PR DESCRIPTION
As we already discussed, `npm publish --dry-run` [fails](https://github.com/jvalue/jayvee/actions/runs/18944629742/job/54092365556) because we are trying to publish version `0.6.4`, which already exists on npm.

The correct solution IMO is to increase the version in this repository to `0.6.5`, because that is the version we are currently working on.
After eventually releasing `0.6.5` we would need to bump the repository's version again, to `0.6.6`. 

(Not sure why this started failing only now, probably changes in the npm backend)